### PR TITLE
support input map in tracker

### DIFF
--- a/kunquat/tracker/audio/audio_engine.py
+++ b/kunquat/tracker/audio/audio_engine.py
@@ -20,7 +20,7 @@ from kunquat.kunquat.kunquat import Kunquat
 
 from drivers.pushaudio import Pushaudio
 
-EVENT_SELECT_INSTRUMENT = '.i'
+EVENT_SELECT_SLOT = '.i'
 EVENT_NOTE_ON = 'n+'
 EVENT_NOTE_OFF = 'n-'
 
@@ -71,9 +71,9 @@ class AudioEngine():
         return tuple(levels)
 
     def _process_event(self, channel_number, event_type, event_value):
-        if event_type == EVENT_SELECT_INSTRUMENT:
-            instrument_number = event_value
-            self._ui_engine.update_selected_instrument(channel_number, instrument_number)
+        if event_type == EVENT_SELECT_SLOT:
+            slot_number = event_value
+            self._ui_engine.update_selected_slot(channel_number, slot_number)
         elif event_type == EVENT_NOTE_OFF:
             pass
             self._ui_engine.update_active_note(channel_number, None)

--- a/kunquat/tracker/threads/uithread.py
+++ b/kunquat/tracker/threads/uithread.py
@@ -70,14 +70,8 @@ class UiThread(threading.Thread):
     def update_audio_levels(self, levels):
         self._q.push('update_audio_levels', levels)
 
-    def update_selected_instrument(self, channel_number, instrument_number):
-        self._q.push('update_selected_instrument', channel_number, instrument_number)
-
-    def update_instrument_existence(self, instrument_number, existence):
-        self._q.push('update_instrument_existence', instrument_number, existence)
-
-    def update_instrument_name(self, instrument_number, name):
-        self._q.push('update_instrument_name', instrument_number, name)
+    def update_selected_slot(self, channel_number, slot_number):
+        self._q.push('update_selected_slot', channel_number, slot_number)
 
     def update_active_note(self, channel_number, pitch):
         self._q.push('update_active_note', channel_number, pitch)

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -23,7 +23,7 @@ from kunquat.tracker.ui.controller.session import Session
 from kunquat.tracker.ui.controller.updater import Updater
 
 #TODO: figure a place for the events
-EVENT_SELECT_INSTRUMENT = '.i'
+EVENT_SELECT_SLOT = '.i'
 EVENT_NOTE_ON = 'n+'
 EVENT_NOTE_OFF = 'n-'
 
@@ -103,18 +103,18 @@ class Controller():
                 self.update_import_progress(i + 1, member_count)
             tfile.close()
             self._store.put(values)
-            self._updater.signal_update(set(['signal_instruments']))
+            self._updater.signal_update(set(['signal_slots']))
             self._audio_engine.set_data(values)
 
     def play(self):
         self._audio_engine.nanoseconds(0)
 
-    def set_active_note(self, channel_number, instrument_id, pitch):
-        parts = instrument_id.split('_')
+    def set_active_note(self, channel_number, slot_id, pitch):
+        parts = slot_id.split('_')
         second = parts[1]
-        instrument_number = int(second)
-        instrument_event = (EVENT_SELECT_INSTRUMENT, instrument_number)
-        self._audio_engine.fire_event(channel_number, instrument_event)
+        slot_number = int(second)
+        slot_event = (EVENT_SELECT_SLOT, slot_number)
+        self._audio_engine.fire_event(channel_number, slot_event)
         note_on_event = (EVENT_NOTE_ON, pitch)
         self._audio_engine.fire_event(channel_number, note_on_event)
 
@@ -142,8 +142,8 @@ class Controller():
         self._session.set_ui_lag(lag)
         self._updater.signal_update()
 
-    def update_selected_instrument(self, channel, instrument):
-        self._session.set_selected_instrument(channel, instrument)
+    def update_selected_slot(self, channel, slot_id):
+        self._session.set_selected_slot_id(channel, slot_id)
         self._updater.signal_update()
 
     def update_active_note(self, channel, pitch):

--- a/kunquat/tracker/ui/controller/session.py
+++ b/kunquat/tracker/ui/controller/session.py
@@ -22,10 +22,10 @@ class Session():
         self._progress_position = 1
         self._progress_steps = 1
         self._audio_levels = (0, 0)
-        self._channel_selected_instrument = dict()
-        self._channel_active_instrument = dict()
+        self._channel_selected_slot_id = dict()
+        self._channel_active_slot_id = dict()
         self._channel_active_note = dict()
-        self._instrument_active_notes = dict()
+        self._slot_active_notes = dict()
 
     def get_output_speed(self):
         return self._output_speed
@@ -69,22 +69,22 @@ class Session():
     def set_audio_levels(self, audio_levels):
         self._audio_levels = audio_levels
 
