### PR TITLE
Hide tracker events

### DIFF
--- a/kunquat/tracker/threads/audiothread.py
+++ b/kunquat/tracker/threads/audiothread.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Authors: Tomi Jylhä-Ollila, Finland 2013-2014
+# Authors: Tomi Jylhä-Ollila, Finland 2013-2016
 #          Toni Ruottu, Finland 2013
 #
 # This file is part of Kunquat.
@@ -76,6 +76,9 @@ class AudioThread(MonitoringThread):
 
     def reset_and_pause(self):
         self._q.push('reset_and_pause')
+
+    def sync_call_post_action(self, action_name, args):
+        self._q.push('sync_call_post_action', action_name, args)
 
     # Thread interface
 

--- a/kunquat/tracker/threads/uithread.py
+++ b/kunquat/tracker/threads/uithread.py
@@ -99,6 +99,9 @@ class UiThread(MonitoringThread):
     def confirm_valid_data(self, transaction_id):
         self._q.push('confirm_valid_data', transaction_id)
 
+    def call_post_action(self, action_name, args):
+        self._q.push('call_post_action', action_name, args)
+
     # Threading interface
 
     def halt(self):

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -269,7 +269,6 @@ class Controller():
         self._audio_engine.tfire_event(0, set_goto_pinst)
         self._audio_engine.tfire_event(0, set_goto_row)
         self._audio_engine.tfire_event(0, ('cg', None))
-        print('goto')
 
         self._session.reset_max_audio_levels()
         self._reset_expressions()

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -283,11 +283,9 @@ class Controller():
         self._reset_runtime_env()
         self._reset_expressions()
 
-        # Note: easy way out for syncing note kills, but causes event noise
-        # TODO: figure out a better solution, this may mess things up with bind
+        # Reset active notes
         for ch in xrange(CHANNELS_MAX):
-            note_off_event = ('n-', None)
-            self._audio_engine.tfire_event(ch, note_off_event)
+            self._session.set_active_note(ch, 'n-', None)
 
         if self._session.get_infinite_mode():
             self._audio_engine.tfire_event(0, ('cinfinite+', None))

--- a/kunquat/tracker/ui/controller/session.py
+++ b/kunquat/tracker/ui/controller/session.py
@@ -262,9 +262,10 @@ class Session():
         return self._visible
 
     def log_event(self, channel, event_type, event_value, context):
-        self._event_log.appendleft(
-                (self._event_index.next(),
-                    channel, event_type, event_value, context))
+        if context != 'tfire':
+            self._event_log.appendleft(
+                    (self._event_index.next(),
+                        channel, event_type, event_value, context))
 
     def get_event_log(self):
         return list(self._event_log)

--- a/kunquat/tracker/ui/model/eventhistory.py
+++ b/kunquat/tracker/ui/model/eventhistory.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2013-2014
+# Author: Tomi Jylhä-Ollila, Finland 2013-2016
 #
 # This file is part of Kunquat.
 #
@@ -31,6 +31,9 @@ class EventHistory():
     def get_log(self):
         return [e for e in self._session.get_event_log()
                 if e[4] in self._context_filter]
+
+    def get_event_count_with_filter(self, context):
+        return sum(1 for e in self._session.get_event_log() if e[4] == context)
 
     def allow_context(self, context, allow):
         if allow:

--- a/kunquat/tracker/ui/views/eventlist.py
+++ b/kunquat/tracker/ui/views/eventlist.py
@@ -149,10 +149,15 @@ class EventFilterButton(QCheckBox):
         self._updater = ui_model.get_updater()
         self._updater.register_updater(self._perform_updates)
 
+        self._update_all()
+
     def unregister_updaters(self):
         self._updater.unregister_updater(self._perform_updates)
 
     def _perform_updates(self, signal):
+        self._update_all()
+
+    def _update_all(self):
         event_history = self._ui_model.get_event_history()
         self.blockSignals(True)
         event_count = event_history.get_event_count_with_filter(self._context)

--- a/kunquat/tracker/ui/views/eventlist.py
+++ b/kunquat/tracker/ui/views/eventlist.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2013-2014
+# Author: Tomi Jylhä-Ollila, Finland 2013-2016
 #
 # This file is part of Kunquat.
 #
@@ -20,7 +20,7 @@ import kunquat.tracker.cmdline as cmdline
 DISP_CONTEXTS = {
         'mix': 'Playback',
         'fire': 'User',
-        'tfire': 'Tracker',
+        #'tfire': 'Tracker',
         }
 
 
@@ -173,22 +173,22 @@ class EventFilterView(QWidget):
         h = QHBoxLayout()
         self._mix_toggle = EventFilterButton('mix')
         self._fire_toggle = EventFilterButton('fire')
-        self._tfire_toggle = EventFilterButton('tfire')
+        #self._tfire_toggle = EventFilterButton('tfire')
         h.addWidget(self._mix_toggle)
         h.addWidget(self._fire_toggle)
-        h.addWidget(self._tfire_toggle)
+        #h.addWidget(self._tfire_toggle)
         h.addStretch()
         self.setLayout(h)
 
     def set_ui_model(self, ui_model):
         self._mix_toggle.set_ui_model(ui_model)
         self._fire_toggle.set_ui_model(ui_model)
-        self._tfire_toggle.set_ui_model(ui_model)
+        #self._tfire_toggle.set_ui_model(ui_model)
 
     def unregister_updaters(self):
         self._mix_toggle.unregister_updaters()
         self._fire_toggle.unregister_updaters()
-        self._tfire_toggle.unregister_updaters()
+        #self._tfire_toggle.unregister_updaters()
 
 
 class EventList(QWidget):

--- a/kunquat/tracker/ui/views/eventlist.py
+++ b/kunquat/tracker/ui/views/eventlist.py
@@ -155,6 +155,8 @@ class EventFilterButton(QCheckBox):
     def _perform_updates(self, signal):
         event_history = self._ui_model.get_event_history()
         self.blockSignals(True)
+        event_count = event_history.get_event_count_with_filter(self._context)
+        self.setText('{} ({})'.format(DISP_CONTEXTS[self._context], event_count))
         is_allowed = event_history.is_context_allowed(self._context)
         if is_allowed != self.isChecked():
             self.setChecked(is_allowed)

--- a/src/lib/player/Player_seq.c
+++ b/src/lib/player/Player_seq.c
@@ -418,6 +418,9 @@ static void Player_set_new_playback_position(
 
         for (int k = 0; k < KQT_CHANNELS_MAX; ++k)
             Cgiter_reset(&player->cgiters[k], &target_pos);
+
+        // Set the new position as a global reference
+        player->master_params.cur_pos = target_pos;
     }
 
     // Make sure all triggers are processed after the jump


### PR DESCRIPTION
This branch hides tracker events from event log completely, as future utilisation of query and auto events will render tracker event logging practically useless from a user's perspective. Also, some playback controls are now better synchronised with audio rendering, and playback from cursor position is fixed.