### PR TITLE
Fix variable access from an empty environment state

### DIFF
--- a/src/lib/player/Env_state.c
+++ b/src/lib/player/Env_state.c
@@ -84,6 +84,9 @@ Env_var* Env_state_get_var(const Env_state* estate, const char* name)
     assert(estate != NULL);
     assert(name != NULL);
 
+    if (estate->vars == NULL)
+        return NULL;
+
     return AAtree_get_exact(estate->vars, name);
 }
 

--- a/src/lib/player/Env_state.h
+++ b/src/lib/player/Env_state.h
@@ -53,7 +53,7 @@ bool Env_state_refresh_space(Env_state* estate);
  * \param estate   The Environment state -- must not be \c NULL.
  * \param name     The variable name -- must not be \c NULL.
  *
- * \return   The variable if found, otherwise \c NULL
+ * \return   The variable if found, otherwise \c NULL.
  */
 Env_var* Env_state_get_var(const Env_state* estate, const char* name);
 


### PR DESCRIPTION
This fixes a crash in playback code when attempting to search for an environment variable in an empty environment state.
