### PR TITLE
Update Fabricate location

### DIFF
--- a/get_build_support.sh
+++ b/get_build_support.sh
@@ -3,9 +3,15 @@
 
 set -e
 
+# Specify location and SHA1 checksum of a tested Fabricate version
+# Note: The current (2015-12-17) project home in GitHub does not contain an
+#       official release, so this URL refers to a specific commit instead.
+
+fabricate_url="https://raw.githubusercontent.com/SimonAlfie/fabricate/2bd38a581836e0bd7a3a5984de5b3354556fb42e/fabricate.py"
+known_sha1sum="fcd2b5da8dc46bbcf9747f63cc7a095947904eed"
+
 verified_path="support/fabricate.py"
 unverified_path="support/fabricate_unverified.py"
-known_sha1sum="7510ec65a6135be611f1b311eb2851e74141859f"
 
 
 # Check for existing verified version
@@ -28,7 +34,7 @@ fi
 
 mkdir -p support
 touch support/__init__.py
-wget -O $unverified_path https://fabricate.googlecode.com/git/fabricate.py
+wget -O $unverified_path $fabricate_url
 
 retrieved_sha1sum=$(sha1sum $unverified_path | cut -d" " -f1)
 
@@ -46,7 +52,7 @@ else
     echo "The downloaded file is located at $unverified_path"
     echo "If you choose to trust this file, you can build Kunquat by running ./make.py --unsafe"
     echo "Alternatively, you can download fabricate.py manually from"
-    echo "http://fabricate.googlecode.com/ and store it in $verified_path"
+    echo "https://github.com/SimonAlfie/fabricate and store it in $verified_path"
     echo ""
     exit 1
 fi


### PR DESCRIPTION
The Fabricate project has moved to GitHub. This branch fixes the build support retrieval script to get Fabricate from an updated location.