### PR TITLE
Sample import formats

### DIFF
--- a/kunquat/extras/sndfile.py
+++ b/kunquat/extras/sndfile.py
@@ -30,7 +30,12 @@ FORMAT_PCM_32 = 0x0004
 
 FORMAT_PCM_U8 = 0x0005
 
-FORMAT_FLOAT = 0x0006
+FORMAT_FLOAT  = 0x0006
+FORMAT_DOUBLE = 0x0007
+
+FORMAT_SUBMASK  = 0x0000ffff
+FORMAT_TYPEMASK = 0x0fff0000
+FORMAT_ENDMASK  = 0x30000000
 
 SF_FALSE = 0
 SF_TRUE = 1
@@ -130,8 +135,47 @@ class _SndFileBase():
 
 class _SndFileRBase(_SndFileBase):
 
-    def __init__(self):
+    def __init__(self, convert_to_float):
         super().__init__()
+        self._convert_to_float = convert_to_float
+        self._is_float = False
+        self._bits = 0
+        self._audio_rate = 0
+
+    def set_format_info(self, sf_info):
+        self._channels = sf_info.channels
+        self._audio_rate = sf_info.samplerate
+
+        sub_format = sf_info.format & FORMAT_SUBMASK
+        if sub_format in (FORMAT_FLOAT, FORMAT_DOUBLE):
+            self._is_float = True
+            self._bits = 32
+        else:
+            self._is_float = False
+            format_bit_map = {
+                FORMAT_PCM_S8: 8,
+                FORMAT_PCM_U8: 8,
+                FORMAT_PCM_16: 16,
+                FORMAT_PCM_24: 24,
+                FORMAT_PCM_32: 32,
+            }
+            if sub_format in format_bit_map:
+                self._bits = format_bit_map[sub_format]
+            else:
+                self._bits = 32
+                self._convert_to_float = True
+
+    def get_bits(self):
+        return self._bits
+
+    def is_float(self):
+        return self._is_float or self._convert_to_float
+
+    def get_channels(self):
+        return self._channels
+
+    def get_audio_rate(self):
+        return self._audio_rate
 
     def read(self, frame_count=float('inf')):
         """Read audio data.
@@ -150,11 +194,19 @@ class _SndFileRBase(_SndFileBase):
         if frames_left == float('inf'):
             frame_count = 4096
 
-        cdata = (ctypes.c_float * (frame_count * self._channels))()
+        use_float = self._convert_to_float or self._is_float
+
+        if use_float:
+            cdata = (ctypes.c_float * (frame_count * self._channels))()
+        else:
+            cdata = (ctypes.c_int32 * (frame_count * self._channels))()
         chunk = [[] for _ in range(self._channels)]
 
         while frames_left > 0:
-            actual_frame_count = _sndfile.sf_readf_float(self._sf, cdata, frame_count)
+            if use_float:
+                actual_frame_count = _sndfile.sf_readf_float(self._sf, cdata, frame_count)
+            else:
+                actual_frame_count = _sndfile.sf_readf_int(self._sf, cdata, frame_count)
             for ch in range(self._channels):
                 channel_data = cdata[ch:actual_frame_count * self._channels:self._channels]
                 chunk[ch].extend(channel_data)
@@ -169,14 +221,19 @@ class _SndFileRBase(_SndFileBase):
 
 class SndFileR(_SndFileRBase):
 
-    def __init__(self, fname):
+    def __init__(self, fname, convert_to_float=True):
         """Create a new readable audio file.
 
         Arguments:
         fname -- Input file name.
 
