### PR TITLE
Processor port names

### DIFF
--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -119,6 +119,9 @@ class AudioUnit():
 
         return out_ports
 
+    def get_port_names(self):
+        return {} # TODO
+
     def set_port_existence(self, port_id, existence):
         key = self._get_key('{}/p_manifest.json'.format(port_id))
         if existence:

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -153,6 +153,9 @@ class Module():
 
         return out_ports
 
+    def get_port_names(self):
+        return { 'out_00': u'out L', 'out_01': u'out R' }
+
     def get_connections(self):
         connections = Connections()
         connections.set_controller(self._controller)

--- a/kunquat/tracker/ui/model/processor.py
+++ b/kunquat/tracker/ui/model/processor.py
@@ -22,6 +22,7 @@ from procparamsfreeverb import ProcParamsFreeverb
 from procparamsgaincomp import ProcParamsGainComp
 from procparamspanning import ProcParamsPanning
 from procparamspitch import ProcParamsPitch
+from procparamsringmod import ProcParamsRingmod
 from procparams_stream import ProcParamsStream
 from procparamsvolume import ProcParamsVolume
 
@@ -93,6 +94,7 @@ class Processor():
             'gaincomp': ProcParamsGainComp,
             'panning':  ProcParamsPanning,
             'pitch':    ProcParamsPitch,
+            'ringmod':  ProcParamsRingmod,
             'stream':   ProcParamsStream,
             'volume':   ProcParamsVolume,
         }
@@ -106,5 +108,9 @@ class Processor():
     def set_signal_type(self, signal_type):
         key = self._get_key('p_signal_type.json')
         self._store[key] = signal_type
+
+    def get_port_names(self):
+        type_params = self.get_type_params()
+        return type_params.get_port_names()
 
 

--- a/kunquat/tracker/ui/model/procparams.py
+++ b/kunquat/tracker/ui/model/procparams.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015
+# Author: Tomi Jylhä-Ollila, Finland 2015-2016
 #
 # This file is part of Kunquat.
 #
@@ -22,6 +22,9 @@ class ProcParams():
     def _get_key(self, impl_or_conf, subkey):
         assert impl_or_conf in ('i/', 'c/')
         return ''.join((self._key_prefix, impl_or_conf, subkey))
+
+    def get_port_names(self):
+        return {}
 
     # Protected interface
 

--- a/kunquat/tracker/ui/model/procparams_stream.py
+++ b/kunquat/tracker/ui/model/procparams_stream.py
@@ -19,6 +19,9 @@ class ProcParamsStream(ProcParams):
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
+    def get_port_names(self):
+        return { 'out_00': u'stream' }
+
     def get_init_value(self):
         return self._get_value('p_f_init_value.json', 0.0)
 

--- a/kunquat/tracker/ui/model/procparamsadd.py
+++ b/kunquat/tracker/ui/model/procparamsadd.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015
+# Author: Tomi Jylhä-Ollila, Finland 2015-2016
 #
 # This file is part of Kunquat.
 #
@@ -182,6 +182,16 @@ class ProcParamsAdd(ProcParams):
 
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
+
+    def get_port_names(self):
+        return {
+            'in_00':  u'freq',
+            'in_01':  u'scale',
+            'in_02':  u'phmod L',
+            'in_03':  u'phmod R',
+            'out_00': u'audio L',
+            'out_01': u'audio R'
+        }
 
     def get_ramp_attack_enabled(self):
         return self._get_value('p_b_ramp_attack.json', True)

--- a/kunquat/tracker/ui/model/procparamsenvgen.py
+++ b/kunquat/tracker/ui/model/procparamsenvgen.py
@@ -19,6 +19,9 @@ class ProcParamsEnvgen(ProcParams):
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
+    def get_port_names(self):
+        return { 'in_00': u'freq', 'in_01': u'scale', 'out_00': u'env' }
+
     def get_scale(self):
         return self._get_value('p_f_scale.json', 0.0)
 