-    def get_selected_instrument_by_channel(self, channel):
-        return self._channel_selected_instrument[channel]
+    def get_selected_slot_id_by_channel(self, channel):
+        return self._channel_selected_slot_id[channel]
 
-    def set_selected_instrument(self, channel, instrument):
-        instrument_id = 'ins_{0:02x}'.format(instrument)
-        self._channel_selected_instrument[channel] = instrument_id
+    def set_selected_slot_id(self, channel, slot):
+        slot_id = 'slot_{0:02x}'.format(slot)
+        self._channel_selected_slot_id[channel] = slot_id
 
-    def get_active_instrument_by_channel(self, channel):
-        return self._channel_active_instrument[channel]
+    def get_active_slot_id_by_channel(self, channel):
+        return self._channel_active_slot_id[channel]
 
     def get_active_note_by_channel(self, channel):
         return self._channel_active_note[channel]
 
-    def get_active_notes_by_instrument(self, instrument):
+    def get_active_notes_by_slot_id(self, slot_id):
         try:
-            notes = self._instrument_active_notes[instrument]
+            notes = self._slot_active_notes[slot_id]
         except KeyError:
             notes = dict()
         return notes
@@ -93,17 +93,17 @@ class Session():
         if pitch == None:
             if channel in self._channel_active_note:
                 del self._channel_active_note[channel]
-            instrument = self.get_active_instrument_by_channel(channel)
-            if instrument in self._instrument_active_notes:
-               notes = self._instrument_active_notes[instrument]
+            slot_id = self.get_active_slot_id_by_channel(channel)
+            if slot_id in self._slot_active_notes:
+               notes = self._slot_active_notes[slot_id]
                if channel in notes:
                    del notes[channel]
         else:
             self._channel_active_note[channel] = pitch
-            instrument = self.get_selected_instrument_by_channel(channel)
-            if not instrument in self._instrument_active_notes:
-                self._instrument_active_notes[instrument] = dict()
-            notes = self._instrument_active_notes[instrument]
+            slot_id = self.get_selected_slot_id_by_channel(channel)
+            if not slot_id in self._slot_active_notes:
+                self._slot_active_notes[slot_id] = dict()
+            notes = self._slot_active_notes[slot_id]
             notes[channel] = pitch
-            self._channel_active_instrument[channel] = instrument
+            self._channel_active_slot_id[channel] = slot_id
 

--- a/kunquat/tracker/ui/model/instrument.py
+++ b/kunquat/tracker/ui/model/instrument.py
@@ -22,36 +22,10 @@ class Instrument():
         self._controller = None
         self._instrument_number = None
         self._existence = None
-        self._updater = None
-        self._session = None
-
-    def set_store(self, store):
-        self._store = store
 
     def set_controller(self, controller):
-        self._session = controller.get_session()
+        self._store = controller.get_store()
         self._controller = controller
-
-    def set_updater(self, updater):
-        self._updater = updater
-
-    def get_active_notes(self):
-        notes = self._session.get_active_notes_by_instrument(self._instrument_id)
-        return notes
-
-    def get_active_note(self, channel_number):
-        notes = self.get_active_notes()
-        if channel_number not in notes:
-            return None
-        return notes[channel_number]
-
-    def set_active_note(self, channel_number, pitch):
-        instrument_id = self.get_id()
-        self._controller.set_active_note(channel_number, instrument_id, pitch)
-
-    def set_rest(self, channel_number):
-        instrument_id = self.get_id()
-        self._controller.set_rest(channel_number)
 
     def get_id(self):
         return self._instrument_id

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -12,6 +12,7 @@
 #
 
 from instrument import Instrument
+from slot import Slot
 
 
 class Module():
@@ -20,6 +21,7 @@ class Module():
         self._updater = None
         self._store = None
         self._controller = None
+        self._model = None
         self._instruments = {}
 
     def set_controller(self, controller):
@@ -27,9 +29,28 @@ class Module():
         self._store = controller.get_store()
         self._controller = controller
 
+    def set_model(self, model):
+        self._model = model
+
+    def get_slot_ids(self):
+        try:
+            input_map = self._store['p_ins_input.json']
+        except KeyError:
+            input_map = []
+        slot_ids = set()
+        for (slot_number, _) in input_map:
+            slot_id = 'slot_{0:02x}'.format(slot_number)
+            slot_ids.add(slot_id)
+        return slot_ids
+
+    def get_slot(self, slot_id):
+        slot = Slot(slot_id)
+        slot.set_controller(self._controller)
+        slot.set_model(self._model)
+        return slot
+
     def get_instrument(self, instrument_id):
         instrument = Instrument(instrument_id)
-        instrument.set_store(self._store)
         instrument.set_controller(self._controller)
         return instrument
 

