### PR TITLE
Carry events

### DIFF
--- a/src/lib/devices/Proc_common.c
+++ b/src/lib/devices/Proc_common.c
@@ -419,29 +419,31 @@ void Proc_common_handle_filter(
 
     const float global_lowpass_delta = proc->au_params->global_lowpass - 100;
 
+    Filter_controls* fc = &vstate->filter_controls;
+
     // Apply lowpass slide
-    if (Slider_in_progress(&vstate->lowpass_slider))
+    if (Slider_in_progress(&fc->lowpass_slider))
     {
-        float new_lowpass = vstate->lowpass;
+        float new_lowpass = fc->lowpass;
         for (int32_t i = buf_start; i < buf_stop; ++i)
         {
-            new_lowpass = Slider_step(&vstate->lowpass_slider);
+            new_lowpass = Slider_step(&fc->lowpass_slider);
             actual_lowpasses[i] = new_lowpass + global_lowpass_delta;
         }
-        vstate->lowpass = new_lowpass;
+        fc->lowpass = new_lowpass;
     }
     else
     {
-        const float lowpass = vstate->lowpass + global_lowpass_delta;
+        const float lowpass = fc->lowpass + global_lowpass_delta;
         for (int32_t i = buf_start; i < buf_stop; ++i)
             actual_lowpasses[i] = lowpass;
     }
 
     // Apply autowah
-    if (LFO_active(&vstate->autowah))
+    if (LFO_active(&fc->autowah))
     {
         for (int32_t i = buf_start; i < buf_stop; ++i)
-            actual_lowpasses[i] += LFO_step(&vstate->autowah);
+            actual_lowpasses[i] += LFO_step(&fc->autowah);
     }
 
     // Apply time->filter envelope
@@ -550,19 +552,19 @@ void Proc_common_handle_filter(
     }
 
     // Apply resonance slide
-    if (Slider_in_progress(&vstate->lowpass_resonance_slider))
+    if (Slider_in_progress(&fc->resonance_slider))
     {
-        float new_resonance = vstate->lowpass_resonance;
+        float new_resonance = fc->resonance;
         for (int32_t i = buf_start; i < buf_stop; ++i)
         {
-            new_resonance = Slider_step(&vstate->lowpass_resonance_slider);
+            new_resonance = Slider_step(&fc->resonance_slider);
             resonances[i] = new_resonance;
         }
-        vstate->lowpass_resonance = new_resonance;
+        fc->resonance = new_resonance;
     }
     else
     {
-        const float resonance = vstate->lowpass_resonance;
+        const float resonance = fc->resonance;
         for (int32_t i = buf_start; i < buf_stop; ++i)
             resonances[i] = resonance;
     }

--- a/src/lib/devices/Proc_common.c
+++ b/src/lib/devices/Proc_common.c
@@ -130,31 +130,33 @@ int32_t Proc_common_handle_force(
             wbs, WORK_BUFFER_ACTUAL_FORCES);
     actual_forces[buf_start - 1] = vstate->actual_force;
 
+    Force_controls* fc = &vstate->force_controls;
+
     int32_t new_buf_stop = buf_stop;
 
     // Apply force slide & global force
-    if (Slider_in_progress(&vstate->force_slider))
+    if (Slider_in_progress(&fc->slider))
     {
-        float new_force = vstate->force;
+        float new_force = fc->force;
         for (int32_t i = buf_start; i < new_buf_stop; ++i)
         {
-            new_force = Slider_step(&vstate->force_slider);
+            new_force = Slider_step(&fc->slider);
             actual_forces[i] = new_force * proc->au_params->global_force;
         }
-        vstate->force = new_force;
+        fc->force = new_force;
     }
     else
     {
-        const float actual_force = vstate->force * proc->au_params->global_force;
+        const float actual_force = fc->force * proc->au_params->global_force;
         for (int32_t i = buf_start; i < new_buf_stop; ++i)
             actual_forces[i] = actual_force;
     }
 
     // Apply tremolo
-    if (LFO_active(&vstate->tremolo))
+    if (LFO_active(&fc->tremolo))
     {
         for (int32_t i = buf_start; i < new_buf_stop; ++i)
-            actual_forces[i] *= LFO_step(&vstate->tremolo);
+            actual_forces[i] *= LFO_step(&fc->tremolo);
     }
 
     // Apply force envelope

--- a/src/lib/devices/Processor.c
+++ b/src/lib/devices/Processor.c
@@ -183,10 +183,8 @@ static void adjust_relative_lengths(
         Slider_set_mix_rate(&vstate->panning_slider, audio_rate);
         Slider_set_tempo(&vstate->panning_slider, tempo);
 
-        Slider_set_mix_rate(&vstate->lowpass_slider, audio_rate);
-        Slider_set_tempo(&vstate->lowpass_slider, tempo);
-        LFO_set_mix_rate(&vstate->autowah, audio_rate);
-        LFO_set_tempo(&vstate->autowah, tempo);
+        Filter_controls_set_audio_rate(&vstate->filter_controls, audio_rate);
+        Filter_controls_set_tempo(&vstate->filter_controls, tempo);
 
         vstate->freq = audio_rate;
         vstate->tempo = tempo;

--- a/src/lib/devices/Processor.c
+++ b/src/lib/devices/Processor.c
@@ -179,10 +179,8 @@ static void adjust_relative_lengths(
             vstate->arpeggio_frames *= vstate->tempo / tempo;
         }
 
-        Slider_set_mix_rate(&vstate->force_slider, audio_rate);
-        Slider_set_tempo(&vstate->force_slider, tempo);
-        LFO_set_mix_rate(&vstate->tremolo, audio_rate);
-        LFO_set_tempo(&vstate->tremolo, tempo);
+        Force_controls_set_audio_rate(&vstate->force_controls, audio_rate);
+        Force_controls_set_tempo(&vstate->force_controls, tempo);
 
         Slider_set_mix_rate(&vstate->panning_slider, audio_rate);
         Slider_set_tempo(&vstate->panning_slider, tempo);

--- a/src/lib/devices/Processor.c
+++ b/src/lib/devices/Processor.c
@@ -166,10 +166,8 @@ static void adjust_relative_lengths(
 
     if (vstate->freq != audio_rate || vstate->tempo != tempo)
     {
-        Slider_set_mix_rate(&vstate->pitch_slider, audio_rate);
-        Slider_set_tempo(&vstate->pitch_slider, tempo);
-        LFO_set_mix_rate(&vstate->vibrato, audio_rate);
-        LFO_set_tempo(&vstate->vibrato, tempo);
+        Pitch_controls_set_audio_rate(&vstate->pitch_controls, audio_rate);
+        Pitch_controls_set_tempo(&vstate->pitch_controls, tempo);
 
         if (vstate->arpeggio)
         {

--- a/src/lib/devices/processors/Proc_sample.c
+++ b/src/lib/devices/processors/Proc_sample.c
@@ -203,7 +203,7 @@ uint32_t Proc_sample_process_vstate(
                 return buf_start;
             }
 
-            vstate->pitch = 440;
+            vstate->pitch_controls.pitch = 440;
             entry = Hit_map_get_entry(
                     map,
                     vstate->hit_index,
@@ -231,7 +231,7 @@ uint32_t Proc_sample_process_vstate(
             //fprintf(stderr, "pitch @ %p: %f\n", (void*)&state->pitch, state->pitch);
             entry = Note_map_get_entry(
                     map,
-                    log2(vstate->pitch / 440) * 1200,
+                    log2(vstate->pitch_controls.pitch / 440) * 1200,
                     vstate->force_controls.force,
                     vstate->rand_p);
             sample_state->middle_tone = entry->ref_freq;

--- a/src/lib/devices/processors/Proc_sample.c
+++ b/src/lib/devices/processors/Proc_sample.c
@@ -207,7 +207,7 @@ uint32_t Proc_sample_process_vstate(
             entry = Hit_map_get_entry(
                     map,
                     vstate->hit_index,
-                    vstate->force,
+                    vstate->force_controls.force,
                     vstate->rand_p);
         }
         else
@@ -232,7 +232,7 @@ uint32_t Proc_sample_process_vstate(
             entry = Note_map_get_entry(
                     map,
                     log2(vstate->pitch / 440) * 1200,
-                    vstate->force,
+                    vstate->force_controls.force,
                     vstate->rand_p);
             sample_state->middle_tone = entry->ref_freq;
         }

--- a/src/lib/player/Channel.c
+++ b/src/lib/player/Channel.c
@@ -105,7 +105,7 @@ void Channel_set_audio_rate(Channel* ch, int32_t audio_rate)
     Force_controls_set_audio_rate(&ch->force_controls, audio_rate);
     Pitch_controls_set_audio_rate(&ch->pitch_controls, audio_rate);
     Slider_set_mix_rate(&ch->panning_slider, audio_rate);
-    LFO_set_mix_rate(&ch->autowah, audio_rate);
+    Filter_controls_set_audio_rate(&ch->filter_controls, audio_rate);
 
     return;
 }
@@ -119,7 +119,7 @@ void Channel_set_tempo(Channel* ch, double tempo)
     Force_controls_set_tempo(&ch->force_controls, tempo);
     Pitch_controls_set_tempo(&ch->pitch_controls, tempo);
     Slider_set_tempo(&ch->panning_slider, tempo);
-    LFO_set_tempo(&ch->autowah, tempo);
+    Filter_controls_set_tempo(&ch->filter_controls, tempo);
 
     return;
 }
@@ -184,12 +184,14 @@ void Channel_reset(Channel* ch)
     Pitch_controls_reset(&ch->pitch_controls);
 
     Tstamp_set(&ch->filter_slide_length, 0, 0);
-    LFO_init(&ch->autowah, LFO_MODE_EXP);
+    //LFO_init(&ch->autowah, LFO_MODE_EXP);
     ch->autowah_speed = 0;
     Tstamp_init(&ch->autowah_speed_slide);
     ch->autowah_depth = 0;
     Tstamp_init(&ch->autowah_depth_slide);
     Tstamp_set(&ch->lowpass_resonance_slide_length, 0, 0);
+    ch->carry_filter = false;
+    Filter_controls_reset(&ch->filter_controls);
 
     ch->panning = 0;
     Slider_init(&ch->panning_slider, SLIDE_MODE_LINEAR);

--- a/src/lib/player/Channel.c
+++ b/src/lib/player/Channel.c
@@ -97,6 +97,34 @@ Channel* new_Channel(
 }
 
 
+void Channel_set_audio_rate(Channel* ch, int32_t audio_rate)
+{
+    assert(ch != NULL);
+    assert(audio_rate > 0);
+
+    Force_controls_set_audio_rate(&ch->force_controls, audio_rate);
+    LFO_set_mix_rate(&ch->vibrato, audio_rate);
+    Slider_set_mix_rate(&ch->panning_slider, audio_rate);
+    LFO_set_mix_rate(&ch->autowah, audio_rate);
+
+    return;
+}
+
+
+void Channel_set_tempo(Channel* ch, double tempo)
+{
+    assert(ch != NULL);
+    assert(tempo > 0);
+
+    Force_controls_set_tempo(&ch->force_controls, tempo);
+    LFO_set_tempo(&ch->vibrato, tempo);
+    Slider_set_tempo(&ch->panning_slider, tempo);
+    LFO_set_tempo(&ch->autowah, tempo);
+
+    return;
+}
+
+
 void Channel_set_random_seed(Channel* ch, uint64_t seed)
 {
     assert(ch != NULL);
@@ -137,11 +165,13 @@ void Channel_reset(Channel* ch)
     ch->volume = 1;
 
     Tstamp_set(&ch->force_slide_length, 0, 0);
-    LFO_init(&ch->tremolo, LFO_MODE_EXP);
+    //LFO_init(&ch->tremolo, LFO_MODE_EXP);
     ch->tremolo_speed = 0;
     Tstamp_init(&ch->tremolo_speed_slide);
     ch->tremolo_depth = 0;
     Tstamp_init(&ch->tremolo_depth_slide);
+    ch->carry_force = false;
+    Force_controls_reset(&ch->force_controls);
 
     Tstamp_set(&ch->pitch_slide_length, 0, 0);
     LFO_init(&ch->vibrato, LFO_MODE_EXP);

--- a/src/lib/player/Channel.c
+++ b/src/lib/player/Channel.c
@@ -165,7 +165,6 @@ void Channel_reset(Channel* ch)
     ch->volume = 1;
 
     Tstamp_set(&ch->force_slide_length, 0, 0);
-    //LFO_init(&ch->tremolo, LFO_MODE_EXP);
     ch->tremolo_speed = 0;
     Tstamp_init(&ch->tremolo_speed_slide);
     ch->tremolo_depth = 0;
@@ -174,7 +173,6 @@ void Channel_reset(Channel* ch)
     Force_controls_reset(&ch->force_controls);
 
     Tstamp_set(&ch->pitch_slide_length, 0, 0);
-    //LFO_init(&ch->vibrato, LFO_MODE_EXP);
     ch->vibrato_speed = 0;
     Tstamp_init(&ch->vibrato_speed_slide);
     ch->vibrato_depth = 0;
@@ -184,7 +182,6 @@ void Channel_reset(Channel* ch)
     Pitch_controls_reset(&ch->pitch_controls);
 
     Tstamp_set(&ch->filter_slide_length, 0, 0);
-    //LFO_init(&ch->autowah, LFO_MODE_EXP);
     ch->autowah_speed = 0;
     Tstamp_init(&ch->autowah_speed_slide);
     ch->autowah_depth = 0;

--- a/src/lib/player/Channel.c
+++ b/src/lib/player/Channel.c
@@ -103,7 +103,7 @@ void Channel_set_audio_rate(Channel* ch, int32_t audio_rate)
     assert(audio_rate > 0);
 
     Force_controls_set_audio_rate(&ch->force_controls, audio_rate);
-    LFO_set_mix_rate(&ch->vibrato, audio_rate);
+    Pitch_controls_set_audio_rate(&ch->pitch_controls, audio_rate);
     Slider_set_mix_rate(&ch->panning_slider, audio_rate);
     LFO_set_mix_rate(&ch->autowah, audio_rate);
 
@@ -117,7 +117,7 @@ void Channel_set_tempo(Channel* ch, double tempo)
     assert(tempo > 0);
 
     Force_controls_set_tempo(&ch->force_controls, tempo);
-    LFO_set_tempo(&ch->vibrato, tempo);
+    Pitch_controls_set_tempo(&ch->pitch_controls, tempo);
     Slider_set_tempo(&ch->panning_slider, tempo);
     LFO_set_tempo(&ch->autowah, tempo);
 
@@ -174,11 +174,14 @@ void Channel_reset(Channel* ch)
     Force_controls_reset(&ch->force_controls);
 
     Tstamp_set(&ch->pitch_slide_length, 0, 0);
-    LFO_init(&ch->vibrato, LFO_MODE_EXP);
+    //LFO_init(&ch->vibrato, LFO_MODE_EXP);
     ch->vibrato_speed = 0;
     Tstamp_init(&ch->vibrato_speed_slide);
     ch->vibrato_depth = 0;
     Tstamp_init(&ch->vibrato_depth_slide);
+    ch->carry_pitch = false;
+    ch->orig_pitch = NAN;
+    Pitch_controls_reset(&ch->pitch_controls);
 
     Tstamp_set(&ch->filter_slide_length, 0, 0);
     LFO_init(&ch->autowah, LFO_MODE_EXP);

--- a/src/lib/player/Channel.h
+++ b/src/lib/player/Channel.h
@@ -58,7 +58,6 @@ typedef struct Channel
     double volume;                 ///< Channel volume (linear factor).
 
     Tstamp force_slide_length;
-    //LFO tremolo;
     double tremolo_speed;
     Tstamp tremolo_speed_slide;
     double tremolo_depth;
@@ -67,7 +66,6 @@ typedef struct Channel
     Force_controls force_controls;
 
     Tstamp pitch_slide_length;
-    //LFO vibrato;
     double vibrato_speed;
     Tstamp vibrato_speed_slide;
     double vibrato_depth;
@@ -78,7 +76,6 @@ typedef struct Channel
 
     Tstamp filter_slide_length;
     Tstamp lowpass_resonance_slide_length;
-    //LFO autowah;
     double autowah_speed;
     Tstamp autowah_speed_slide;
     double autowah_depth;

--- a/src/lib/player/Channel.h
+++ b/src/lib/player/Channel.h
@@ -78,11 +78,13 @@ typedef struct Channel
 
     Tstamp filter_slide_length;
     Tstamp lowpass_resonance_slide_length;
-    LFO autowah;
+    //LFO autowah;
     double autowah_speed;
     Tstamp autowah_speed_slide;
     double autowah_depth;
     Tstamp autowah_depth_slide;
+    bool carry_filter;
+    Filter_controls filter_controls;
 
     double panning;                ///< The current panning.
     Slider panning_slider;

--- a/src/lib/player/Channel.h
+++ b/src/lib/player/Channel.h
@@ -67,11 +67,14 @@ typedef struct Channel
     Force_controls force_controls;
 
     Tstamp pitch_slide_length;
-    LFO vibrato;
+    //LFO vibrato;
     double vibrato_speed;
     Tstamp vibrato_speed_slide;
     double vibrato_depth;
     Tstamp vibrato_depth_slide;
+    bool carry_pitch;
+    double orig_pitch;
+    Pitch_controls pitch_controls;
 
     Tstamp filter_slide_length;
     Tstamp lowpass_resonance_slide_length;

--- a/src/lib/player/Channel.h
+++ b/src/lib/player/Channel.h
@@ -26,6 +26,7 @@
 #include <player/Channel_proc_state.h>
 #include <player/Env_state.h>
 #include <player/Event_cache.h>
+#include <player/Force_controls.h>
 #include <player/General_state.h>
 #include <player/LFO.h>
 #include <player/Voice_pool.h>
@@ -57,11 +58,13 @@ typedef struct Channel
     double volume;                 ///< Channel volume (linear factor).
 
     Tstamp force_slide_length;
-    LFO tremolo;
+    //LFO tremolo;
     double tremolo_speed;
     Tstamp tremolo_speed_slide;
     double tremolo_depth;
     Tstamp tremolo_depth_slide;
+    bool carry_force;
+    Force_controls force_controls;
 
     Tstamp pitch_slide_length;
     LFO vibrato;
@@ -111,6 +114,24 @@ Channel* new_Channel(
         Voice_pool* voices,
         double* tempo,
         int32_t* audio_rate);
+
+
+/**
+ * Set the Channel audio rate.
+ *
+ * \param ch           The Channel -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ */
+void Channel_set_audio_rate(Channel* ch, int32_t audio_rate);
+
+
+/**
+ * Set the Channel tempo.
+ *
+ * \param ch      The Channel -- must not be \c NULL.
+ * \param tempo   The tempo -- must be positive.
+ */
+void Channel_set_tempo(Channel* ch, double tempo);
 
 
 /**

--- a/src/lib/player/Filter_controls.c
+++ b/src/lib/player/Filter_controls.c
@@ -1,0 +1,99 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <math.h>
+
+#include <debug/assert.h>
+#include <player/Filter_controls.h>
+#include <player/LFO.h>
+#include <player/Slider.h>
+
+
+void Filter_controls_init(Filter_controls* fc, int32_t audio_rate, double tempo)
+{
+    assert(fc != NULL);
+    assert(audio_rate > 0);
+    assert(tempo > 0);
+
+    fc->lowpass = NAN;
+    fc->resonance = NAN;
+
+    Filter_controls_set_audio_rate(fc, audio_rate);
+    Filter_controls_set_tempo(fc, tempo);
+
+    return;
+}
+
+
+void Filter_controls_set_audio_rate(Filter_controls* fc, int32_t audio_rate)
+{
+    assert(fc != NULL);
+    assert(audio_rate > 0);
+
+    Slider_set_mix_rate(&fc->lowpass_slider, audio_rate);
+    LFO_set_mix_rate(&fc->autowah, audio_rate);
+
+    Slider_set_mix_rate(&fc->resonance_slider, audio_rate);
+
+    return;
+}
+
+
+void Filter_controls_set_tempo(Filter_controls* fc, double tempo)
+{
+    assert(fc != NULL);
+    assert(tempo > 0);
+
+    Slider_set_tempo(&fc->lowpass_slider, tempo);
+    LFO_set_tempo(&fc->autowah, tempo);
+
+    Slider_set_tempo(&fc->resonance_slider, tempo);
+
+    return;
+}
+
+
+void Filter_controls_reset(Filter_controls* fc)
+{
+    assert(fc != NULL);
+
+    fc->lowpass = NAN;
+    Slider_init(&fc->lowpass_slider, SLIDE_MODE_LINEAR);
+    LFO_init(&fc->autowah, LFO_MODE_LINEAR);
+
+    fc->resonance = NAN;
+    Slider_init(&fc->resonance_slider, SLIDE_MODE_LINEAR);
+
+    return;
+}
+
+
+void Filter_controls_copy(
+        Filter_controls* restrict dest, const Filter_controls* restrict src)
+{
+    assert(dest != NULL);
+    assert(src != NULL);
+    assert(src != dest);
+
+    dest->lowpass = src->lowpass;
+    Slider_copy(&dest->lowpass_slider, &src->lowpass_slider);
+    LFO_copy(&dest->autowah, &src->autowah);
+
+    dest->resonance = src->resonance;
+    Slider_copy(&dest->resonance_slider, &src->resonance_slider);
+
+    return;
+}
+
+

--- a/src/lib/player/Filter_controls.h
+++ b/src/lib/player/Filter_controls.h
@@ -1,0 +1,87 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#ifndef K_FILTER_CONTROLS_H
+#define K_FILTER_CONTROLS_H
+
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <player/LFO.h>
+#include <player/Slider.h>
+
+
+/**
+ * Filter parameters that can be carried from one note to the next in a channel.
+ */
+typedef struct Filter_controls
+{
+    double lowpass;
+    Slider lowpass_slider;
+    LFO    autowah;
+    double resonance;
+    Slider resonance_slider;
+} Filter_controls;
+
+
+/**
+ * Initialise Filter controls.
+ *
+ * \param fc           The Filter controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ * \param tempo        the tempo -- must be positive.
+ */
+void Filter_controls_init(Filter_controls* fc, int32_t audio_rate, double tempo);
+
+
+/**
+ * Set audio rate of the Filter controls.
+ *
+ * \param fc           The Filter controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ */
+void Filter_controls_set_audio_rate(Filter_controls* fc, int32_t audio_rate);
+
+
+/**
+ * Set tempo of the Filter controls.
+ *
+ * \param fc      The Filter controls -- must not be \c NULL.
+ * \param tempo   the tempo -- must be positive.
+ */
+void Filter_controls_set_tempo(Filter_controls* fc, double tempo);
+
+
+/**
+ * Reset Filter controls.
+ *
+ * \param fc   The Filter controls -- must not be \c NULL.
+ */
+void Filter_controls_reset(Filter_controls* fc);
+
+
+/**
+ * Copy the current state of Filter controls.
+ *
+ * \param dest   The destination Filter controls -- must not be \c NULL.
+ * \param src    The source Filter controls -- must not be \c NULL or \a dest.
+ */
+void Filter_controls_copy(
+        Filter_controls* restrict dest, const Filter_controls* restrict src);
+
+
+#endif // K_FILTER_CONTROLS_H
+
+

--- a/src/lib/player/Force_controls.c
+++ b/src/lib/player/Force_controls.c
@@ -60,7 +60,7 @@ void Force_controls_reset(Force_controls* fc)
 {
     assert(fc != NULL);
 
-    fc->force = 1;
+    fc->force = NAN;
     Slider_init(&fc->slider, SLIDE_MODE_EXP);
     LFO_init(&fc->tremolo, LFO_MODE_EXP);
 

--- a/src/lib/player/Force_controls.c
+++ b/src/lib/player/Force_controls.c
@@ -1,0 +1,85 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <math.h>
+
+#include <debug/assert.h>
+#include <player/Force_controls.h>
+#include <player/LFO.h>
+#include <player/Slider.h>
+
+
+void Force_controls_init(Force_controls* fc, int32_t audio_rate, double tempo)
+{
+    assert(fc != NULL);
+
+    fc->force = NAN;
+    Force_controls_set_audio_rate(fc, audio_rate);
+    Force_controls_set_tempo(fc, tempo);
+
+    return;
+}
+
+
+void Force_controls_set_audio_rate(Force_controls* fc, int32_t audio_rate)
+{
+    assert(fc != NULL);
+    assert(audio_rate > 0);
+
+    Slider_set_mix_rate(&fc->slider, audio_rate);
+    LFO_set_mix_rate(&fc->tremolo, audio_rate);
+
+    return;
+}
+
+
+void Force_controls_set_tempo(Force_controls* fc, double tempo)
+{
+    assert(fc != NULL);
+    assert(tempo > 0);
+
+    Slider_set_tempo(&fc->slider, tempo);
+    LFO_set_tempo(&fc->tremolo, tempo);
+
+    return;
+}
+
+
+void Force_controls_reset(Force_controls* fc)
+{
+    assert(fc != NULL);
+
+    fc->force = 1;
+    Slider_init(&fc->slider, SLIDE_MODE_EXP);
+    LFO_init(&fc->tremolo, LFO_MODE_EXP);
+
+    return;
+}
+
+
+void Force_controls_copy(
+        Force_controls* restrict dest, const Force_controls* restrict src)
+{
+    assert(dest != NULL);
+    assert(src != NULL);
+    assert(src != dest);
+
+    dest->force = src->force;
+    Slider_copy(&dest->slider, &src->slider);
+    LFO_copy(&dest->tremolo, &src->tremolo);
+
+    return;
+}
+
+

--- a/src/lib/player/Force_controls.h
+++ b/src/lib/player/Force_controls.h
@@ -1,0 +1,85 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#ifndef K_FORCE_CONTROLS_H
+#define K_FORCE_CONTROLS_H
+
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <player/LFO.h>
+#include <player/Slider.h>
+
+
+/**
+ * Force parameters that can be carried from one note to the next in a channel.
+ */
+typedef struct Force_controls
+{
+    double force;
+    Slider slider;
+    LFO    tremolo;
+} Force_controls;
+
+
+/**
+ * Initialise Force controls.
+ *
+ * \param fc           The Force controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ * \param tempo        the tempo -- must be positive.
+ */
+void Force_controls_init(Force_controls* fc, int32_t audio_rate, double tempo);
+
+
+/**
+ * Set audio rate of the Force controls.
+ *
+ * \param fc           The Force controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ */
+void Force_controls_set_audio_rate(Force_controls* fc, int32_t audio_rate);
+
+
+/**
+ * Set tempo of the Force controls.
+ *
+ * \param fc      The Force controls -- must not be \c NULL.
+ * \param tempo   the tempo -- must be positive.
+ */
+void Force_controls_set_tempo(Force_controls* fc, double tempo);
+
+
+/**
+ * Reset Force controls.
+ *
+ * \param fc   The Force controls -- must not be \c NULL.
+ */
+void Force_controls_reset(Force_controls* fc);
+
+
+/**
+ * Copy the current state of Force controls.
+ *
+ * \param dest   The destination Force controls -- must not be \c NULL.
+ * \param src    The source Force controls -- must not be \c NULL or \a dest.
+ */
+void Force_controls_copy(
+        Force_controls* restrict dest, const Force_controls* restrict src);
+
+
+#endif // K_FORCE_CONTROLS_H
+
+

--- a/src/lib/player/LFO.c
+++ b/src/lib/player/LFO.c
@@ -292,8 +292,7 @@ double LFO_skip(LFO* lfo, uint64_t steps)
     lfo->speed = Slider_skip(&lfo->speed_slider, steps);
     lfo->update = (lfo->speed * (2 * PI)) / lfo->mix_rate;
     lfo->depth = Slider_skip(&lfo->depth_slider, steps);
-    // TODO: calculate phase properly :-)
-    lfo->phase = fmod(lfo->phase + lfo->update, 2 * PI);
+    lfo->phase = fmod(lfo->phase + (lfo->update * steps), 2 * PI);
 
     const double value = fast_sin(lfo->phase) * lfo->depth;
     if (lfo->mode == LFO_MODE_EXP)

--- a/src/lib/player/Pitch_controls.c
+++ b/src/lib/player/Pitch_controls.c
@@ -27,7 +27,7 @@ void Pitch_controls_init(Pitch_controls* pc, int32_t audio_rate, double tempo)
     assert(tempo > 0);
 
     pc->pitch = NAN;
-    pc->orig_pitch = NAN;
+    pc->orig_carried_pitch = NAN;
     pc->freq_mul = 1;
     Pitch_controls_set_audio_rate(pc, audio_rate);
     Pitch_controls_set_tempo(pc, tempo);
@@ -65,7 +65,7 @@ void Pitch_controls_reset(Pitch_controls* pc)
     assert(pc != NULL);
 
     pc->pitch = NAN;
-    pc->orig_pitch = NAN;
+    pc->orig_carried_pitch = NAN;
     pc->freq_mul = 1;
     Slider_init(&pc->slider, SLIDE_MODE_EXP);
     LFO_init(&pc->vibrato, LFO_MODE_EXP);
@@ -82,7 +82,7 @@ void Pitch_controls_copy(
     assert(src != dest);
 
     dest->pitch = src->pitch;
-    dest->orig_pitch = src->orig_pitch;
+    dest->orig_carried_pitch = src->orig_carried_pitch;
     dest->freq_mul = src->freq_mul;
     Slider_copy(&dest->slider, &src->slider);
     LFO_copy(&dest->vibrato, &src->vibrato);

--- a/src/lib/player/Pitch_controls.c
+++ b/src/lib/player/Pitch_controls.c
@@ -1,0 +1,93 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <math.h>
+
+#include <debug/assert.h>
+#include <player/LFO.h>
+#include <player/Pitch_controls.h>
+#include <player/Slider.h>
+
+
+void Pitch_controls_init(Pitch_controls* pc, int32_t audio_rate, double tempo)
+{
+    assert(pc != NULL);
+    assert(audio_rate > 0);
+    assert(tempo > 0);
+
+    pc->pitch = NAN;
+    pc->orig_pitch = NAN;
+    pc->freq_mul = 1;
+    Pitch_controls_set_audio_rate(pc, audio_rate);
+    Pitch_controls_set_tempo(pc, tempo);
+
+    return;
+}
+
+
+void Pitch_controls_set_audio_rate(Pitch_controls* pc, int32_t audio_rate)
+{
+    assert(pc != NULL);
+    assert(audio_rate > 0);
+
+    Slider_set_mix_rate(&pc->slider, audio_rate);
+    LFO_set_mix_rate(&pc->vibrato, audio_rate);
+
+    return;
+}
+
+
+void Pitch_controls_set_tempo(Pitch_controls* pc, double tempo)
+{
+    assert(pc != NULL);
+    assert(tempo > 0);
+
+    Slider_set_tempo(&pc->slider, tempo);
+    LFO_set_tempo(&pc->vibrato, tempo);
+
+    return;
+}
+
+
+void Pitch_controls_reset(Pitch_controls* pc)
+{
+    assert(pc != NULL);
+
+    pc->pitch = NAN;
+    pc->orig_pitch = NAN;
+    pc->freq_mul = 1;
+    Slider_init(&pc->slider, SLIDE_MODE_EXP);
+    LFO_init(&pc->vibrato, LFO_MODE_EXP);
+
+    return;
+}
+
+
+void Pitch_controls_copy(
+        Pitch_controls* restrict dest, const Pitch_controls* restrict src)
+{
+    assert(dest != NULL);
+    assert(src != NULL);
+    assert(src != dest);
+
+    dest->pitch = src->pitch;
+    dest->orig_pitch = src->orig_pitch;
+    dest->freq_mul = src->freq_mul;
+    Slider_copy(&dest->slider, &src->slider);
+    LFO_copy(&dest->vibrato, &src->vibrato);
+
+    return;
+}
+
+

--- a/src/lib/player/Pitch_controls.h
+++ b/src/lib/player/Pitch_controls.h
@@ -28,8 +28,8 @@
  */
 typedef struct Pitch_controls
 {
-    double pitch;       // TODO: change this to cents
-    double orig_pitch;  // Note: this is in cents
+    double pitch;               // TODO: change this to cents
+    double orig_carried_pitch;  // Note: this is in cents
     double freq_mul;
     Slider slider;
     LFO    vibrato;

--- a/src/lib/player/Pitch_controls.h
+++ b/src/lib/player/Pitch_controls.h
@@ -1,0 +1,87 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2015
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#ifndef K_PITCH_CONTROLS_H
+#define K_PITCH_CONTROLS_H
+
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <player/LFO.h>
+#include <player/Slider.h>
+
+
+/**
+ * Pitch parameters that can be carried from one note to the next in a channel.
+ */
+typedef struct Pitch_controls
+{
+    double pitch;       // TODO: change this to cents
+    double orig_pitch;  // Note: this is in cents
+    double freq_mul;
+    Slider slider;
+    LFO    vibrato;
+} Pitch_controls;
+
+
+/**
+ * Initialise Pitch controls.
+ *
+ * \param pc           The Pitch controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ * \param tempo        the tempo -- must be positive.
+ */
+void Pitch_controls_init(Pitch_controls* pc, int32_t audio_rate, double tempo);
+
+
+/**
+ * Set audio rate of the Pitch controls.
+ *
+ * \param pc           The Pitch controls -- must not be \c NULL.
+ * \param audio_rate   The audio rate -- must be positive.
+ */
+void Pitch_controls_set_audio_rate(Pitch_controls* pc, int32_t audio_rate);
+
+
+/**
+ * Set tempo of the Pitch controls.
+ *
+ * \param pc      The Pitch controls -- must not be \c NULL.
+ * \param tempo   the tempo -- must be positive.
+ */
+void Pitch_controls_set_tempo(Pitch_controls* pc, double tempo);
+
+
+/**
+ * Reset Pitch controls.
+ *
+ * \param pc   The Pitch controls -- must not be \c NULL.
+ */
+void Pitch_controls_reset(Pitch_controls* pc);
+
+
+/**
+ * Copy the current state of Pitch controls.
+ *
+ * \param dest   The destination Pitch controls -- must not be \c NULL.
+ * \param src    The source Pitch controls -- must not be \c NULL or \a dest.
+ */
+void Pitch_controls_copy(
+        Pitch_controls* restrict dest, const Pitch_controls* restrict src);
+
+
+#endif // K_PITCH_CONTROLS_H
+
+

--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -42,10 +42,7 @@ static void Player_update_sliders_and_lfos_audio_rate(Player* player)
     for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
     {
         Channel* ch = player->channels[i];
-        LFO_set_mix_rate(&ch->vibrato, rate);
-        LFO_set_mix_rate(&ch->tremolo, rate);
-        Slider_set_mix_rate(&ch->panning_slider, rate);
-        LFO_set_mix_rate(&ch->autowah, rate);
+        Channel_set_audio_rate(ch, rate);
     }
 
     Master_params* mp = &player->master_params;
@@ -599,6 +596,19 @@ void Player_play(Player* player, int32_t nframes)
 
         // Process voices
         Player_process_voices(player, rendered, to_be_rendered);
+
+        // Update carried force controls
+        for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
+        {
+            Channel* ch = player->channels[i];
+            Force_controls* fc = &ch->force_controls;
+
+            if (Slider_in_progress(&fc->slider))
+                fc->force = Slider_skip(&fc->slider, to_be_rendered);
+
+            if (LFO_active(&fc->tremolo))
+                LFO_skip(&fc->tremolo, to_be_rendered);
+        }
 
         // Update panning slides, TODO: revisit
         for (int i = 0; i < KQT_CHANNELS_MAX; ++i)

--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -597,17 +597,30 @@ void Player_play(Player* player, int32_t nframes)
         // Process voices
         Player_process_voices(player, rendered, to_be_rendered);
 
-        // Update carried force controls
+        // Update carried force and pitch controls
         for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
         {
             Channel* ch = player->channels[i];
-            Force_controls* fc = &ch->force_controls;
 
-            if (Slider_in_progress(&fc->slider))
-                fc->force = Slider_skip(&fc->slider, to_be_rendered);
+            {
+                Force_controls* fc = &ch->force_controls;
 
-            if (LFO_active(&fc->tremolo))
-                LFO_skip(&fc->tremolo, to_be_rendered);
+                if (Slider_in_progress(&fc->slider))
+                    fc->force = Slider_skip(&fc->slider, to_be_rendered);
+
+                if (LFO_active(&fc->tremolo))
+                    LFO_skip(&fc->tremolo, to_be_rendered);
+            }
+
+            {
+                Pitch_controls* pc = &ch->pitch_controls;
+
+                if (Slider_in_progress(&pc->slider))
+                    pc->pitch = Slider_skip(&pc->slider, to_be_rendered);
+
+                if (LFO_active(&pc->vibrato))
+                    LFO_skip(&pc->vibrato, to_be_rendered);
+            }
         }
 
         // Update panning slides, TODO: revisit

--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -597,7 +597,7 @@ void Player_play(Player* player, int32_t nframes)
         // Process voices
         Player_process_voices(player, rendered, to_be_rendered);
 
-        // Update carried force and pitch controls
+        // Update carried controls
         for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
         {
             Channel* ch = player->channels[i];
@@ -620,6 +620,19 @@ void Player_play(Player* player, int32_t nframes)
 
                 if (LFO_active(&pc->vibrato))
                     LFO_skip(&pc->vibrato, to_be_rendered);
+            }
+
+            {
+                Filter_controls* fc = &ch->filter_controls;
+
+                if (Slider_in_progress(&fc->lowpass_slider))
+                    fc->lowpass = Slider_skip(&fc->lowpass_slider, to_be_rendered);
+
+                if (LFO_active(&fc->autowah))
+                    LFO_skip(&fc->autowah, to_be_rendered);
+
+                if (Slider_in_progress(&fc->resonance_slider))
+                    fc->resonance = Slider_skip(&fc->resonance_slider, to_be_rendered);
             }
         }
 

--- a/src/lib/player/Player_seq.c
+++ b/src/lib/player/Player_seq.c
@@ -799,10 +799,7 @@ void Player_update_sliders_and_lfos_tempo(Player* player)
     for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
     {
         Channel* ch = player->channels[i];
-        LFO_set_tempo(&ch->vibrato, tempo);
-        LFO_set_tempo(&ch->tremolo, tempo);
-        Slider_set_tempo(&ch->panning_slider, tempo);
-        LFO_set_tempo(&ch->autowah, tempo);
+        Channel_set_tempo(ch, tempo);
     }
 
     Master_params* mp = &player->master_params;

--- a/src/lib/player/Voice_state.c
+++ b/src/lib/player/Voice_state.c
@@ -48,14 +48,14 @@ Voice_state* Voice_state_init(
     state->rand_p = rand_p;
     state->rand_s = rand_s;
 
+    Force_controls_init(&state->force_controls, freq, tempo);
+
 #define SET_RATE_TEMPO(type, field) \
     type ## _set_mix_rate(&state->field, freq); \
     type ## _set_tempo(&state->field, tempo)
 
     SET_RATE_TEMPO(Slider, pitch_slider);
     SET_RATE_TEMPO(LFO, vibrato);
-    SET_RATE_TEMPO(Slider, force_slider);
-    SET_RATE_TEMPO(LFO, tremolo);
     SET_RATE_TEMPO(Slider, panning_slider);
     SET_RATE_TEMPO(Slider, lowpass_slider);
     SET_RATE_TEMPO(LFO, autowah);
@@ -113,10 +113,8 @@ Voice_state* Voice_state_clear(Voice_state* state)
     Time_env_state_init(&state->force_env_state);
     Time_env_state_init(&state->force_rel_env_state);
 
-    state->force = 1;
+    Force_controls_reset(&state->force_controls);
     state->actual_force = 1;
-    Slider_init(&state->force_slider, SLIDE_MODE_EXP);
-    LFO_init(&state->tremolo, LFO_MODE_EXP);
 
     state->panning = 0;
     state->actual_panning = 0;

--- a/src/lib/player/Voice_state.c
+++ b/src/lib/player/Voice_state.c
@@ -50,17 +50,10 @@ Voice_state* Voice_state_init(
 
     Force_controls_init(&state->force_controls, freq, tempo);
     Pitch_controls_init(&state->pitch_controls, freq, tempo);
+    Filter_controls_init(&state->filter_controls, freq, tempo);
 
-#define SET_RATE_TEMPO(type, field) \
-    type ## _set_mix_rate(&state->field, freq); \
-    type ## _set_tempo(&state->field, tempo)
-
-    SET_RATE_TEMPO(Slider, panning_slider);
-    SET_RATE_TEMPO(Slider, lowpass_slider);
-    SET_RATE_TEMPO(LFO, autowah);
-    SET_RATE_TEMPO(Slider, lowpass_resonance_slider);
-
-#undef SET_RATE_TEMPO
+    Slider_set_mix_rate(&state->panning_slider, freq);
+    Slider_set_tempo(&state->panning_slider, tempo);
 
     return state;
 }
@@ -95,8 +88,6 @@ Voice_state* Voice_state_clear(Voice_state* state)
     }
 #endif
 
-    LFO_init(&state->autowah, LFO_MODE_LINEAR);
-
     state->pos = 0;
     state->pos_rem = 0;
     state->rel_pos = 0;
@@ -122,15 +113,14 @@ Voice_state* Voice_state_clear(Voice_state* state)
     Time_env_state_init(&state->env_filter_state);
     Time_env_state_init(&state->env_filter_rel_state);
 
-    state->lowpass = 100;
-    state->actual_lowpass = state->lowpass;
-    state->lowpass_resonance = 0;
+    Filter_controls_reset(&state->filter_controls);
+    //state->lowpass = 100;
+    state->actual_lowpass = 100;
+    //state->lowpass_resonance = 0;
 
     state->applied_lowpass = state->actual_lowpass;
-    state->applied_resonance = state->lowpass_resonance;
+    state->applied_resonance = state->filter_controls.resonance;
     state->true_lowpass = INFINITY;
-    Slider_init(&state->lowpass_slider, SLIDE_MODE_LINEAR);
-    Slider_init(&state->lowpass_resonance_slider, SLIDE_MODE_LINEAR);
     state->true_resonance = 0.5;
     state->lowpass_state_used = -1;
     state->lowpass_xfade_state_used = -1;

--- a/src/lib/player/Voice_state.c
+++ b/src/lib/player/Voice_state.c
@@ -115,9 +115,7 @@ Voice_state* Voice_state_clear(Voice_state* state)
     Time_env_state_init(&state->env_filter_rel_state);
 
     Filter_controls_reset(&state->filter_controls);
-    //state->lowpass = 100;
     state->actual_lowpass = 100;
-    //state->lowpass_resonance = 0;
 
     state->applied_lowpass = state->actual_lowpass;
     state->applied_resonance = state->filter_controls.resonance;

--- a/src/lib/player/Voice_state.c
+++ b/src/lib/player/Voice_state.c
@@ -49,13 +49,12 @@ Voice_state* Voice_state_init(
     state->rand_s = rand_s;
 
     Force_controls_init(&state->force_controls, freq, tempo);
+    Pitch_controls_init(&state->pitch_controls, freq, tempo);
 
 #define SET_RATE_TEMPO(type, field) \
     type ## _set_mix_rate(&state->field, freq); \
     type ## _set_tempo(&state->field, tempo)
 
-    SET_RATE_TEMPO(Slider, pitch_slider);
-    SET_RATE_TEMPO(LFO, vibrato);
     SET_RATE_TEMPO(Slider, panning_slider);
     SET_RATE_TEMPO(Slider, lowpass_slider);
     SET_RATE_TEMPO(LFO, autowah);
@@ -77,14 +76,11 @@ Voice_state* Voice_state_clear(Voice_state* state)
     state->tempo = 0;
     state->ramp_attack = 0;
     state->ramp_release = 0;
-    state->orig_cents = 0;
 
     state->hit_index = -1;
-    state->pitch = 0;
+    Pitch_controls_reset(&state->pitch_controls);
     state->actual_pitch = 0;
     state->prev_actual_pitch = 0;
-    Slider_init(&state->pitch_slider, SLIDE_MODE_EXP);
-    LFO_init(&state->vibrato, LFO_MODE_EXP);
 
     state->arpeggio = false;
     state->arpeggio_ref = NAN;

--- a/src/lib/player/Voice_state.c
+++ b/src/lib/player/Voice_state.c
@@ -72,6 +72,7 @@ Voice_state* Voice_state_clear(Voice_state* state)
 
     state->hit_index = -1;
     Pitch_controls_reset(&state->pitch_controls);
+    state->orig_pitch_param = NAN;
     state->actual_pitch = 0;
     state->prev_actual_pitch = 0;
 

--- a/src/lib/player/Voice_state.h
+++ b/src/lib/player/Voice_state.h
@@ -24,6 +24,7 @@
 #include <mathnum/Random.h>
 #include <pitch_t.h>
 #include <player/Channel_proc_state.h>
+#include <player/Filter_controls.h>
 #include <player/Force_controls.h>
 #include <player/LFO.h>
 #include <player/Pitch_controls.h>
@@ -100,12 +101,13 @@ typedef struct Voice_state
     Time_env_state env_filter_state;
     Time_env_state env_filter_rel_state;
 
-    double lowpass;                ///< The current lowpass parameter.
+    Filter_controls filter_controls;
+    //double lowpass;                ///< The current lowpass parameter.
     double actual_lowpass;         ///< The current actual lowpass parameter.
-    Slider lowpass_slider;
-    LFO autowah;
-    double lowpass_resonance;      ///< The filter resonance (Q factor).
-    Slider lowpass_resonance_slider;
+    //Slider lowpass_slider;
+    //LFO autowah;
+    //double lowpass_resonance;      ///< The filter resonance (Q factor).
+    //Slider lowpass_resonance_slider;
 
     // Lowpass filter implementation state
     double applied_lowpass;

--- a/src/lib/player/Voice_state.h
+++ b/src/lib/player/Voice_state.h
@@ -56,11 +56,11 @@ typedef struct Voice_state
 
     double ramp_attack;            ///< The current state of volume ramp during attack.
     double ramp_release;           ///< The current state of volume ramp during release.
-    //double orig_cents;             ///< The pitch in cents used at the beginning.
 
     int hit_index;                 ///< The hit index (negative for normal notes).
     Pitch_controls pitch_controls;
     //pitch_t pitch;                 ///< The frequency at which the note is played.
+    double orig_pitch_param;       ///< The original pitch parameter.
     pitch_t actual_pitch;          ///< The actual frequency (includes vibrato).
     pitch_t prev_actual_pitch;     ///< The actual frequency in the previous mixing cycle.
     //Slider pitch_slider;

--- a/src/lib/player/Voice_state.h
+++ b/src/lib/player/Voice_state.h
@@ -26,6 +26,7 @@
 #include <player/Channel_proc_state.h>
 #include <player/Force_controls.h>
 #include <player/LFO.h>
+#include <player/Pitch_controls.h>
 #include <player/Slider.h>
 #include <player/Time_env_state.h>
 #include <Tstamp.h>
@@ -54,14 +55,15 @@ typedef struct Voice_state
 
     double ramp_attack;            ///< The current state of volume ramp during attack.
     double ramp_release;           ///< The current state of volume ramp during release.
-    double orig_cents;             ///< The pitch in cents used at the beginning.
+    //double orig_cents;             ///< The pitch in cents used at the beginning.
 
     int hit_index;                 ///< The hit index (negative for normal notes).
-    pitch_t pitch;                 ///< The frequency at which the note is played.
+    Pitch_controls pitch_controls;
+    //pitch_t pitch;                 ///< The frequency at which the note is played.
     pitch_t actual_pitch;          ///< The actual frequency (includes vibrato).
     pitch_t prev_actual_pitch;     ///< The actual frequency in the previous mixing cycle.
-    Slider pitch_slider;
-    LFO vibrato;
+    //Slider pitch_slider;
+    //LFO vibrato;
 
     bool arpeggio;                 ///< Arpeggio enabled.
     double arpeggio_ref;           ///< Arpeggio reference note in cents.

--- a/src/lib/player/Voice_state.h
+++ b/src/lib/player/Voice_state.h
@@ -24,6 +24,7 @@
 #include <mathnum/Random.h>
 #include <pitch_t.h>
 #include <player/Channel_proc_state.h>
+#include <player/Force_controls.h>
 #include <player/LFO.h>
 #include <player/Slider.h>
 #include <player/Time_env_state.h>
@@ -81,10 +82,11 @@ typedef struct Voice_state
     Time_env_state force_env_state;
     Time_env_state force_rel_env_state;
 
-    double force;                  ///< The current force (linear factor).
+    Force_controls force_controls;
+    //double force;                  ///< The current force (linear factor).
     double actual_force;           ///< The current actual force (includes tremolo & envs).
-    Slider force_slider;
-    LFO tremolo;
+    //Slider force_slider;
+    //LFO tremolo;
 
     double panning;                ///< The current panning.
     double actual_panning;         ///< The current actual panning.

--- a/src/lib/player/Voice_state.h
+++ b/src/lib/player/Voice_state.h
@@ -59,12 +59,9 @@ typedef struct Voice_state
 
     int hit_index;                 ///< The hit index (negative for normal notes).
     Pitch_controls pitch_controls;
-    //pitch_t pitch;                 ///< The frequency at which the note is played.
     double orig_pitch_param;       ///< The original pitch parameter.
     pitch_t actual_pitch;          ///< The actual frequency (includes vibrato).
     pitch_t prev_actual_pitch;     ///< The actual frequency in the previous mixing cycle.
-    //Slider pitch_slider;
-    //LFO vibrato;
 
     bool arpeggio;                 ///< Arpeggio enabled.
     double arpeggio_ref;           ///< Arpeggio reference note in cents.
@@ -86,10 +83,7 @@ typedef struct Voice_state
     Time_env_state force_rel_env_state;
 
     Force_controls force_controls;
-    //double force;                  ///< The current force (linear factor).
     double actual_force;           ///< The current actual force (includes tremolo & envs).
-    //Slider force_slider;
-    //LFO tremolo;
 
     double panning;                ///< The current panning.
     double actual_panning;         ///< The current actual panning.
@@ -102,12 +96,7 @@ typedef struct Voice_state
     Time_env_state env_filter_rel_state;
 
     Filter_controls filter_controls;
-    //double lowpass;                ///< The current lowpass parameter.
     double actual_lowpass;         ///< The current actual lowpass parameter.
-    //Slider lowpass_slider;
-    //LFO autowah;
-    //double lowpass_resonance;      ///< The filter resonance (Q factor).
-    //Slider lowpass_resonance_slider;
 
     // Lowpass filter implementation state
     double applied_lowpass;

--- a/src/lib/player/events/Event_channel_arpeggio.c
+++ b/src/lib/player/events/Event_channel_arpeggio.c
@@ -61,7 +61,7 @@ bool Event_channel_arpeggio_on_process(
         }
 #endif
         if (isnan(ch->arpeggio_ref))
-            ch->arpeggio_ref = vs->orig_cents;
+            ch->arpeggio_ref = vs->pitch_controls.orig_pitch;
 
         if (isnan(ch->arpeggio_tones[0]))
             ch->arpeggio_tones[0] = ch->arpeggio_ref;

--- a/src/lib/player/events/Event_channel_arpeggio.c
+++ b/src/lib/player/events/Event_channel_arpeggio.c
@@ -61,7 +61,7 @@ bool Event_channel_arpeggio_on_process(
         }
 #endif
         if (isnan(ch->arpeggio_ref))
-            ch->arpeggio_ref = vs->pitch_controls.orig_pitch;
+            ch->arpeggio_ref = vs->orig_pitch_param;
 
         if (isnan(ch->arpeggio_tones[0]))
             ch->arpeggio_tones[0] = ch->arpeggio_ref;

--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -106,15 +106,17 @@ bool Event_channel_note_on_process(
         }
 #endif
 
+        vs->orig_pitch_param = value->value.float_type;
+
         if (ch->carry_pitch)
         {
             if (isnan(ch->pitch_controls.pitch))
-                ch->pitch_controls.pitch = exp2(value->value.float_type / 1200) * 440;
-            if (isnan(ch->pitch_controls.orig_pitch))
-                ch->pitch_controls.orig_pitch = value->value.float_type;
+                ch->pitch_controls.pitch = exp2(vs->orig_pitch_param / 1200) * 440;
+            if (isnan(ch->pitch_controls.orig_carried_pitch))
+                ch->pitch_controls.orig_carried_pitch = vs->orig_pitch_param;
 
             const double pitch_diff =
-                value->value.float_type - ch->pitch_controls.orig_pitch;
+                vs->orig_pitch_param - ch->pitch_controls.orig_carried_pitch;
             if (pitch_diff != 0)
                 ch->pitch_controls.freq_mul = exp2(pitch_diff / 1200);
             else
@@ -124,8 +126,8 @@ bool Event_channel_note_on_process(
         }
         else
         {
-            vs->pitch_controls.pitch = exp2(value->value.float_type / 1200) * 440;
-            vs->pitch_controls.orig_pitch = value->value.float_type;
+            vs->pitch_controls.pitch = exp2(vs->orig_pitch_param / 1200) * 440;
+            vs->pitch_controls.orig_carried_pitch = vs->orig_pitch_param;
 
             Slider_set_length(&vs->pitch_controls.slider, &ch->pitch_slide_length);
 

--- a/src/lib/player/events/Event_channel_types.h
+++ b/src/lib/player/events/Event_channel_types.h
@@ -40,6 +40,8 @@ EVENT_CHANNEL_DEF("vs",     vibrato_speed,          FLOAT,          v_nonneg_flo
 EVENT_CHANNEL_DEF("vd",     vibrato_depth,          FLOAT,          v_nonneg_float)
 EVENT_CHANNEL_DEF("v/=s",   vibrato_speed_slide,    TSTAMP,         v_nonneg_ts)
 EVENT_CHANNEL_DEF("v/=d",   vibrato_depth_slide,    TSTAMP,         v_nonneg_ts)
+EVENT_CHANNEL_DEF("->p+",   carry_pitch_on,         NONE,           NULL)
+EVENT_CHANNEL_DEF("->p-",   carry_pitch_off,        NONE,           NULL)
 
 EVENT_CHANNEL_DEF("<arp",   reset_arpeggio,         NONE,           NULL)
 EVENT_CHANNEL_DEF(".arpn",  set_arpeggio_note,      FLOAT,          v_pitch)

--- a/src/lib/player/events/Event_channel_types.h
+++ b/src/lib/player/events/Event_channel_types.h
@@ -57,10 +57,11 @@ EVENT_CHANNEL_DEF("ws",     autowah_speed,          FLOAT,          v_nonneg_flo
 EVENT_CHANNEL_DEF("wd",     autowah_depth,          FLOAT,          v_nonneg_float)
 EVENT_CHANNEL_DEF("w/=s",   autowah_speed_slide,    TSTAMP,         v_nonneg_ts)
 EVENT_CHANNEL_DEF("w/=d",   autowah_depth_slide,    TSTAMP,         v_nonneg_ts)
-
 EVENT_CHANNEL_DEF(".r",     set_resonance,          FLOAT,          v_resonance)
 EVENT_CHANNEL_DEF("/r",     slide_resonance,        FLOAT,          v_resonance)
 EVENT_CHANNEL_DEF("/=r",    slide_resonance_length, TSTAMP,         v_nonneg_ts)
+EVENT_CHANNEL_DEF("->l+",   carry_filter_on,        NONE,           NULL)
+EVENT_CHANNEL_DEF("->l-",   carry_filter_off,       NONE,           NULL)
 
 EVENT_CHANNEL_DEF(".P",     set_panning,            FLOAT,          v_panning)
 EVENT_CHANNEL_DEF("/P",     slide_panning,          FLOAT,          v_panning)

--- a/src/lib/player/events/Event_channel_types.h
+++ b/src/lib/player/events/Event_channel_types.h
@@ -31,6 +31,8 @@ EVENT_CHANNEL_DEF("ts",     tremolo_speed,          FLOAT,          v_nonneg_flo
 EVENT_CHANNEL_DEF("td",     tremolo_depth,          FLOAT,          v_tremolo_depth)
 EVENT_CHANNEL_DEF("t/=s",   tremolo_speed_slide,    TSTAMP,         v_nonneg_ts)
 EVENT_CHANNEL_DEF("t/=d",   tremolo_depth_slide,    TSTAMP,         v_nonneg_ts)
+EVENT_CHANNEL_DEF("->f+",   carry_force_on,         NONE,           NULL)
+EVENT_CHANNEL_DEF("->f-",   carry_force_off,        NONE,           NULL)
 
 EVENT_CHANNEL_DEF("/p",     slide_pitch,            FLOAT,          v_pitch)
 EVENT_CHANNEL_DEF("/=p",    slide_pitch_length,     TSTAMP,         v_nonneg_ts)

--- a/src/lib/player/events/note_setup.c
+++ b/src/lib/player/events/note_setup.c
@@ -117,11 +117,8 @@ void set_au_properties(Voice* voice, Voice_state* vs, Channel* ch, double* force
         Filter_controls_copy(&ch->filter_controls, &vs->filter_controls);
     }
 
-
-//    LFO_copy(&vs->vibrato, &ch->vibrato);
     vs->panning = ch->panning;
     Slider_copy(&vs->panning_slider, &ch->panning_slider);
-//    LFO_copy(&vs->autowah, &ch->autowah);
 
     return;
 }

--- a/src/lib/player/events/note_setup.c
+++ b/src/lib/player/events/note_setup.c
@@ -95,13 +95,32 @@ void set_au_properties(Voice* voice, Voice_state* vs, Channel* ch, double* force
             vs->force_controls.force * voice->proc->au_params->global_force;
     }
 
-    vs->lowpass = voice->proc->au_params->default_lowpass;
-    vs->lowpass_resonance = voice->proc->au_params->default_resonance;
+    if (ch->carry_filter)
+    {
+        if (isnan(ch->filter_controls.lowpass))
+            ch->filter_controls.lowpass = voice->proc->au_params->default_lowpass;
+        if (isnan(ch->filter_controls.resonance))
+            ch->filter_controls.resonance = voice->proc->au_params->default_resonance;
+
+        Filter_controls_copy(&vs->filter_controls, &ch->filter_controls);
+    }
+    else
+    {
+        vs->filter_controls.lowpass = voice->proc->au_params->default_lowpass;
+        vs->filter_controls.resonance = voice->proc->au_params->default_resonance;
+
+        Slider_set_length(&vs->filter_controls.lowpass_slider, &ch->filter_slide_length);
+        Slider_set_length(
+                &vs->filter_controls.resonance_slider,
+                &ch->lowpass_resonance_slide_length);
+
+        Filter_controls_copy(&ch->filter_controls, &vs->filter_controls);
+    }
+
 
 //    LFO_copy(&vs->vibrato, &ch->vibrato);
     vs->panning = ch->panning;
     Slider_copy(&vs->panning_slider, &ch->panning_slider);
-    Slider_set_length(&vs->lowpass_slider, &ch->filter_slide_length);
 //    LFO_copy(&vs->autowah, &ch->autowah);
 
     return;

--- a/src/lib/player/events/note_setup.c
+++ b/src/lib/player/events/note_setup.c
@@ -98,7 +98,6 @@ void set_au_properties(Voice* voice, Voice_state* vs, Channel* ch, double* force
     vs->lowpass = voice->proc->au_params->default_lowpass;
     vs->lowpass_resonance = voice->proc->au_params->default_resonance;
 
-    Slider_set_length(&vs->pitch_slider, &ch->pitch_slide_length);
 //    LFO_copy(&vs->vibrato, &ch->vibrato);
     vs->panning = ch->panning;
     Slider_copy(&vs->panning_slider, &ch->panning_slider);


### PR DESCRIPTION
This branch adds support for carrying the state of some basic force, pitch and lowpass filter parameters between notes in a channel. This makes it easier to write e.g. slow force slides that span across several notes (i.e. no need to specify intermediate force values for each note).