### PR TITLE
Long tests

### DIFF
--- a/options.py
+++ b/options.py
@@ -18,6 +18,9 @@ enable_python_bindings = True
 # Build and run libkunquat tests.
 enable_tests = True
 
+# Build and run long libkunquat tests.
+enable_long_tests = False
+
 # Run tests with memory debugging (requires valgrind, disables assert tests).
 enable_tests_mem_debug = False
 

--- a/scripts/test_libkunquat.py
+++ b/scripts/test_libkunquat.py
@@ -38,6 +38,8 @@ def test_libkunquat(builder, options, cc):
     cc.add_lib_dir(libkunquat_dir)
     cc.add_lib('kunquat')
 
+    if options.enable_long_tests:
+        cc.add_define('KQT_LONG_TESTS')
     if options.enable_tests_mem_debug:
         cc.add_define('K_MEM_DEBUG')
 

--- a/src/test/memory.c
+++ b/src/test/memory.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2016
  *
  * This file is part of Kunquat.
  *
@@ -21,6 +21,7 @@
 #include <string.h>
 
 
+#ifdef KQT_LONG_TESTS
 START_TEST(Out_of_memory_at_handle_creation_fails_cleanly)
 {
     assert(handle == 0);
@@ -72,6 +73,7 @@ START_TEST(Out_of_memory_at_handle_creation_fails_cleanly)
     handle = 0;
 }
 END_TEST
+#endif // KQT_LONG_TESTS
 
 
 Suite* Memory_suite(void)
@@ -85,7 +87,10 @@ Suite* Memory_suite(void)
     tcase_set_timeout(tc_create, timeout);
     //tcase_add_checked_fixture(tc_create, setup_empty, handle_teardown);
 
+#ifdef KQT_LONG_TESTS
+    tcase_set_timeout(tc_create, LONG_TIMEOUT);
     tcase_add_test(tc_create, Out_of_memory_at_handle_creation_fails_cleanly);
+#endif
 
     return s;
 }

--- a/src/test/test_common.h
+++ b/src/test/test_common.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2012-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2012-2016
  *
  * This file is part of Kunquat.
  *
@@ -34,6 +34,7 @@
 
 
 #define DEFAULT_TIMEOUT 30
+#define LONG_TIMEOUT 300
 
 
 #endif // KT_TEST_COMMON_H


### PR DESCRIPTION
This branch adds a separate category for libkunquat tests that are expected to run long. These tests are disabled by default. The Kunquat handle allocation test is in this category, as its duration may be an inconvenience in slow systems.