--- a/kunquat/tracker/ui/model/slot.py
+++ b/kunquat/tracker/ui/model/slot.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+#
+# Authors: Toni Ruottu, Finland 2013
+#          Tomi Jylhä-Ollila, Finland 2013
+#
+# This file is part of Kunquat.
+#
+# CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+#
+# To the extent possible under law, Kunquat Affirmers have waived all
+# copyright and related or neighboring rights to Kunquat.
+#
+
+
+class Slot():
+
+    def __init__(self, slot_id):
+        assert(slot_id)
+        self._slot_id = slot_id
+        self._controller = None
+        self._instrument_number = None
+        self._existence = None
+        self._session = None
+        self._store = None
+        self._model = None
+
+    def set_controller(self, controller):
+        self._store = controller.get_store()
+        self._session = controller.get_session()
+        self._controller = controller
+
+    def set_model(self, model):
+        self._model = model
+
+    def get_instrument(self):
+        slot_id = self.get_id()
+        parts = slot_id.split('_')
+        second = parts[1]
+        slot_number = int(second)
+        try:
+            input_map = self._store['p_ins_input.json']
+        except KeyError:
+            input_map = []
+        slots = dict(input_map)
+        instrument_number = slots[slot_number]
+        instrument_id = 'ins_{0:02x}'.format(instrument_number)
+        module = self._model.get_module()
+        instrument = module.get_instrument(instrument_id)
+        return instrument
+
+    def get_active_notes(self):
+        notes = self._session.get_active_notes_by_slot_id(self._slot_id)
+        return notes
+
+    def get_active_note(self, channel_number):
+        notes = self.get_active_notes()
+        if channel_number not in notes:
+            return None
+        return notes[channel_number]
+
+    def set_active_note(self, channel_number, pitch):
+        slot_id = self.get_id()
+        self._controller.set_active_note(channel_number, slot_id, pitch)
+
+    def set_rest(self, channel_number):
+        self._controller.set_rest(channel_number)
+
+    def get_id(self):
+        return self._slot_id
+

--- a/kunquat/tracker/ui/model/ui_manager.py
+++ b/kunquat/tracker/ui/model/ui_manager.py
@@ -16,7 +16,7 @@
 class UiManager():
 
     def __init__(self):
-        self._selected_instrument_id = None
+        self._selected_slot_id = None
         self._updater = None
         self._model = None
 
@@ -27,26 +27,26 @@ class UiManager():
     def set_model(self, model):
         self._model = model
 
-    def get_selected_instrument_id(self):
+    def get_selected_slot_id(self):
         module = self._model.get_module()
-        instrument_ids = module.get_instrument_ids()
-        selected_id = self._selected_instrument_id
-        if len(instrument_ids) < 1:
+        slot_ids = module.get_slot_ids()
+        selected_id = self._selected_slot_id
+        if len(slot_ids) < 1:
             return None
-        if not selected_id in instrument_ids:
-            some_id = list(instrument_ids)[0]
+        if not selected_id in slot_ids:
+            some_id = sorted(slot_ids)[0]
             return some_id
         return selected_id
 
-    def set_selected_instrument_id(self, instrument_id):
-        self._selected_instrument_id = instrument_id
+    def set_selected_slot_id(self, slot_id):
+        self._selected_slot_id = slot_id
         self._updater.signal_update()
 
-    def get_selected_instrument(self):
-        instrument_id = self.get_selected_instrument_id()
-        if instrument_id == None:
+    def get_selected_slot(self):
+        slot_id = self.get_selected_slot_id()
+        if slot_id == None:
             return None
         module = self._model.get_module()
-        instrument = module.get_instrument(instrument_id)
-        return instrument
+        slot = module.get_slot(slot_id)
+        return slot
 

--- a/kunquat/tracker/ui/model/uimodel.py
+++ b/kunquat/tracker/ui/model/uimodel.py
@@ -116,6 +116,7 @@ class UiModel():
 
     def set_module(self, module):
         self._module = module
+        self._module.set_model(self)
 
     def get_module(self):
         return self._module

--- a/kunquat/tracker/ui/views/instrumentselect.py
+++ b/kunquat/tracker/ui/views/instrumentselect.py
@@ -21,7 +21,7 @@ class InstrumentSelect(QComboBox):
         QComboBox.__init__(self)
         self._ui_manager = None
         self._module = None
-        self._instrument_catalog = {}
+        self._slot_catalog = dict()
         QObject.connect(self, SIGNAL("currentIndexChanged(int)"), self._select_instrument)
 
     def set_ui_model(self, ui_model):
@@ -30,41 +30,37 @@ class InstrumentSelect(QComboBox):
         self._ui_manager = ui_model.get_ui_manager()
         self._module = ui_model.get_module()
 