--- a/kunquat/tracker/ui/model/procparamsfilter.py
+++ b/kunquat/tracker/ui/model/procparamsfilter.py
@@ -19,6 +19,16 @@ class ProcParamsFilter(ProcParams):
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
+    def get_port_names(self):
+        return {
+            'in_00':  u'cutoff',
+            'in_01':  u'reso',
+            'in_02':  u'audio L',
+            'in_03':  u'audio R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
+
     def get_cutoff(self):
         return self._get_value('p_f_cutoff.json', 100.0)
 

--- a/kunquat/tracker/ui/model/procparamsforce.py
+++ b/kunquat/tracker/ui/model/procparamsforce.py
@@ -19,6 +19,9 @@ class ProcParamsForce(ProcParams):
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
+    def get_port_names(self):
+        return { 'in_00': u'freq', 'out_00': u'scale' }
+
     def get_global_force(self):
         return self._get_value('p_f_global_force.json', 0.0)
 

--- a/kunquat/tracker/ui/model/procparamsfreeverb.py
+++ b/kunquat/tracker/ui/model/procparamsfreeverb.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015
+# Author: Tomi Jylhä-Ollila, Finland 2015-2016
 #
 # This file is part of Kunquat.
 #
@@ -18,6 +18,14 @@ class ProcParamsFreeverb(ProcParams):
 
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
+
+    def get_port_names(self):
+        return {
+            'in_00':  u'audio L',
+            'in_01':  u'audio R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
 
     def get_reflectivity(self):
         return self._get_value('p_f_refl.json', 20)

--- a/kunquat/tracker/ui/model/procparamsgaincomp.py
+++ b/kunquat/tracker/ui/model/procparamsgaincomp.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015
+# Author: Tomi Jylhä-Ollila, Finland 2015-2016
 #
 # This file is part of Kunquat.
 #
@@ -18,6 +18,14 @@ class ProcParamsGainComp(ProcParams):
 
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
+
+    def get_port_names(self):
+        return {
+            'in_00':  u'audio L',
+            'in_01':  u'audio R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
 
     def get_mapping_enabled(self):
         return self._get_value('p_b_map_enabled.json', False)

--- a/kunquat/tracker/ui/model/procparamspanning.py
+++ b/kunquat/tracker/ui/model/procparamspanning.py
@@ -19,6 +19,15 @@ class ProcParamsPanning(ProcParams):
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
+    def get_port_names(self):
+        return {
+            'in_00':  u'pan',
+            'in_01':  u'audio L',
+            'in_02':  u'audio R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
+
     def get_panning(self):
         return self._get_value('p_f_panning.json', 0.0)
 

--- a/kunquat/tracker/ui/model/procparamsringmod.py
+++ b/kunquat/tracker/ui/model/procparamsringmod.py
@@ -14,12 +14,20 @@
 from procparams import ProcParams
 
 
-class ProcParamsPitch(ProcParams):
+class ProcParamsRingmod(ProcParams):
 
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
 
     def get_port_names(self):
-        return { 'out_00': u'freq' }
+        return {
+            'in_00':  u'audio1 L',
+            'in_01':  u'audio1 R',
+            'in_02':  u'audio2 L',
+            'in_03':  u'audio2 R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
+
 
 

--- a/kunquat/tracker/ui/model/procparamsvolume.py
+++ b/kunquat/tracker/ui/model/procparamsvolume.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015
+# Author: Tomi Jylhä-Ollila, Finland 2015-2016
 #
 # This file is part of Kunquat.
 #
@@ -18,6 +18,15 @@ class ProcParamsVolume(ProcParams):
 
     def __init__(self, proc_id, controller):
         ProcParams.__init__(self, proc_id, controller)
+
+    def get_port_names(self):
+        return {
+            'in_00':  u'scale',
+            'in_01':  u'audio L',
+            'in_02':  u'audio R',
+            'out_00': u'audio L',
+            'out_01': u'audio R',
+        }
 
     def get_volume(self):
         return self._get_value('p_f_volume.json', 0.0)

--- a/kunquat/tracker/ui/views/connections.py
+++ b/kunquat/tracker/ui/views/connections.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2014-2015
+# Author: Tomi Jylhä-Ollila, Finland 2014-2016
 #
 # This file is part of Kunquat.
 #

--- a/kunquat/tracker/ui/views/connections.py
+++ b/kunquat/tracker/ui/views/connections.py
@@ -1108,6 +1108,8 @@ class Device():
         self._in_ports = in_ports
         self._out_ports = out_ports
 
+        self._port_names = model_device.get_port_names()
+
         self._bg = None
 
     def get_name(self):
@@ -1146,27 +1148,29 @@ class Device():
         painter.setFont(self._config['port_font'])
         text_option = QTextOption(Qt.AlignLeft | Qt.AlignVCenter)
         port_height = self._get_port_height()
-        port_y = self._get_title_height()
+        port_y = self._get_title_height() + pad
 
         for port_id in self._in_ports:
-            port_num = int(port_id.split('_')[1], 16)
+            port_str = self._port_names.get(
+                    port_id, str(int(port_id.split('_')[1], 16)))
             painter.drawText(
                     QRectF(pad, port_y, self._bg.width() // 2, port_height),
-                    str(port_num),
+                    port_str,
                     text_option)
             port_y += port_height
 
         text_option = QTextOption(Qt.AlignRight | Qt.AlignVCenter)
-        port_y = self._get_title_height()
+        port_y = self._get_title_height() + pad
         for port_id in self._out_ports:
-            port_num = int(port_id.split('_')[1], 16)
+            port_str = self._port_names.get(
+                    port_id, str(int(port_id.split('_')[1], 16)))
             painter.drawText(
                     QRectF(
                         self._bg.width() // 2,
                         port_y,
                         self._bg.width() // 2 - pad,
                         port_height),
-                    str(port_num),
+                    port_str,
                     text_option)
             port_y += port_height
 
@@ -1201,7 +1205,7 @@ class Device():
         port_offset = self._config['port_handle_size'] // 2
         padding = self._config['padding']
         port_x = bg_offset_x - port_offset
-        port_y = bg_offset_y + padding + self._get_title_height() + port_offset
+        port_y = bg_offset_y + padding + self._get_title_height() + padding + port_offset
 
         for _ in self._in_ports:
             yield (port_x, port_y)
@@ -1214,7 +1218,7 @@ class Device():
         port_offset = self._config['port_handle_size'] // 2
         padding = self._config['padding']
         port_x = bg_offset_x + self._bg.width() + port_offset - 1
-        port_y = bg_offset_y + padding + self._get_title_height() + port_offset
+        port_y = bg_offset_y + padding + self._get_title_height() + padding + port_offset
 
         for _ in self._out_ports:
             yield (port_x, port_y)
@@ -1399,10 +1403,12 @@ class Device():
         port_height = self._get_port_height()
         ports_height = max(len(self._in_ports), len(self._out_ports)) * port_height
 
+        padding = self._config['padding']
+
         if ports_height > 0:
-            total_height = title_height + ports_height
+            total_height = title_height + padding + ports_height
         else:
-            total_height = title_height + self._config['padding'] * 2
+            total_height = title_height + padding * 2
 
         if self._has_edit_button():
             edit_button_height = self._get_edit_button_height()


### PR DESCRIPTION
This branch adds names to processor ports to improve readability of signal processing graphs. Interfaces for retrieving port names are also included for audio units and interface devices (and the global master has port names as well). Chorus and tap delay processors are not updated as they will soon become obsolete.