+        Optional arguments:
+        convert_to_float -- Convert audio data to float.  If set to
+                            False, integer audio data will be scaled
+                            to 32-bit integers.
+
         """
-        super().__init__()
+        super().__init__(convert_to_float)
 
         info = _SF_INFO(0, 0, 0, 0, 0, 0)
 
@@ -185,7 +242,7 @@ class SndFileR(_SndFileRBase):
             raise SndFileError('Could not open file {}: {}'.format(
                 fname, _sndfile.sf_strerror(None)))
 
-        self._channels = info.channels
+        self.set_format_info(info)
 
     def __del__(self):
         self.close()
@@ -193,14 +250,19 @@ class SndFileR(_SndFileRBase):
 
 class SndFileRMem(_SndFileRBase):
 
-    def __init__(self, data):
+    def __init__(self, data, convert_to_float=True):
         """Create a new readable audio stream from data in memory.
 
         Arguments:
         data -- Input data.
 
+        Optional arguments:
+        convert_to_float -- Convert audio data to float.  If set to
+                            False, integer audio data will be scaled
+                            to 32-bit integers.
+
         """
-        super().__init__()
+        super().__init__(convert_to_float)
         self._data = data
 
         self._bytes = bytes(self._data)
@@ -213,7 +275,7 @@ class SndFileRMem(_SndFileRBase):
             raise SndFileError('Could not set up data access: {}'.format(
                 _sndfile.sf_strerror(None)))
 
-        self._channels = info.channels
+        self.set_format_info(info)
 
     def __del__(self):
         self.close()
@@ -424,17 +486,23 @@ _sndfile.sf_command.argtypes = [
         ctypes.c_int]
 _sndfile.sf_command.restype = ctypes.c_int
 
+_sndfile.sf_readf_int.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int),
+        _sf_count_t]
+_sndfile.sf_readf_int.restype = _sf_count_t
+
 _sndfile.sf_readf_float.argtypes = [
         ctypes.c_void_p,
         ctypes.POINTER(ctypes.c_float),
-        ctypes.c_int64]
-_sndfile.sf_readf_float.restype = ctypes.c_int64
+        _sf_count_t]
+_sndfile.sf_readf_float.restype = _sf_count_t
 
 _sndfile.sf_writef_float.argtypes = [
         ctypes.c_void_p,
         ctypes.POINTER(ctypes.c_float),
-        ctypes.c_int64]
-_sndfile.sf_writef_float.restype = ctypes.c_int64
+        _sf_count_t]
+_sndfile.sf_writef_float.restype = _sf_count_t
 
 _sndfile.sf_close.argtypes = [ctypes.c_void_p]
 _sndfile.sf_close.restype = ctypes.c_int

--- a/kunquat/extras/sndfile.py
+++ b/kunquat/extras/sndfile.py
@@ -239,8 +239,8 @@ class SndFileR(_SndFileRBase):
 
         self._sf = _sndfile.sf_open(bytes(fname, encoding='utf-8'), SFM_READ, info)
         if not self._sf:
-            raise SndFileError('Could not open file {}: {}'.format(
-                fname, _sndfile.sf_strerror(None)))
+            err_cstr = _sndfile.sf_strerror(None)
+            raise SndFileError(str(err_cstr, encoding='utf-8'))
 
         self.set_format_info(info)
 
@@ -272,8 +272,9 @@ class SndFileRMem(_SndFileRBase):
 
         self._sf = _sndfile.sf_open_virtual(vio, SFM_READ, info, None)
         if not self._sf:
+            err_cstr = _sndfile.sf_strerror(None)
             raise SndFileError('Could not set up data access: {}'.format(
-                _sndfile.sf_strerror(None)))
+                str(err_cstr, encoding='utf-8')))
 
         self.set_format_info(info)
 
@@ -356,8 +357,9 @@ class SndFileW(_SndFileWBase):
 
         self._sf = _sndfile.sf_open(bytes(fname, encoding='utf-8'), SFM_WRITE, info)
         if not self._sf:
+            err_cstr = _sndfile.sf_strerror(None)
             raise SndFileError('Could not create file {}: {}'.format(
-                fname, _sndfile.sf_strerror(None)))
+                fname, str(err_cstr, encoding='utf-8')))
 
         if not use_float:
             _sndfile.sf_command(self._sf, SFC_SET_CLIPPING, None, SF_TRUE)
@@ -394,8 +396,9 @@ class SndFileWMem(_SndFileWBase):
 
         self._sf = _sndfile.sf_open_virtual(vio, SFM_WRITE, info, None)
         if not self._sf:
+            err_cstr = _sndfile.sf_strerror(None)
             raise SndFileError('Could not set up data access: {}'.format(
-                _sndfile.sf_strerror(None)))
+                str(err_cstr, encoding='utf-8')))
 
         if not use_float:
             _sndfile.sf_command(self._sf, SFC_SET_CLIPPING, None, SF_TRUE)

--- a/kunquat/extras/wavpack.py
+++ b/kunquat/extras/wavpack.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+
+#
+# Author: Tomi Jylhä-Ollila, Finland 2016
+#
+# This file is part of Kunquat.
+#
+# CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+#
+# To the extent possible under law, Kunquat Affirmers have waived all
+# copyright and related or neighboring rights to Kunquat.
+#
+
+"""A wrapper for accessing WavPack sound data.
+
+"""
+
+import ctypes
+from io import BytesIO
+
+
+class _WavPackBase():
+
+    def __init__(self):
+        self._wpc = None
+
+    def close(self):
+        if self._wpc != None:
+            _wavpack.WavpackCloseFile(self._wpc)
+            self._wpc = None
+
+
+class _WavPackWBase(_WavPackBase):
+
+    def __init__(self, file_obj):
+        super().__init__()
+        self._f = file_obj
+
+        self._channels = 0
+        self._use_float = False
+        self._bits = 0
+
+        self._first_block = None
+
+    def _prepare(self, rate, channels, use_float, bits):
+        self._channels = channels
+        self._use_float = use_float
+        self._bits = bits
+
+        if self._use_float and (bits != 32):
+            raise ValueError('Bit depth must be 32 in floating-point mode')
+
+        if self._bits in (8, 16, 32):
+            bytes_per_sample = self._bits // 8
+        elif bits == 24:
+            bytes_per_sample = 4
+        else:
+            raise NotImplementedError('Bit depths not multiple by 8 are not supported')
+
+        channel_mask = { 1: 4, 2: 3 }.get(self._channels, 0)
+
+        def block_output_cb(id_, data, bcount):
+            if not self._first_block:
+                self._first_block = (ctypes.c_char * bcount)()
+                self._first_block[:] = data[:bcount]
+            return self._block_output(id_, data, bcount)
+        self._block_output_cb = _WavpackBlockOutput(block_output_cb)
+
+        self._wpc = _wavpack.WavpackOpenFileOutput(self._block_output_cb, None, None)
+        if self._wpc == None:
+            raise MemoryError('Could not allocate memory for WavPack context')
+
+        flags = _CONFIG_VERY_HIGH_FLAG | _CONFIG_SKIP_WVX
+        float_norm_exp = 0
+        if self._use_float:
+            flags |= _CONFIG_FLOAT_DATA
+            float_norm_exp = 127
+
+        config = _WavpackConfig(
+                0,                  # bitrate
+                0,                  # shaping_weight
+                self._bits,         # bits_per_sample
+                bytes_per_sample,   # bytes_per_sample
+                0,                  # qmode
+                flags,              # flags
+                0,                  # xmode
+                self._channels,     # num_channels
+                float_norm_exp,     # float_norm_exp (127 for +/-1.0)
+                0,                  # block_samples
+                0,                  # extra_flags
+                rate,               # sample_rate
+                channel_mask,       # channel_mask
+                (ctypes.c_ubyte * 16)(), # md5_checksum
+                0,                  # md5_read
+                0,                  # num_tag_strings
+                None)               # tag_strings
+
+        if not _wavpack.WavpackSetConfiguration(self._wpc, config, -1):
+            raise WavPackError('Error while setting WavPack configuration: {}'.format(
+                _wavpack.WavpackGetErrorMessage(self._wpc)))
+
+        if not _wavpack.WavpackPackInit(self._wpc):
+            raise WavPackError('Could not init WavPack packing: {}'.format(
+                _wavpack.WavpackGetErrorMessage(self._wpc)))
+
+    def _fill_buffer(self, frame_count, target, src):
+        for ch in range(self._channels):
+            if len(src[ch]) != frame_count:
+                raise ValueError('Output channel buffer lengths do not match')
+            target[ch::self._channels] = src[ch]
+
+    def write(self, *data):
+        """Write audio data.
+
+        Arguments:
+        data -- The output buffers, each channel as a separate argument.
+
+        """
+        assert self._wpc
+
+        if len(data) != self._channels:
+            raise ValueError('Expected {} output channels, got {}'.format(
+                self._channels, len(data)))
+
+        frame_count = len(data[0])
+        if self._use_float:
+            fdata = (ctypes.c_float * (frame_count * self._channels))()
+            self._fill_buffer(frame_count, fdata, data)
+            cdata = ctypes.cast(fdata, ctypes.POINTER(ctypes.c_int32))
+        else:
+            cdata = (ctypes.c_int32 * (frame_count * self._channels))()
+            self._fill_buffer(frame_count, cdata, data)
+
+        if not _wavpack.WavpackPackSamples(self._wpc, cdata, frame_count):
+            raise WavPackError('Error while writing WavPack data: {}'.format(
+                _wavpack.WavpackGetErrorMessage(self._wpc)))
+
+    def close(self):
+        super().close()
+        if self._f:
+            self._f.close()
+            self._f = None
+
+    def finalise(self):
+        if self._wpc:
+            if not _wavpack.WavpackFlushSamples(self._wpc):
+                raise WavPackError('Error while flushing output: {}'.format(
+                    _wavpack.WavpackGetErrorMessage(self._wpc)))
+
+            if self._first_block:
+                _wavpack.WavpackUpdateNumSamples(self._wpc, self._first_block)
+                self._update_first_block(self._first_block)
+
+    def _block_output(self, id_, data, bcount):
+        if self._f:
+            self._f.write(bytes(data[:bcount]))
+        return 1
+
+    def _update_first_block(self, block):
+        if self._f:
+            self._f.seek(0)
+            self._f.write(bytes(block))
+
+
+class WavPackW(_WavPackWBase):
+
+    def __init__(
+            self,
+            fname,
+            rate=48000,
+            channels=1,
+            use_float=False,
+            bits=16):
+        """Create a new writable WavPack file.
+
+        Arguments:
+        fname -- Output file name.
+
+        Optional arguments:
+        rate      -- Audio rate.
+        channels  -- Number of output channels.
+        use_float -- Use floating-point frames.
+        bits      -- Bits per item.
+
+        """
+        super().__init__(open(fname, 'wb'))
+        self._prepare(rate, channels, use_float, bits)
+
+    def __del__(self):
+        self.finalise()
+        self.close()
+
+
+class WavPackWMem(_WavPackWBase):
+
+    def __init__(
+            self,
+            rate=48000,
+            channels=2,
+            use_float=False,
+            bits=16):
+        """Create a new writable WavPack stream to memory.
+
+        Optional arguments:
+        rate      -- Audio rate.
+        channels  -- Number of output channels.
+        use_float -- Use floating-point frames.
+        bits      -- Bits per item.
+
+        """
+        super().__init__(BytesIO())
+
+        self._data = None
+
+        self._prepare(rate, channels, use_float, bits)
+
+    def close(self):
+        self.finalise()
+
+        self._f.seek(0)
+        self._data = self._f.read()
+
+        super().close()
+
+    def get_contents(self):
+        self.close()
+        return self._data
+
+    def __del__(self):
+        self.close()
+
+
+class WavPackError(Exception):
+    '''Class for WavPack-related errors.
+
+    '''
+
+
+_MODE_FLOAT     = 0x8
+
+_CONFIG_FLOAT_DATA      = 0x80
+_CONFIG_FAST_FLAG       = 0x200
+_CONFIG_HIGH_FLAG       = 0x800
+_CONFIG_VERY_HIGH_FLAG  = 0x1000
+_CONFIG_SKIP_WVX        = 0x4000000
+
+_OPEN_2CH_MAX   = 0x8
+_OPEN_NORMALIZE = 0x10
+
+
+_read_bytes = ctypes.CFUNCTYPE(
+        ctypes.c_int32,
+        ctypes.c_void_p, # id
+        ctypes.c_void_p, # data
+        ctypes.c_int32) # bcount
+
+_get_pos = ctypes.CFUNCTYPE(
+        ctypes.c_uint32,
+        ctypes.c_void_p) # id
+
+_set_pos_abs = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p, # id
+        ctypes.c_uint32) # pos
+
+_set_pos_rel = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p, # id
+        ctypes.c_int32, # delta
+        ctypes.c_int) # mode
+
+_push_back_byte = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p, # id
+        ctypes.c_int) # byte
+
+_get_length = ctypes.CFUNCTYPE(
+        ctypes.c_uint32,
+        ctypes.c_void_p) # id
+
+_can_seek = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p) # id
+
+_write_bytes = ctypes.CFUNCTYPE(
+        ctypes.c_int32,
+        ctypes.c_void_p, # id
+        ctypes.c_void_p, # data
+        ctypes.c_int32) # bcount
+
+class _WavpackStreamReader(ctypes.Structure):
+    _fields_ = [
+        ('read_bytes', _read_bytes),
+        ('get_pos', _get_pos),
+        ('set_pos_abs', _set_pos_abs),
+        ('set_pos_rel', _set_pos_rel),
+        ('push_back_byte', _push_back_byte),
+        ('get_length', _get_length),
+        ('can_seek', _can_seek),
+        ('write_bytes', _write_bytes),
+    ]
+
+
+_WavpackContext = ctypes.c_void_p
+
+
+class _WavpackConfig(ctypes.Structure):
+    _fields_ = [
+        ('bitrate', ctypes.c_float),
+        ('shaping_weight', ctypes.c_float),
+        ('bits_per_sample', ctypes.c_int),
+        ('bytes_per_sample', ctypes.c_int),
+        ('qmode', ctypes.c_int),
+        ('flags', ctypes.c_int),
+        ('xmode', ctypes.c_int),
+        ('num_channels', ctypes.c_int),
+        ('float_norm_exp', ctypes.c_int),
+        ('block_samples', ctypes.c_int32),
+        ('extra_flags', ctypes.c_int32),
+        ('sample_rate', ctypes.c_int32),
+        ('channel_mask', ctypes.c_int32),
+        ('md5_checksum', ctypes.c_ubyte * 16),
+        ('md5_read', ctypes.c_ubyte),
+        ('num_tag_strings', ctypes.c_int),
+        ('tag_strings', ctypes.POINTER(ctypes.c_char_p)),
+    ]
+
+
+_WavpackBlockOutput = ctypes.CFUNCTYPE(
+        ctypes.c_int,
+        ctypes.c_void_p, # id
+        ctypes.POINTER(ctypes.c_char), # data
+        ctypes.c_int32) # bcount
+
+
+_wavpack = ctypes.CDLL('libwavpack.so')
+
+_wavpack.WavpackGetErrorMessage.argtypes = [_WavpackContext]
+_wavpack.WavpackGetErrorMessage.restype = ctypes.c_char_p
+
+_wavpack.WavpackOpenFileInputEx.argtypes = [
+        ctypes.POINTER(_WavpackStreamReader),
+        ctypes.c_void_p, # wv_id
+        ctypes.c_void_p, # wvc_id
+        ctypes.c_char_p, # error
+        ctypes.c_int, # flags
+        ctypes.c_int] # norm_offset
+_wavpack.WavpackOpenFileInputEx.restype = _WavpackContext
+
+_wavpack.WavpackGetMode.argtypes = [_WavpackContext]
+_wavpack.WavpackGetMode.restype = ctypes.c_int
+
+_wavpack.WavpackGetReducedChannels.argtypes = [_WavpackContext]
+_wavpack.WavpackGetReducedChannels.restype = ctypes.c_int
+
+_wavpack.WavpackGetSampleRate.argtypes = [_WavpackContext]
+_wavpack.WavpackGetSampleRate.restype = ctypes.c_uint32
+
+_wavpack.WavpackGetBitsPerSample.argtypes = [_WavpackContext]
+_wavpack.WavpackGetBitsPerSample.restype = ctypes.c_int
+
+_wavpack.WavpackGetBytesPerSample.argtypes = [_WavpackContext]
+_wavpack.WavpackGetBytesPerSample.restype = ctypes.c_int
+
+_wavpack.WavpackGetNumSamples.argtypes = [_WavpackContext]
+_wavpack.WavpackGetNumSamples.restype = ctypes.c_uint32
+
+_wavpack.WavpackUnpackSamples.argtypes = [
+        _WavpackContext, ctypes.POINTER(ctypes.c_int32), ctypes.c_uint32]
+_wavpack.WavpackUnpackSamples.restype = ctypes.c_uint32
+
+_wavpack.WavpackOpenFileOutput.argtypes = [
+        _WavpackBlockOutput,
+        ctypes.c_void_p, # wv_id
+        ctypes.c_void_p] # wvc_id
+_wavpack.WavpackOpenFileOutput.restype = _WavpackContext
+
+_wavpack.WavpackSetConfiguration.argtypes = [
+        _WavpackContext,
+        ctypes.POINTER(_WavpackConfig),
+        ctypes.c_uint32] # total_samples
+_wavpack.WavpackSetConfiguration.restype = ctypes.c_int
+
+_wavpack.WavpackPackInit.argtypes = [_WavpackContext]
+_wavpack.WavpackPackInit.restype = ctypes.c_int
+
+_wavpack.WavpackPackSamples.argtypes = [
+        _WavpackContext,
+        ctypes.POINTER(ctypes.c_int32), # sample_buffer
+        ctypes.c_uint32] # sample_count
+_wavpack.WavpackPackSamples.restype = ctypes.c_int
+
+_wavpack.WavpackFlushSamples.argtypes = [_WavpackContext]
+_wavpack.WavpackFlushSamples.restype = ctypes.c_int
+
+_wavpack.WavpackUpdateNumSamples.argtypes = [
+        _WavpackContext,
+        ctypes.c_void_p] # first_block
+
+_wavpack.WavpackCloseFile.argtypes = [_WavpackContext]
+_wavpack.WavpackCloseFile.restype = _WavpackContext
+
+

--- a/kunquat/extras/wavpack.py
+++ b/kunquat/extras/wavpack.py
@@ -119,8 +119,8 @@ class _WavPackWBase(_WavPackBase):
         assert self._wpc
 
         if len(data) != self._channels:
-            raise ValueError('Expected {} output channels, got {}'.format(
-                self._channels, len(data)))
+            raise ValueError('Expected {} output channel{}, got {}'.format(
+                self._channels, '' if self._channels == 1 else 's', len(data)))
 
         frame_count = len(data[0])
         if self._use_float:

--- a/kunquat/extras/wavpack.py
+++ b/kunquat/extras/wavpack.py
@@ -70,7 +70,7 @@ class _WavPackWBase(_WavPackBase):
         if self._wpc == None:
             raise MemoryError('Could not allocate memory for WavPack context')
 
-        flags = _CONFIG_VERY_HIGH_FLAG | _CONFIG_SKIP_WVX
+        flags = _CONFIG_VERY_HIGH_FLAG
         float_norm_exp = 0
         if self._use_float:
             flags |= _CONFIG_FLOAT_DATA

--- a/kunquat/extras/wavpack.py
+++ b/kunquat/extras/wavpack.py
@@ -220,8 +220,9 @@ class WavPackWMem(_WavPackWBase):
     def close(self):
         self.finalise()
 
-        self._f.seek(0)
-        self._data = self._f.read()
+        if self._f:
+            self._f.seek(0)
+            self._data = self._f.read()
 
         super().close()
 

--- a/kunquat/extras/wavpack.py
+++ b/kunquat/extras/wavpack.py
@@ -130,6 +130,9 @@ class _WavPackWBase(_WavPackBase):
         else:
             cdata = (ctypes.c_int32 * (frame_count * self._channels))()
             self._fill_buffer(frame_count, cdata, data)
+            if self._bits == 24:
+                for i in range(frame_count * self._channels):
+                    cdata[i] <<= 8
 
         if not _wavpack.WavpackPackSamples(self._wpc, cdata, frame_count):
             raise WavPackError('Error while writing WavPack data: {}'.format(

--- a/kunquat/tracker/ui/views/processor/sampleproc.py
+++ b/kunquat/tracker/ui/views/processor/sampleproc.py
@@ -1324,8 +1324,17 @@ class SampleListToolBar(QToolBar):
         if not sample_id:
             return
 
+        filters = [
+            'All supported types (*.wav *.aiff *.aif *.aifc *.au *.snd *.wv *.flac)',
+            'Waveform Audio File Format (*.wav)',
+            'Audio Interchange File Format (*.aiff *.aif *.aifc)',
+            'Sun Au (*.au *.snd)',
+            'WavPack (*.wv)',
+            'Free Lossless Audio Codec (*.flac)',
+        ]
+
         sample_path, _ = QFileDialog.getOpenFileName(
-                caption='Import sample', filter='WavPack audio (*.wv)')
+                caption='Import sample', filter=';;'.join(filters))
         if sample_path:
             success = sample_params.import_sample(sample_id, sample_path)
             if success:

--- a/kunquat/tracker/ui/views/processor/sampleproc.py
+++ b/kunquat/tracker/ui/views/processor/sampleproc.py
@@ -17,6 +17,7 @@ import time
 from PySide.QtCore import *
 from PySide.QtGui import *
 
+from kunquat.tracker.ui.model.procparams.sampleparams import SampleImportError
 from kunquat.tracker.ui.views.audio_unit.hitselector import HitSelector
 from kunquat.tracker.ui.views.axisrenderer import HorizontalAxisRenderer, VerticalAxisRenderer
 from kunquat.tracker.ui.views.editorlist import EditorList
@@ -1336,16 +1337,16 @@ class SampleListToolBar(QToolBar):
         sample_path, _ = QFileDialog.getOpenFileName(
                 caption='Import sample', filter=';;'.join(filters))
         if sample_path:
-            success = sample_params.import_sample(sample_id, sample_path)
-            if success:
+            try:
+                sample_params.import_sample(sample_id, sample_path)
                 self._updater.signal_update(set([
                     self._get_list_signal_type(),
                     self._get_note_map_random_list_signal_type(),
                     self._get_hit_map_random_list_signal_type()]))
-            else:
+            except SampleImportError as e:
                 icon_bank = self._ui_model.get_icon_bank()
-                # TODO: Add a more descriptive error message
-                error_msg = '<p>Could not import \'{}\'.</p>'.format(sample_path)
+                error_msg_lines = str(e).split('\n')
+                error_msg = '<p>{}</p>'.format('<br>'.join(error_msg_lines))
                 dialog = ImportErrorDialog(icon_bank, error_msg)
                 dialog.exec_()
 


### PR DESCRIPTION
This branch adds support for importing samples of some common uncompressed and lossless audio formats besides WavPack. No changes were made inside libkunquat; instead, the tracker converts foreign sample formats to WavPack while importing.