-    def _select_instrument(self, instrument_number):
-        instrument = self._instrument_catalog[instrument_number]
-        instrument_id = instrument.get_id()
-        self._ui_manager.set_selected_instrument_id(instrument_id)
+    def _select_instrument(self, catalog_index):
+        slot_id = self._slot_catalog[catalog_index]
+        self._ui_manager.set_selected_slot_id(slot_id)
 
-    def update_texts(self):
-        for i, instrument in self._instrument_catalog.items():
+    def update_slot_texts(self):
+        for i, slot_id in self._slot_catalog.items():
+            parts = slot_id.split('_')
+            second = parts[1]
+            slot_number = int(second)
+            slot = self._module.get_slot(slot_id)
+            instrument = slot.get_instrument()
             instrument_name = instrument.get_name() or '-'
-            play = '' if len(instrument.get_active_notes()) < 1 else u'*'
-            text = '%s %s' % (instrument_name, play)
+            play = '' if len(slot.get_active_notes()) < 1 else u'*'
+            text = 'instrument %s: %s %s' % (slot_number, instrument_name, play)
             self.setItemText(i, text)
 
-    def update_instruments(self):
-        instruments = self._module.get_instruments()
-        selected_instrument_id = self._ui_manager.get_selected_instrument_id()
+    def update_slots(self):
+        slot_ids = self._module.get_slot_ids()
+        self._slot_catalog = dict(enumerate(sorted(slot_ids)))
+        selected_slot_id = self._ui_manager.get_selected_slot_id()
         old_block = self.blockSignals(True)
         self.clear()
-        self._instrument_catalog = dict(enumerate(instruments))
-        invalid_selection = True
-        for i, instrument in self._instrument_catalog.items():
+        for i, slot_id in self._slot_catalog.items():
             self.addItem('')
-            if selected_instrument_id:
-                instrument_id = instrument.get_id()
-                if instrument_id == selected_instrument_id:
-                    self.setCurrentIndex(i)
-                    invalid_selection = False
-        self.update_texts()
+            if selected_slot_id and slot_id == selected_slot_id:
+                self.setCurrentIndex(i)
+        self.update_slot_texts()
         self.blockSignals(old_block)
-        if invalid_selection and len(instruments) > 0:
-            top_instrument = instruments[0]
-            top_instrument_id = top_instrument.get_id()
-            self._ui_manager.set_selected_instrument_id(top_instrument_id)
 
     def perform_updates(self, signals):
-        if 'signal_instruments' in signals:
-            self.update_instruments()
-        self.update_texts()
+        if 'signal_slots' in signals:
+            self.update_slots()
+        self.update_slot_texts()
 

--- a/kunquat/tracker/ui/views/typewriterbutton.py
+++ b/kunquat/tracker/ui/views/typewriterbutton.py
@@ -87,7 +87,7 @@ class TypeWriterButton(QPushButton):
         self._pitch = pitch
         self._ui_manager = None
 
-        self._selected_instrument = None
+        self._selected_slot = None
         self.setMinimumWidth(60)
         self.setMinimumHeight(60)
         layout = QVBoxLayout(self)
@@ -115,22 +115,22 @@ class TypeWriterButton(QPushButton):
         self._ui_manager = ui_model.get_ui_manager()
 
     def _play_sound(self):
-        if self._selected_instrument:
-            self._selected_instrument.set_active_note(0, self._pitch)
+        if self._selected_slot:
+            self._selected_slot.set_active_note(0, self._pitch)
 
     def _stop_sound(self):
-        if self._selected_instrument:
-            self._selected_instrument.set_rest(0)
+        if self._selected_slot:
+            self._selected_slot.set_rest(0)
 
-    def update_selected_instrument(self):
-        self._selected_instrument = self._ui_manager.get_selected_instrument()
+    def update_selected_slot(self):
+        self._selected_slot = self._ui_manager.get_selected_slot()
         self.setEnabled(True)
 
     def update_leds(self):
-        if self._selected_instrument == None:
+        if self._selected_slot == None:
             return
         (left_on, center_on, right_on) = 3 * [0]
-        notes = self._selected_instrument.get_active_notes()
+        notes = self._selected_slot.get_active_notes()
         for (_, note) in notes.items():
             if closest(note) == self._pitch:
                 if note < self._pitch:
@@ -144,6 +144,6 @@ class TypeWriterButton(QPushButton):
         self._led.set_leds(left_on, center_on, right_on)
 
     def perform_updates(self, signals):
-        self.update_selected_instrument()
+        self.update_selected_slot()
         self.update_leds()
 


### PR DESCRIPTION
This fixes the problem with instrument selector not working. We could use the name "instrument 1" for the instrument that happens to be connected to input slot number 1. That way we do not need to explain slots to the user. I could not find identifier names for the slots so I names of the form slot_00 for now. We could later consider renaming them.
