### PR TITLE
Optimisations for buffers with constant data

### DIFF
--- a/src/lib/player/LFO.c
+++ b/src/lib/player/LFO.c
@@ -364,6 +364,17 @@ bool LFO_active(const LFO* lfo)
 }
 
 
+int32_t LFO_estimate_active_steps_left(const LFO* lfo)
+{
+    assert(lfo != NULL);
+
+    if (Slider_in_progress(&lfo->depth_slider) && lfo->target_depth == 0)
+        return Slider_estimate_active_steps_left(&lfo->depth_slider);
+
+    return LFO_active(lfo) ? INT32_MAX : 0;
+}
+
+
 double LFO_get_target_speed(const LFO* lfo)
 {
     assert(lfo != NULL);

--- a/src/lib/player/LFO.c
+++ b/src/lib/player/LFO.c
@@ -274,8 +274,10 @@ double LFO_step(LFO* lfo)
     if (new_phase >= (2 * PI))
         new_phase = fmod(new_phase, 2 * PI);
 
-    if (!lfo->on && (new_phase < lfo->phase ||
-                (new_phase >= PI && lfo->phase < PI))) // TODO: offset
+    if ((!Slider_in_progress(&lfo->depth_slider) && cur_depth == 0) ||
+            (!lfo->on &&
+            (new_phase < lfo->phase ||
+             (new_phase >= PI && lfo->phase < PI)))) // TODO: offset
     {
         lfo->phase = 0;
         lfo->update = 0;

--- a/src/lib/player/LFO.h
+++ b/src/lib/player/LFO.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *

--- a/src/lib/player/LFO.h
+++ b/src/lib/player/LFO.h
@@ -200,6 +200,21 @@ bool LFO_active(const LFO* lfo);
 
 
 /**
+ * Estimate the number of active steps left in the LFO.
+ *
+ * This may be different from the actual number of steps with very slow depth
+ * slides.
+ *
+ * \param lfo   The LFO -- must not be \c NULL.
+ *
+ * \return   The estimated number of steps left (always positive), or \c 0 if
+ *           \a lfo is inactive. Note that this value becomes obsolete if
+ *           audio rate or tempo changes.
+ */
+int32_t LFO_estimate_active_steps_left(const LFO* lfo);
+
+
+/**
  * Return the current target speed of the LFO.
  *
  * \param lfo   The LFO -- must not be \c NULL.

--- a/src/lib/player/Linear_controls.c
+++ b/src/lib/player/Linear_controls.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2016
  *
  * This file is part of Kunquat.
  *

--- a/src/lib/player/Linear_controls.c
+++ b/src/lib/player/Linear_controls.c
@@ -220,23 +220,6 @@ void Linear_controls_fill_work_buffer(
             }
         }
     }
-    /*
-    if (Slider_in_progress(&lc->slider))
-    {
-        float new_value = lc->value;
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-        {
-            new_value = Slider_step(&lc->slider);
-            values[i] = new_value;
-        }
-        lc->value = new_value;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            values[i] = lc->value;
-    }
-    // */
 
     // Apply LFO
     {
@@ -266,15 +249,6 @@ void Linear_controls_fill_work_buffer(
 
         const_start = max(const_start, final_lfo_stop);
     }
-    /*
-    if (LFO_active(&lc->lfo))
-    {
-        const_start = buf_stop;
-
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            values[i] += LFO_step(&lc->lfo);
-    }
-    // */
 
     // Clamp values
     if (lc->min_value > -INFINITY)

--- a/src/lib/player/Linear_controls.c
+++ b/src/lib/player/Linear_controls.c
@@ -175,7 +175,7 @@ void Linear_controls_osc_depth_slide_value(Linear_controls* lc, const Tstamp* le
 
 void Linear_controls_fill_work_buffer(
         Linear_controls* lc,
-        const Work_buffer* wb,
+        Work_buffer* wb,
         int32_t buf_start,
         int32_t buf_stop)
 {

--- a/src/lib/player/Linear_controls.h
+++ b/src/lib/player/Linear_controls.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2016
  *
  * This file is part of Kunquat.
  *

--- a/src/lib/player/Linear_controls.h
+++ b/src/lib/player/Linear_controls.h
@@ -158,7 +158,7 @@ void Linear_controls_osc_depth_slide_value(Linear_controls* lc, const Tstamp* le
  */
 void Linear_controls_fill_work_buffer(
         Linear_controls* lc,
-        const Work_buffer* wb,
+        Work_buffer* wb,
         int32_t buf_start,
         int32_t buf_stop);
 

--- a/src/lib/player/Slider.c
+++ b/src/lib/player/Slider.c
@@ -121,7 +121,7 @@ double Slider_skip(Slider* slider, uint64_t steps)
 }
 
 
-int64_t Slider_estimate_active_steps_left(const Slider* slider)
+int32_t Slider_estimate_active_steps_left(const Slider* slider)
 {
     assert(slider != NULL);
 
@@ -129,7 +129,7 @@ int64_t Slider_estimate_active_steps_left(const Slider* slider)
         return 0;
 
     const double steps = ceil((1 - slider->progress) / slider->progress_update);
-    const int64_t steps_i = (steps > INT64_MAX) ? INT64_MAX : (int64_t)steps;
+    const int32_t steps_i = (steps > INT32_MAX) ? INT32_MAX : (int32_t)steps;
 
     return max(1, steps_i);
 }

--- a/src/lib/player/Slider.c
+++ b/src/lib/player/Slider.c
@@ -121,6 +121,20 @@ double Slider_skip(Slider* slider, uint64_t steps)
 }
 
 
+int64_t Slider_estimate_active_steps_left(const Slider* slider)
+{
+    assert(slider != NULL);
+
+    if (!Slider_in_progress(slider))
+        return 0;
+
+    const double steps = ceil((1 - slider->progress) / slider->progress_update);
+    const int64_t steps_i = (steps > INT64_MAX) ? INT64_MAX : (int64_t)steps;
+
+    return max(1, steps_i);
+}
+
+
 void Slider_break(Slider* slider)
 {
     assert(slider != NULL);

--- a/src/lib/player/Slider.h
+++ b/src/lib/player/Slider.h
@@ -129,7 +129,7 @@ double Slider_skip(Slider* slider, uint64_t steps);
  *           \a slider is inactive. Note that this value becomes obsolete if
  *           audio rate or tempo changes.
  */
-int64_t Slider_estimate_active_steps_left(const Slider* slider);
+int32_t Slider_estimate_active_steps_left(const Slider* slider);
 
 
 /**

--- a/src/lib/player/Slider.h
+++ b/src/lib/player/Slider.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -116,6 +116,20 @@ double Slider_step(Slider* slider);
  * \return   The new intermediate (or target) value in \a slider.
  */
 double Slider_skip(Slider* slider, uint64_t steps);
+
+
+/**
+ * Estimate the number of active steps left in the Slider.
+ *
+ * This may be different from the actual number of steps with very slow slides.
+ *
+ * \param slider   The Slider -- must not be \c NULL.
+ *
+ * \return   The estimated number of steps left (always positive), or \c 0 if
+ *           \a slider is inactive. Note that this value becomes obsolete if
+ *           audio rate or tempo changes.
+ */
+int64_t Slider_estimate_active_steps_left(const Slider* slider);
 
 
 /**

--- a/src/lib/player/Time_env_state.c
+++ b/src/lib/player/Time_env_state.c
@@ -71,6 +71,9 @@ int32_t Time_env_state_process(
     assert(buf_stop >= 0);
     assert(audio_rate > 0);
 
+    if (testate->is_finished)
+        return buf_start;
+
     // Get constant values used inside the loop
     const double slowdown_fac = 1.0 - sustain;
     const double inv_audio_rate = 1.0 / audio_rate;

--- a/src/lib/player/Time_env_state.h
+++ b/src/lib/player/Time_env_state.h
@@ -57,7 +57,7 @@ void Time_env_state_init(Time_env_state* testate);
  *                        (0 indicates no sustain).
  * \param min_value       Minimum envelope value -- must be finite.
  * \param max_value       Maximum envelope value -- must be finite.
- * \param pitch_buf       Input pitch values -- must not be \c NULL.
+ * \param pitch_wb        Input pitch values -- must not be \c NULL.
  * \param env_buf         Destination buffer for envelope values
  *                        -- must not be \c NULL.
  * \param buf_start       Write starting position of the work buffer
@@ -77,7 +77,7 @@ int32_t Time_env_state_process(
         double sustain,
         double min_value,
         double max_value,
-        const float* pitch_buf,
+        const Work_buffer* pitch_wb,
         float* env_buf,
         int32_t buf_start,
         int32_t buf_stop,

--- a/src/lib/player/Work_buffer.h
+++ b/src/lib/player/Work_buffer.h
@@ -88,13 +88,30 @@ const float* Work_buffer_get_contents(const Work_buffer* buffer);
 /**
  * Get the mutable contents of the Work buffer.
  *
+ * Note: This function clears the const start index of the buffer as it no
+ *       longer makes any assumptions of the buffer contents. If you wish to
+ *       utilise this optimisation feature, call the function
+ *       \a Work_buffer_get_contents_mut_keep_const instead.
+ *
  * \param buffer   The Work buffer -- must not be \c NULL.
  *
  * \return   The address of the internal buffer, with a valid index range of
  *           [-1, Work_buffer_get_size(\a buffer)]. For devices that receive
  *           the buffer from a caller, this function never returns \c NULL.
  */
-float* Work_buffer_get_contents_mut(const Work_buffer* buffer);
+float* Work_buffer_get_contents_mut(Work_buffer* buffer);
+
+
+/**
+ * Get the mutable contents of the Work buffer with the current const start.
+ *
+ * \param buffer   The Work buffer -- must not be \c NULL.
+ *
+ * \return   The address of the internal buffer, with a valid index range of
+ *           [-1, Work_buffer_get_size(\a buffer)]. For devices that receive
+ *           the buffer from a caller, this function never returns \c NULL.
+ */
+float* Work_buffer_get_contents_mut_keep_const(Work_buffer* buffer);
 
 
 /**
@@ -106,7 +123,7 @@ float* Work_buffer_get_contents_mut(const Work_buffer* buffer);
  *           [-1, Work_buffer_get_size(\a buffer)]. For devices that receive
  *           the buffer from a caller, this function never returns \c NULL.
  */
-int32_t* Work_buffer_get_contents_int_mut(const Work_buffer* buffer);
+int32_t* Work_buffer_get_contents_int_mut(Work_buffer* buffer);
 
 
 /**
@@ -120,10 +137,41 @@ int32_t* Work_buffer_get_contents_int_mut(const Work_buffer* buffer);
  *                    >= \c -1 and less than or equal to buffer size + \c 1.
  */
 void Work_buffer_copy(
-        const Work_buffer* restrict dest,
+        Work_buffer* restrict dest,
         const Work_buffer* restrict src,
         int32_t buf_start,
         int32_t buf_stop);
+
+
+/**
+ * Mark a trailing part of Work buffer contents as having constant value.
+ *
+ * NOTE: This is used as an optional performance optimisation. The caller
+ * must still fill the marked buffer area with constant values for code
+ * that does not take advantage of this information.
+ *
+ * \param buffer   The Work buffer -- must not be \c NULL.
+ * \param start    The start index in \a buffer -- must be non-negative.
+ */
+void Work_buffer_set_const_start(Work_buffer* buffer, int32_t start);
+
+
+/**
+ * Clear Work buffer constant-value part marker.
+ *
+ * \param buffer   The Work buffer -- must not be \c NULL.
+ */
+void Work_buffer_clear_const_start(Work_buffer* buffer);
+
+
+/**
+ * Get Work buffer constant-value part marker.
+ *
+ * \param buffer   The Work buffer -- must not be \c NULL.
+ *
+ * \return   The constant-value start marker, or \c INT32_MAX if not set.
+ */
+int32_t Work_buffer_get_const_start(const Work_buffer* buffer);
 
 
 /**

--- a/src/lib/player/devices/Proc_state.c
+++ b/src/lib/player/devices/Proc_state.c
@@ -236,7 +236,7 @@ float* Proc_state_get_voice_buffer_contents_mut(
     assert(port_num >= 0);
     assert(port_num < KQT_DEVICE_PORTS_MAX);
 
-    const Work_buffer* wb =
+    Work_buffer* wb =
         Proc_state_get_voice_buffer_mut(proc_state, port_type, port_num);
     if (wb == NULL)
         return NULL;

--- a/src/lib/player/devices/processors/Add_state.c
+++ b/src/lib/player/devices/processors/Add_state.c
@@ -105,21 +105,6 @@ static int32_t Add_vstate_render_voice(
         scales_wb = Work_buffers_get_buffer_mut(wbs, ADD_WORK_BUFFER_FIXED_FORCE);
     Proc_fill_scale_buffer(scales_wb, dBs_wb, buf_start, buf_stop);
     const float* scales = Work_buffer_get_contents(scales_wb);
-    /*
-    float* scales = Proc_state_get_voice_buffer_contents_mut(
-            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
-    if (scales == NULL)
-    {
-        scales = Work_buffers_get_buffer_contents_mut(wbs, ADD_WORK_BUFFER_FIXED_FORCE);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            scales[i] = 1;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            scales[i] = fast_dB_to_scale(scales[i]);
-    }
-    // */
 
     // Get output buffer for writing
     float* out_bufs[2] = { NULL };

--- a/src/lib/player/devices/processors/Add_state.c
+++ b/src/lib/player/devices/processors/Add_state.c
@@ -98,6 +98,14 @@ static int32_t Add_vstate_render_voice(
     const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get volume scales
+    Work_buffer* scales_wb = Proc_state_get_voice_buffer_mut(
+            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
+    const Work_buffer* dBs_wb = scales_wb;
+    if (scales_wb == NULL)
+        scales_wb = Work_buffers_get_buffer_mut(wbs, ADD_WORK_BUFFER_FIXED_FORCE);
+    Proc_fill_scale_buffer(scales_wb, dBs_wb, buf_start, buf_stop);
+    const float* scales = Work_buffer_get_contents(scales_wb);
+    /*
     float* scales = Proc_state_get_voice_buffer_contents_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
     if (scales == NULL)
@@ -111,6 +119,7 @@ static int32_t Add_vstate_render_voice(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             scales[i] = fast_dB_to_scale(scales[i]);
     }
+    // */
 
     // Get output buffer for writing
     float* out_bufs[2] = { NULL };

--- a/src/lib/player/devices/processors/Add_state.c
+++ b/src/lib/player/devices/processors/Add_state.c
@@ -89,19 +89,13 @@ static int32_t Add_vstate_render_voice(
     assert(is_p2(ADD_BASE_FUNC_SIZE));
 
     // Get frequencies
-    float* freqs = Proc_state_get_voice_buffer_contents_mut(
+    Work_buffer* freqs_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
-    if (freqs == NULL)
-    {
-        freqs = Work_buffers_get_buffer_contents_mut(wbs, ADD_WORK_BUFFER_FIXED_PITCH);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = 440;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = fast_cents_to_Hz(freqs[i]);
-    }
+    const Work_buffer* pitches_wb = freqs_wb;
+    if (freqs_wb == NULL)
+        freqs_wb = Work_buffers_get_buffer_mut(wbs, ADD_WORK_BUFFER_FIXED_PITCH);
+    Proc_fill_freq_buffer(freqs_wb, pitches_wb, buf_start, buf_stop);
+    const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get volume scales
     float* scales = Proc_state_get_voice_buffer_contents_mut(

--- a/src/lib/player/devices/processors/Envgen_state.c
+++ b/src/lib/player/devices/processors/Envgen_state.c
@@ -82,13 +82,15 @@ static int32_t Envgen_vstate_render_voice(
     Envgen_vstate* egen_state = (Envgen_vstate*)vstate;
 
     // Get pitch input
-    float* pitches = Proc_state_get_voice_buffer_contents_mut(
+    Work_buffer* pitches_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
-    if (pitches == NULL)
+    if (pitches_wb == NULL)
     {
-        pitches = Work_buffers_get_buffer_contents_mut(wbs, ENVGEN_WB_FIXED_PITCH);
+        pitches_wb = Work_buffers_get_buffer_mut(wbs, ENVGEN_WB_FIXED_PITCH);
+        float* pitches = Work_buffer_get_contents_mut(pitches_wb);
         for (int32_t i = buf_start; i < buf_stop; ++i)
             pitches[i] = 0;
+        Work_buffer_set_const_start(pitches_wb, buf_start);
     }
 
     // Get force scales
@@ -127,7 +129,7 @@ static int32_t Envgen_vstate_render_voice(
                 egen->env_scale_center,
                 0, // sustain
                 0, 1, // range, NOTE: this needs to be mapped to our [y_min, y_max]!
-                pitches,
+                pitches_wb,
                 Work_buffers_get_buffer_contents_mut(wbs, WORK_BUFFER_TIME_ENV),
                 buf_start,
                 new_buf_stop,

--- a/src/lib/player/devices/processors/Envgen_state.c
+++ b/src/lib/player/devices/processors/Envgen_state.c
@@ -218,9 +218,21 @@ static int32_t Envgen_vstate_render_voice(
         }
 
         // Convert to dB
-        const double global_adjust = egen->global_adjust;
-        for (int32_t i = buf_start; i < new_buf_stop; ++i)
-            out_buffer[i] = fast_scale_to_dB(out_buffer[i]) + global_adjust;
+        {
+            const double global_adjust = egen->global_adjust;
+
+            const int32_t fast_stop = min(const_start, new_buf_stop);
+
+            for (int32_t i = buf_start; i < fast_stop; ++i)
+                out_buffer[i] = fast_scale_to_dB(out_buffer[i]) + global_adjust;
+
+            if (fast_stop < new_buf_stop)
+            {
+                const float dB = scale_to_dB(out_buffer[fast_stop]) + global_adjust;
+                for (int32_t i = fast_stop; i < new_buf_stop; ++i)
+                    out_buffer[i] = dB;
+            }
+        }
     }
     else
     {

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -151,27 +151,6 @@ static int32_t Force_vstate_render_voice(
             }
         }
     }
-    /*
-    {
-        const double fixed_adjust = fvstate->fixed_adjust;
-        if (Slider_in_progress(&fc->slider))
-        {
-            float new_force = fc->force;
-            for (int32_t i = buf_start; i < new_buf_stop; ++i)
-            {
-                new_force = Slider_step(&fc->slider);
-                out_buf[i] = new_force + fixed_adjust;
-            }
-            fc->force = new_force;
-        }
-        else
-        {
-            const float actual_force = fc->force + fixed_adjust;
-            for (int32_t i = buf_start; i < new_buf_stop; ++i)
-                out_buf[i] = actual_force;
-        }
-    }
-    // */
 
     // Apply tremolo
     {
@@ -202,15 +181,6 @@ static int32_t Force_vstate_render_voice(
 
         const_start = max(const_start, final_lfo_stop);
     }
-    /*
-    if (LFO_active(&fc->tremolo))
-    {
-        const_start = buf_stop;
-
-        for (int32_t i = buf_start; i < new_buf_stop; ++i)
-            out_buf[i] += LFO_step(&fc->tremolo);
-    }
-    // */
 
     // Apply force envelope
     if (force->is_force_env_enabled && (force->force_env != NULL))

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -98,12 +98,12 @@ static int32_t Force_vstate_render_voice(
     // Get output
     Work_buffer* out_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_SEND, PORT_OUT_FORCE);
-    float* out_buf = Work_buffer_get_contents_mut(out_wb);
-    if (out_buf == NULL)
+    if (out_wb == NULL)
     {
         vstate->active = false;
         return buf_start;
     }
+    float* out_buf = Work_buffer_get_contents_mut(out_wb);
 
     Force_vstate* fvstate = (Force_vstate*)vstate;
     const Proc_force* force = (const Proc_force*)proc_state->parent.device->dimpl;

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -159,8 +159,8 @@ static int32_t Force_vstate_render_voice(
                 new_buf_stop,
                 proc_state->parent.audio_rate);
 
-        const Work_buffer* wb_time_env =
-            Work_buffers_get_buffer(wbs, WORK_BUFFER_TIME_ENV);
+        Work_buffer* wb_time_env =
+            Work_buffers_get_buffer_mut(wbs, WORK_BUFFER_TIME_ENV);
         float* time_env = Work_buffer_get_contents_mut(wb_time_env);
 
         // Convert envelope data to dB
@@ -224,8 +224,8 @@ static int32_t Force_vstate_render_voice(
             if (fvstate->release_env_state.is_finished)
                 new_buf_stop = env_force_rel_stop;
 
-            const Work_buffer* wb_time_env = Work_buffers_get_buffer(
-                    wbs, WORK_BUFFER_TIME_ENV);
+            Work_buffer* wb_time_env =
+                Work_buffers_get_buffer_mut(wbs, WORK_BUFFER_TIME_ENV);
             float* time_env = Work_buffer_get_contents_mut(wb_time_env);
 
             // Convert envelope data to dB

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -185,8 +185,6 @@ static int32_t Force_vstate_render_voice(
     // Apply force envelope
     if (force->is_force_env_enabled && (force->force_env != NULL))
     {
-        const_start = buf_stop; // TODO: check end of envelope
-
         const Envelope* env = force->force_env;
 
         const int32_t env_force_stop = Time_env_state_process(
@@ -202,6 +200,8 @@ static int32_t Force_vstate_render_voice(
                 buf_start,
                 new_buf_stop,
                 proc_state->parent.audio_rate);
+
+        const_start = max(const_start, env_force_stop);
 
         Work_buffer* wb_time_env =
             Work_buffers_get_buffer_mut(wbs, WORK_BUFFER_TIME_ENV);

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -86,13 +86,15 @@ static int32_t Force_vstate_render_voice(
     assert(tempo > 0);
 
     // Get pitch input
-    float* pitches = Proc_state_get_voice_buffer_contents_mut(
+    Work_buffer* pitches_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
-    if (pitches == NULL)
+    if (pitches_wb == NULL)
     {
-        pitches = Work_buffers_get_buffer_contents_mut(wbs, FORCE_WB_FIXED_PITCH);
+        pitches_wb = Work_buffers_get_buffer_mut(wbs, FORCE_WB_FIXED_PITCH);
+        float* pitches = Work_buffer_get_contents_mut(pitches_wb);
         for (int32_t i = buf_start; i < buf_stop; ++i)
             pitches[i] = 0;
+        Work_buffer_set_const_start(pitches_wb, buf_start);
     }
 
     // Get output
@@ -195,7 +197,7 @@ static int32_t Force_vstate_render_voice(
                 force->force_env_scale_center,
                 0, // sustain
                 0, 1, // range
-                pitches,
+                pitches_wb,
                 Work_buffers_get_buffer_contents_mut(wbs, WORK_BUFFER_TIME_ENV),
                 buf_start,
                 new_buf_stop,
@@ -261,7 +263,7 @@ static int32_t Force_vstate_render_voice(
                     force->force_release_env_scale_center,
                     au_state->sustain,
                     0, 1, // range
-                    pitches,
+                    pitches_wb,
                     Work_buffers_get_buffer_contents_mut(wbs, WORK_BUFFER_TIME_ENV),
                     buf_start,
                     new_buf_stop,

--- a/src/lib/player/devices/processors/Gaincomp_state.c
+++ b/src/lib/player/devices/processors/Gaincomp_state.c
@@ -28,7 +28,7 @@
 
 static void distort(
         const Proc_gaincomp* gc,
-        Work_buffer* in_buffer,
+        const Work_buffer* in_buffer,
         Work_buffer* out_buffer,
         int32_t buf_start,
         int32_t buf_stop)

--- a/src/lib/player/devices/processors/Padsynth_state.c
+++ b/src/lib/player/devices/processors/Padsynth_state.c
@@ -114,21 +114,6 @@ static int32_t Padsynth_vstate_render_voice(
         scales_wb = Work_buffers_get_buffer_mut(wbs, PADSYNTH_WB_FIXED_FORCE);
     Proc_fill_scale_buffer(scales_wb, dBs_wb, buf_start, buf_stop);
     const float* scales = Work_buffer_get_contents(scales_wb);
-    /*
-    float* scales = Proc_state_get_voice_buffer_contents_mut(
-            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
-    if (scales == NULL)
-    {
-        scales = Work_buffers_get_buffer_contents_mut(wbs, PADSYNTH_WB_FIXED_FORCE);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            scales[i] = 1;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            scales[i] = fast_dB_to_scale(scales[i]);
-    }
-    // */
 
     // Get output buffer for writing
     float* out_bufs[2] = { NULL };

--- a/src/lib/player/devices/processors/Padsynth_state.c
+++ b/src/lib/player/devices/processors/Padsynth_state.c
@@ -93,25 +93,18 @@ static int32_t Padsynth_vstate_render_voice(
     }
 
     // Get frequencies
-    float* freqs = Proc_state_get_voice_buffer_contents_mut(
+    Work_buffer* freqs_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
-    if (freqs == NULL)
-    {
-        if (isnan(ps_vstate->init_pitch))
-            ps_vstate->init_pitch = 0;
+    const Work_buffer* pitches_wb = freqs_wb;
 
-        freqs = Work_buffers_get_buffer_contents_mut(wbs, PADSYNTH_WB_FIXED_PITCH);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = 440;
-    }
-    else
-    {
-        if (isnan(ps_vstate->init_pitch))
-            ps_vstate->init_pitch = freqs[buf_start];
+    if (isnan(ps_vstate->init_pitch))
+        ps_vstate->init_pitch =
+            (pitches_wb != NULL) ? Work_buffer_get_contents(pitches_wb)[buf_start] : 0;
 
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = fast_cents_to_Hz(freqs[i]);
-    }
+    if (freqs_wb == NULL)
+        freqs_wb = Work_buffers_get_buffer_mut(wbs, PADSYNTH_WB_FIXED_PITCH);
+    Proc_fill_freq_buffer(freqs_wb, pitches_wb, buf_start, buf_stop);
+    const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get volume scales
     float* scales = Proc_state_get_voice_buffer_contents_mut(

--- a/src/lib/player/devices/processors/Padsynth_state.c
+++ b/src/lib/player/devices/processors/Padsynth_state.c
@@ -107,6 +107,14 @@ static int32_t Padsynth_vstate_render_voice(
     const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get volume scales
+    Work_buffer* scales_wb = Proc_state_get_voice_buffer_mut(
+            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
+    const Work_buffer* dBs_wb = scales_wb;
+    if (scales_wb == NULL)
+        scales_wb = Work_buffers_get_buffer_mut(wbs, PADSYNTH_WB_FIXED_FORCE);
+    Proc_fill_scale_buffer(scales_wb, dBs_wb, buf_start, buf_stop);
+    const float* scales = Work_buffer_get_contents(scales_wb);
+    /*
     float* scales = Proc_state_get_voice_buffer_contents_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
     if (scales == NULL)
@@ -120,6 +128,7 @@ static int32_t Padsynth_vstate_render_voice(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             scales[i] = fast_dB_to_scale(scales[i]);
     }
+    // */
 
     // Get output buffer for writing
     float* out_bufs[2] = { NULL };

--- a/src/lib/player/devices/processors/Pitch_state.c
+++ b/src/lib/player/devices/processors/Pitch_state.c
@@ -77,12 +77,12 @@ static int32_t Pitch_vstate_render_voice(
     // Get output
     Work_buffer* out_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_SEND, PORT_OUT_PITCH);
-    float* out_buf = Work_buffer_get_contents_mut(out_wb);
-    if (out_buf == NULL)
+    if (out_wb == NULL)
     {
         vstate->active = false;
         return buf_start;
     }
+    float* out_buf = Work_buffer_get_contents_mut(out_wb);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
 

--- a/src/lib/player/devices/processors/Pitch_state.c
+++ b/src/lib/player/devices/processors/Pitch_state.c
@@ -103,7 +103,7 @@ static int32_t Pitch_vstate_render_voice(
         int32_t cur_pos = buf_start;
         while (cur_pos < buf_stop)
         {
-            const int64_t estimated_steps =
+            const int32_t estimated_steps =
                 Slider_estimate_active_steps_left(&pc->slider);
             if (estimated_steps > 0)
             {

--- a/src/lib/player/devices/processors/Pitch_state.c
+++ b/src/lib/player/devices/processors/Pitch_state.c
@@ -131,23 +131,6 @@ static int32_t Pitch_vstate_render_voice(
             }
         }
     }
-    /*
-    if (Slider_in_progress(&pc->slider))
-    {
-        float new_pitch = pc->pitch;
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-        {
-            new_pitch = Slider_step(&pc->slider);
-            out_buf[i] = new_pitch;
-        }
-        pc->pitch = new_pitch;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            out_buf[i] = pc->pitch;
-    }
-    // */
 
     // Adjust carried pitch
     if (pc->pitch_add != 0)

--- a/src/lib/player/devices/processors/Pitch_state.c
+++ b/src/lib/player/devices/processors/Pitch_state.c
@@ -74,8 +74,9 @@ static int32_t Pitch_vstate_render_voice(
     assert(tempo > 0);
 
     // Get output
-    float* out_buf = Proc_state_get_voice_buffer_contents_mut(
+    Work_buffer* out_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_SEND, PORT_OUT_PITCH);
+    float* out_buf = Work_buffer_get_contents_mut(out_wb);
     if (out_buf == NULL)
     {
         vstate->active = false;
@@ -95,7 +96,42 @@ static int32_t Pitch_vstate_render_voice(
 
     out_buf[buf_start - 1] = pc->pitch;
 
+    int32_t const_start = buf_start;
+
     // Apply pitch slide
+    {
+        int32_t cur_pos = buf_start;
+        while (cur_pos < buf_stop)
+        {
+            const int64_t estimated_steps =
+                Slider_estimate_active_steps_left(&pc->slider);
+            if (estimated_steps > 0)
+            {
+                int32_t slide_stop = buf_stop;
+                if (estimated_steps < buf_stop - cur_pos)
+                    slide_stop = cur_pos + estimated_steps;
+
+                float new_pitch = pc->pitch;
+                for (int32_t i = cur_pos; i < slide_stop; ++i)
+                {
+                    new_pitch = Slider_step(&pc->slider);
+                    out_buf[i] = new_pitch;
+                }
+                pc->pitch = new_pitch;
+
+                const_start = slide_stop;
+                cur_pos = slide_stop;
+            }
+            else
+            {
+                for (int32_t i = cur_pos; i < buf_stop; ++i)
+                    out_buf[i] = pc->pitch;
+
+                cur_pos = buf_stop;
+            }
+        }
+    }
+    /*
     if (Slider_in_progress(&pc->slider))
     {
         float new_pitch = pc->pitch;
@@ -111,6 +147,7 @@ static int32_t Pitch_vstate_render_voice(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             out_buf[i] = pc->pitch;
     }
+    // */
 
     // Adjust carried pitch
     if (pc->pitch_add != 0)
@@ -122,6 +159,9 @@ static int32_t Pitch_vstate_render_voice(
     // Apply vibrato
     if (LFO_active(&pc->vibrato))
     {
+        // TODO: estimate end of vibrato
+        const_start = buf_stop;
+
         for (int32_t i = buf_start; i < buf_stop; ++i)
             out_buf[i] += LFO_step(&pc->vibrato);
     }
@@ -129,6 +169,8 @@ static int32_t Pitch_vstate_render_voice(
     // Apply arpeggio
     if (pvstate->is_arpeggio_enabled)
     {
+        const_start = buf_stop;
+
         const Device_state* dstate = &proc_state->parent;
         const double progress_update =
             (pvstate->arpeggio_speed / dstate->audio_rate) * (tempo / 60.0);
@@ -156,6 +198,9 @@ static int32_t Pitch_vstate_render_voice(
 
     // Update pitch for next iteration
     pvstate->pitch = out_buf[buf_stop - 1];
+
+    // Mark constant region of the buffer
+    Work_buffer_set_const_start(out_wb, const_start);
 
     return buf_stop;
 }

--- a/src/lib/player/devices/processors/Proc_state_utils.c
+++ b/src/lib/player/devices/processors/Proc_state_utils.c
@@ -274,7 +274,7 @@ void Proc_fill_scale_buffer(
         for (int32_t i = buf_start; i < fast_stop; ++i)
             scales_data[i] = fast_dB_to_scale(dBs_data[i]);
 
-        fprintf(stdout, "%d %d %d\n", (int)buf_start, (int)fast_stop, (int)buf_stop);
+        //fprintf(stdout, "%d %d %d\n", (int)buf_start, (int)fast_stop, (int)buf_stop);
 
         if (fast_stop < buf_stop)
         {

--- a/src/lib/player/devices/processors/Proc_state_utils.h
+++ b/src/lib/player/devices/processors/Proc_state_utils.h
@@ -132,6 +132,27 @@ void Proc_ramp_attack(
 
 
 /**
+ * Convert pitch values to frequencies.
+ *
+ * NOTE: This function assumes that the index range defined by \a buf_start
+ *       and \a buf_stop is the full range used in the current mixing cycle.
+ *       If that is not the case, the const start value of \a freqs may be
+ *       incorrect.
+ *
+ * \param freqs       The destination buffer -- must not be \c NULL.
+ * \param pitches     The pitch buffer -- must not be \c NULL. This buffer may
+ *                    be the same as \a freqs.
+ * \param buf_start   The start index of the buffer area to be processed.
+ * \param buf_stop    The stop index of the buffer area to be processed.
+ */
+void Proc_fill_freq_buffer(
+        Work_buffer* freqs,
+        const Work_buffer* pitches,
+        int32_t buf_start,
+        int32_t buf_stop);
+
+
+/**
  * A helper for conditional Work buffer access.
  *
  * If a voice feature is disabled, this class provides an interface to a

--- a/src/lib/player/devices/processors/Proc_state_utils.h
+++ b/src/lib/player/devices/processors/Proc_state_utils.h
@@ -135,7 +135,7 @@ void Proc_ramp_attack(
  * Convert pitch values to frequencies.
  *
  * NOTE: This function assumes that the index range defined by \a buf_start
- *       and \a buf_stop is the full range used in the current mixing cycle.
+ *       and \a buf_stop is the full range used in the current rendering cycle.
  *       If that is not the case, the const start value of \a freqs may be
  *       incorrect.
  *
@@ -148,6 +148,27 @@ void Proc_ramp_attack(
 void Proc_fill_freq_buffer(
         Work_buffer* freqs,
         const Work_buffer* pitches,
+        int32_t buf_start,
+        int32_t buf_stop);
+
+
+/**
+ * Convert decibel values to scales.
+ *
+ * NOTE: This function assumes that the index range defined by \a buf_start
+ *       and \a buf_stop is the full range used in the current rendering cycle.
+ *       If that is not the case, the const start value of \a scales may be
+ *       incorrect.
+ *
+ * \param scales      The destination buffer -- must not be \c NULL.
+ * \param dBs         The decibel buffer -- must not be \c NULL. This buffer
+ *                    may be the same as \a scales.
+ * \param buf_start   The start index of the buffer area to be processed.
+ * \param buf_stop    The stop index of the buffer area to be processed.
+ */
+void Proc_fill_scale_buffer(
+        Work_buffer* scales,
+        const Work_buffer* dBs,
         int32_t buf_start,
         int32_t buf_stop);
 

--- a/src/lib/player/devices/processors/Sample_state.c
+++ b/src/lib/player/devices/processors/Sample_state.c
@@ -102,20 +102,14 @@ static int32_t Sample_render(
         return buf_start;
     }
 
-    // Get actual pitches
-    float* freqs = Proc_state_get_voice_buffer_contents_mut(
+    // Get frequencies
+    Work_buffer* freqs_wb = Proc_state_get_voice_buffer_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
-    if (freqs == NULL)
-    {
-        freqs = Work_buffers_get_buffer_contents_mut(wbs, SAMPLE_WB_FIXED_PITCH);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = 440;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            freqs[i] = fast_cents_to_Hz(freqs[i]);
-    }
+    const Work_buffer* pitches_wb = freqs_wb;
+    if (freqs_wb == NULL)
+        freqs_wb = Work_buffers_get_buffer_mut(wbs, SAMPLE_WB_FIXED_PITCH);
+    Proc_fill_freq_buffer(freqs_wb, pitches_wb, buf_start, buf_stop);
+    const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get force input
     float* force_scales = Proc_state_get_voice_buffer_contents_mut(
@@ -436,16 +430,6 @@ static int32_t Sample_vstate_render_voice(
     if (buf_start >= buf_stop)
         return buf_start;
 
-    // Get actual pitches
-    float* pitches = Proc_state_get_voice_buffer_contents_mut(
-            proc_state, DEVICE_PORT_TYPE_RECEIVE, 0);
-    if (pitches == NULL)
-    {
-        pitches = Work_buffers_get_buffer_contents_mut(wbs, SAMPLE_WB_FIXED_PITCH);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            pitches[i] = 0;
-    }
-
     // Get volume scales
     const Cond_work_buffer* vols = Cond_work_buffer_init(
             COND_WORK_BUFFER_AUTO,
@@ -486,7 +470,14 @@ static int32_t Sample_vstate_render_voice(
             }
 
             //fprintf(stderr, "pitch @ %p: %f\n", (void*)&state->pitch, state->pitch);
-            const float start_pitch = pitches[buf_start];
+
+            // Get starting pitch
+            float start_pitch = 0;
+            const float* pitches = Proc_state_get_voice_buffer_contents(
+                    proc_state, DEVICE_PORT_TYPE_RECEIVE, 0);
+            if (pitches != NULL)
+                start_pitch = pitches[buf_start];
+
             entry = Note_map_get_entry(
                     map,
                     start_pitch,

--- a/src/lib/player/devices/processors/Sample_state.c
+++ b/src/lib/player/devices/processors/Sample_state.c
@@ -119,21 +119,6 @@ static int32_t Sample_render(
         force_scales_wb = Work_buffers_get_buffer_mut(wbs, SAMPLE_WB_FIXED_FORCE);
     Proc_fill_scale_buffer(force_scales_wb, dBs_wb, buf_start, buf_stop);
     const float* force_scales = Work_buffer_get_contents(force_scales_wb);
-    /*
-    float* force_scales = Proc_state_get_voice_buffer_contents_mut(
-            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
-    if (force_scales == NULL)
-    {
-        force_scales = Work_buffers_get_buffer_contents_mut(wbs, SAMPLE_WB_FIXED_FORCE);
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            force_scales[i] = 1;
-    }
-    else
-    {
-        for (int32_t i = buf_start; i < buf_stop; ++i)
-            force_scales[i] = fast_dB_to_scale(force_scales[i]);
-    }
-    // */
 
     float* abufs[KQT_BUFFERS_MAX] = { out_buffers[0], out_buffers[1] };
     if ((sample->channels == 1) && (out_buffers[0] == NULL))

--- a/src/lib/player/devices/processors/Sample_state.c
+++ b/src/lib/player/devices/processors/Sample_state.c
@@ -112,6 +112,14 @@ static int32_t Sample_render(
     const float* freqs = Work_buffer_get_contents(freqs_wb);
 
     // Get force input
+    Work_buffer* force_scales_wb = Proc_state_get_voice_buffer_mut(
+            proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
+    const Work_buffer* dBs_wb = force_scales_wb;
+    if (force_scales_wb == NULL)
+        force_scales_wb = Work_buffers_get_buffer_mut(wbs, SAMPLE_WB_FIXED_FORCE);
+    Proc_fill_scale_buffer(force_scales_wb, dBs_wb, buf_start, buf_stop);
+    const float* force_scales = Work_buffer_get_contents(force_scales_wb);
+    /*
     float* force_scales = Proc_state_get_voice_buffer_contents_mut(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE);
     if (force_scales == NULL)
@@ -125,6 +133,7 @@ static int32_t Sample_render(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             force_scales[i] = fast_dB_to_scale(force_scales[i]);
     }
+    // */
 
     float* abufs[KQT_BUFFERS_MAX] = { out_buffers[0], out_buffers[1] };
     if ((sample->channels == 1) && (out_buffers[0] == NULL))
@@ -433,7 +442,8 @@ static int32_t Sample_vstate_render_voice(
     // Get volume scales
     const Cond_work_buffer* vols = Cond_work_buffer_init(
             COND_WORK_BUFFER_AUTO,
-            Proc_state_get_voice_buffer(proc_state, DEVICE_PORT_TYPE_RECEIVE, 1),
+            Proc_state_get_voice_buffer(
+                proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_FORCE),
             0.0);
 
     if (sample_state->sample < 0)
@@ -474,7 +484,7 @@ static int32_t Sample_vstate_render_voice(
             // Get starting pitch
             float start_pitch = 0;
             const float* pitches = Proc_state_get_voice_buffer_contents(
-                    proc_state, DEVICE_PORT_TYPE_RECEIVE, 0);
+                    proc_state, DEVICE_PORT_TYPE_RECEIVE, PORT_IN_PITCH);
             if (pitches != NULL)
                 start_pitch = pitches[buf_start];
 

--- a/src/lib/player/devices/processors/Stream_state.c
+++ b/src/lib/player/devices/processors/Stream_state.c
@@ -36,7 +36,7 @@ enum
 
 static void apply_controls(
         Linear_controls* controls,
-        const Work_buffer* out_wb,
+        Work_buffer* out_wb,
         int32_t buf_start,
         int32_t buf_stop,
         double tempo)


### PR DESCRIPTION
This branch optimises processing of audio buffers that contain constant data, which is common for pitch data in particular. Pitch, force and stream processors mark constant (trailing) regions of their outputs, and processors that accept pitch or force input can take advantage of this information. Additionally, constant pitch is calculated accurately again, which is useful with justly tuned intervals.