### PR TITLE
Work around file tracking issue when building example files

### DIFF
--- a/scripts/build_examples.py
+++ b/scripts/build_examples.py
@@ -12,6 +12,7 @@
 #
 
 from __future__ import print_function
+import os
 import os.path
 
 import command
@@ -34,6 +35,22 @@ def build_examples(builder):
     for src, dest in packages.iteritems():
         dest_path = os.path.join(build_dir, dest)
         echo = echo_prefix + 'Building {}'.format(dest)
+
+        # Mega hack to ensure Fabricate tracks correct input files
+        script_path = os.path.join('scripts', 'write_example_file.py')
+        in_dir = os.path.join(example_dir, src)
+        in_files = []
+        for dir_path, _, fnames in os.walk(in_dir, src):
+            for fname in fnames:
+                fpath = os.path.join(dir_path, fname)
+                in_files.append(fpath)
+
+        if command.run_command(
+                builder, 'python', script_path, dest_path, in_dir, *in_files, echo=echo):
+            echo_prefix = ''
+
+        # The proper way to do it (probably) as soon as Fabricate supports it
+        '''
         if command.run_command(
                 builder,
                 'tar',
@@ -43,6 +60,7 @@ def build_examples(builder):
                 src,
                 echo=echo):
             echo_prefix = ''
+        '''
 
     # Copy the example instrument to share
     # TODO: remove once we figure out the instrument stuff

--- a/scripts/write_example_file.py
+++ b/scripts/write_example_file.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Author: Tomi Jylhä-Ollila, Finland 2014
+#
+# This file is part of Kunquat.
+#
+# CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+#
+# To the extent possible under law, Kunquat Affirmers have waived all
+# copyright and related or neighboring rights to Kunquat.
+#
+
+from __future__ import print_function
+from distutils.spawn import find_executable
+import os
+import os.path
+import sys
+
+
+# Note: This hackety sax works around the issue of Fabricate
+#       not tracking tar input files properly.
+
+
+# Make Fabricate see our inputs
+def look_at_files(in_files):
+    for in_path in in_files:
+        with open(in_path) as f:
+            pass
+
+
+def create_archive(out_file, examples_path, archive_root):
+    tar_path = find_executable('tar')
+    if not tar_path:
+        print('tar not found.')
+        sys.exit(1)
+
+    args = (
+        'tar',
+        'cj', '--format=ustar',
+        '-f', out_file,
+        '--directory', examples_path,
+        archive_root)
+    #print('running tar {}'.format(' '.join(args)))
+    os.execv(tar_path, args)
+
+
+def main():
+    if len(sys.argv) < 4:
+        print('Usage: {} <out_file> <in_dir> <in_file> [<in_file> [...]]'.format(
+            sys.argv[0]), file=sys.stderr)
+        sys.exit(1)
+
+    out_file = sys.argv[1]
+    in_dir = sys.argv[2]
+    in_files = sys.argv[3:]
+
+    look_at_files(in_files)
+
+    examples_path, archive_root = os.path.split(in_dir)
+    create_archive(out_file, examples_path, archive_root)
+
+
+if __name__ == '__main__':
+    main()
+
+


### PR DESCRIPTION
This hack ensures that file changes inside the example directories are detected by Fabricate. I considered bypassing Fabricate entirely, but that might have side effects on other parts of the build that depend on the example files.
