### PR TITLE
Release and debug asserts

### DIFF
--- a/src/lib/Error.c
+++ b/src/lib/Error.c
@@ -32,16 +32,16 @@ static const char* error_codes[ERROR_COUNT_] =
 
 bool Error_is_set(const Error* error)
 {
-    assert(error != NULL);
+    rassert(error != NULL);
     return error->desc[0] != '\0';
 }
 
 
 Error_type Error_get_type(const Error* error)
 {
-    assert(error != NULL);
-    assert(Error_is_set(error));
-    assert(error->type < ERROR_COUNT_);
+    rassert(error != NULL);
+    rassert(Error_is_set(error));
+    rassert(error->type < ERROR_COUNT_);
 
     return error->type;
 }
@@ -49,16 +49,16 @@ Error_type Error_get_type(const Error* error)
 
 const char* Error_get_desc(const Error* error)
 {
-    assert(error != NULL);
+    rassert(error != NULL);
     return error->desc;
 }
 
 
 void Error_copy(Error* restrict dest, const Error* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(src != dest);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(src != dest);
 
     memcpy(dest, src, sizeof(Error));
 
@@ -75,12 +75,12 @@ void Error_set_desc(
         const char* message,
         ...)
 {
-    assert(error != NULL);
-    assert(type < ERROR_COUNT_);
-    assert(file != NULL);
-    assert(line >= 0);
-    assert(func != NULL);
-    assert(message != NULL);
+    rassert(error != NULL);
+    rassert(type < ERROR_COUNT_);
+    rassert(file != NULL);
+    rassert(line >= 0);
+    rassert(func != NULL);
+    rassert(message != NULL);
 
     va_list args;
     va_start(args, message);
@@ -100,12 +100,12 @@ void Error_set_desc_va_list(
         const char* message,
         va_list args)
 {
-    assert(error != NULL);
-    assert(type < ERROR_COUNT_);
-    assert(file != NULL);
-    assert(line >= 0);
-    assert(func != NULL);
-    assert(message != NULL);
+    rassert(error != NULL);
+    rassert(type < ERROR_COUNT_);
+    rassert(file != NULL);
+    rassert(line >= 0);
+    rassert(func != NULL);
+    rassert(message != NULL);
 
     memset(error->desc, 0, ERROR_LENGTH_MAX);
 
@@ -143,8 +143,8 @@ void Error_set_desc_va_list(
                 break;
 
             const ptrdiff_t pos = named_control - named_controls;
-            assert(pos >= 0);
-            assert(pos < (int)strlen(named_controls));
+            rassert(pos >= 0);
+            rassert(pos < (int)strlen(named_controls));
             strcpy(&error->desc[json_pos], named_replace[pos]);
             json_pos += strlen(named_replace[pos]) - 1;
         }
@@ -176,7 +176,7 @@ void Error_set_desc_va_list(
 
 void Error_clear(Error* error)
 {
-    assert(error != NULL);
+    rassert(error != NULL);
     memset(error->desc, 0, ERROR_LENGTH_MAX);
     return;
 }

--- a/src/lib/Handle.c
+++ b/src/lib/Handle.c
@@ -48,11 +48,11 @@ void Handle_deinit(Handle* handle);
 
 static kqt_Handle add_handle(Handle* handle)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
 #ifndef NDEBUG
     for (int i = 0; i < KQT_HANDLES_MAX; ++i)
-        assert(handles[i] != handle);
+        rassert(handles[i] != handle);
 #endif
 
     static int next_try = 0;
@@ -76,10 +76,10 @@ static kqt_Handle add_handle(Handle* handle)
 
 Handle* get_handle(kqt_Handle id)
 {
-    assert(kqt_Handle_is_valid(id));
+    rassert(kqt_Handle_is_valid(id));
 
     Handle* handle = handles[id - 1];
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     return handle;
 }
@@ -87,7 +87,7 @@ Handle* get_handle(kqt_Handle id)
 
 static bool remove_handle(kqt_Handle id)
 {
-    assert(kqt_Handle_is_valid(id));
+    rassert(kqt_Handle_is_valid(id));
 
     const bool was_null = (handles[id - 1] == NULL);
     handles[id - 1] = NULL;
@@ -165,7 +165,7 @@ int kqt_Handle_set_data(
 
 bool Handle_init(Handle* handle)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     handle->data_is_valid = true;
     handle->data_is_validated = true;
@@ -233,7 +233,7 @@ void kqt_Handle_clear_error(kqt_Handle handle)
 
 static bool Handle_update_connections(Handle* handle)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     Module* module = Handle_get_module(handle);
     const Connections* graph = Module_get_connections(module);
@@ -341,7 +341,7 @@ int kqt_Handle_validate(kqt_Handle handle)
     if (h->module->album_is_existent)
     {
         const Track_list* tl = h->module->track_list;
-        assert(tl != NULL);
+        rassert(tl != NULL);
 
         for (uint16_t i = 0; i < Track_list_get_len(tl); ++i)
         {
@@ -380,7 +380,7 @@ int kqt_Handle_validate(kqt_Handle handle)
                 bool instance_found = false;
 
                 const Track_list* tl = h->module->track_list;
-                assert(tl != NULL);
+                rassert(tl != NULL);
 
                 for (int track = 0; track < Track_list_get_len(tl); ++track)
                 {
@@ -390,7 +390,7 @@ int kqt_Handle_validate(kqt_Handle handle)
                         continue;
 
                     const Order_list* ol = h->module->order_lists[song_index];
-                    assert(ol != NULL);
+                    rassert(ol != NULL);
 
                     for (int system = 0; system < Order_list_get_len(ol); ++system)
                     {
@@ -544,12 +544,12 @@ void Handle_set_error_(
         const char* message,
         ...)
 {
-    assert(type < ERROR_COUNT_);
-    assert(delay_type == ERROR_IMMEDIATE || delay_type == ERROR_VALIDATION);
-    assert(file != NULL);
-    assert(line >= 0);
-    assert(func != NULL);
-    assert(message != NULL);
+    rassert(type < ERROR_COUNT_);
+    rassert(delay_type == ERROR_IMMEDIATE || delay_type == ERROR_VALIDATION);
+    rassert(file != NULL);
+    rassert(line >= 0);
+    rassert(func != NULL);
+    rassert(message != NULL);
 
     Error* error = ERROR_AUTO;
 
@@ -568,7 +568,7 @@ void Handle_set_error_(
         else if (delay_type == ERROR_VALIDATION)
             Error_copy(&handle->validation_error, error);
         else
-            assert(false);
+            rassert(false);
     }
 
     return;
@@ -577,8 +577,8 @@ void Handle_set_error_(
 
 void Handle_set_error_from_Error(Handle* handle, const Error* error)
 {
-    assert(error != NULL);
-    assert(Error_is_set(error));
+    rassert(error != NULL);
+    rassert(Error_is_set(error));
 
     Error_copy(&null_error, error);
 
@@ -591,9 +591,9 @@ void Handle_set_error_from_Error(Handle* handle, const Error* error)
 
 void Handle_set_validation_error_from_Error(Handle* handle, const Error* error)
 {
-    assert(handle != NULL);
-    assert(error != NULL);
-    assert(Error_get_type(error) == ERROR_FORMAT);
+    rassert(handle != NULL);
+    rassert(error != NULL);
+    rassert(Error_get_type(error) == ERROR_FORMAT);
 
     Error_copy(&handle->validation_error, error);
 
@@ -603,7 +603,7 @@ void Handle_set_validation_error_from_Error(Handle* handle, const Error* error)
 
 bool key_is_valid(Handle* handle, const char* key)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     if (key == NULL)
     {
@@ -677,14 +677,14 @@ bool key_is_valid(Handle* handle, const char* key)
 
 Module* Handle_get_module(Handle* handle)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
     return handle->module;
 }
 
 
 void Handle_deinit(Handle* handle)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     del_Player(handle->length_counter);
     handle->length_counter = NULL;

--- a/src/lib/Handle.c
+++ b/src/lib/Handle.c
@@ -263,7 +263,7 @@ static bool Handle_update_connections(Handle* handle)
             h->data_is_valid = false;                       \
             return 0;                                       \
         }                                                   \
-    } else (void)0
+    } else ignore(0)
 
 int kqt_Handle_validate(kqt_Handle handle)
 {

--- a/src/lib/Handle_player.c
+++ b/src/lib/Handle_player.c
@@ -285,7 +285,7 @@ int kqt_Handle_fire_event(kqt_Handle handle, int channel, const char* event)
     Streader* sr = Streader_init(STREADER_AUTO, event, (int64_t)length);
     if (!Player_fire(h->player, channel, sr))
     {
-        assert(Streader_is_error_set(sr));
+        rassert(Streader_is_error_set(sr));
         Handle_set_error(
                 h,
                 ERROR_ARGUMENT,

--- a/src/lib/Handle_private.h
+++ b/src/lib/Handle_private.h
@@ -145,7 +145,7 @@ int Handle_get_buffer_count(Handle* handle);
                     "Invalid Kunquat Handle: %d", (id)); \
             return (ret);                                \
         }                                                \
-    } else (void)0
+    } else ignore(0)
 
 #define check_handle_void(id)                            \
     if (true)                                            \
@@ -156,7 +156,7 @@ int Handle_get_buffer_count(Handle* handle);
                     "Invalid Kunquat Handle: %d", (id)); \
             return;                                      \
         }                                                \
-    } else (void)0
+    } else ignore(0)
 
 
 Handle* get_handle(kqt_Handle id);
@@ -167,14 +167,14 @@ Handle* get_handle(kqt_Handle id);
     {                                    \
         if (!handle->data_is_valid)      \
             return (ret);                \
-    } else (void)0
+    } else ignore(0)
 
 #define check_data_is_valid_void(handle) \
     if (true)                            \
     {                                    \
         if (!handle->data_is_valid)      \
             return;                      \
-    } else (void)0
+    } else ignore(0)
 
 
 #define check_data_is_validated(handle, ret)                          \
@@ -187,7 +187,7 @@ Handle* get_handle(kqt_Handle id);
                     " before calling this function)");                \
             return (ret);                                             \
         }                                                             \
-    } else (void)0
+    } else ignore(0)
 
 #define check_data_is_validated_void(handle)                          \
     if (true)                                                         \
@@ -199,7 +199,7 @@ Handle* get_handle(kqt_Handle id);
                     " before calling this function)");                \
             return;                                                   \
         }                                                             \
-    } else (void)0
+    } else ignore(0)
 
 
 bool key_is_valid(Handle* handle, const char* key);
@@ -212,7 +212,7 @@ bool key_is_valid(Handle* handle, const char* key);
         if (!key_is_valid((handle), (key))) \
             return (ret);                   \
     }                                       \
-    else (void)0
+    else ignore(0)
 
 
 /**

--- a/src/lib/Handle_private.h
+++ b/src/lib/Handle_private.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -208,7 +208,7 @@ bool key_is_valid(Handle* handle, const char* key);
 #define check_key(handle, key, ret)         \
     if (true)                               \
     {                                       \
-        assert((handle) != NULL);           \
+        rassert((handle) != NULL);          \
         if (!key_is_valid((handle), (key))) \
             return (ret);                   \
     }                                       \

--- a/src/lib/Pat_inst_ref.c
+++ b/src/lib/Pat_inst_ref.c
@@ -34,8 +34,8 @@ static bool Pat_inst_ref_is_valid(const Pat_inst_ref* p)
 
 int Pat_inst_ref_cmp(const Pat_inst_ref* p1, const Pat_inst_ref* p2)
 {
-    assert(Pat_inst_ref_is_valid(p1));
-    assert(Pat_inst_ref_is_valid(p2));
+    rassert(Pat_inst_ref_is_valid(p1));
+    rassert(Pat_inst_ref_is_valid(p2));
 
     if (p1->pat < p2->pat)
         return -1;

--- a/src/lib/Value.c
+++ b/src/lib/Value.c
@@ -26,8 +26,8 @@
 
 bool Value_type_is_realtime(Value_type type)
 {
-    assert(type >= VALUE_TYPE_NONE);
-    assert(type < VALUE_TYPE_COUNT);
+    rassert(type >= VALUE_TYPE_NONE);
+    rassert(type < VALUE_TYPE_COUNT);
 
     return (type == VALUE_TYPE_BOOL) ||
         (type == VALUE_TYPE_INT) ||
@@ -38,9 +38,9 @@ bool Value_type_is_realtime(Value_type type)
 
 Value* Value_copy(Value* restrict dest, const Value* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(dest != src);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(dest != src);
 
     memcpy(dest, src, sizeof(Value));
 
@@ -50,10 +50,10 @@ Value* Value_copy(Value* restrict dest, const Value* restrict src)
 
 bool Value_convert(Value* dest, const Value* src, Value_type new_type)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(new_type > VALUE_TYPE_NONE);
-    assert(new_type < VALUE_TYPE_COUNT);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(new_type > VALUE_TYPE_NONE);
+    rassert(new_type < VALUE_TYPE_COUNT);
 
     if (src->type == new_type)
     {
@@ -150,9 +150,9 @@ bool Value_convert(Value* dest, const Value* src, Value_type new_type)
 
 int Value_serialise(const Value* value, int len, char* str)
 {
-    assert(value != NULL);
-    assert(len > 0);
-    assert(str != NULL);
+    rassert(value != NULL);
+    rassert(len > 0);
+    rassert(str != NULL);
 
     switch (value->type)
     {
@@ -203,10 +203,10 @@ int Value_serialise(const Value* value, int len, char* str)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
-    assert(false);
+    rassert(false);
     return 0;
 }
 

--- a/src/lib/containers/AAtree.c
+++ b/src/lib/containers/AAtree.c
@@ -54,7 +54,7 @@ static void aafree(AAnode* node, void (*destroy)(void*));
 #define aavalidate(node, msg) (rassert(aavalidate_(node, msg)))
 static bool aavalidate_(const AAnode* node, const char* msg);
 #else
-#define aavalidate(node, msg) (void)0
+#define aavalidate(node, msg) ignore(0)
 #endif
 
 

--- a/src/lib/containers/AAtree.c
+++ b/src/lib/containers/AAtree.c
@@ -51,7 +51,7 @@ static AAnode* aasplit(AAnode* root);
 static void aafree(AAnode* node, void (*destroy)(void*));
 
 #ifndef NDEBUG
-#define aavalidate(node, msg) (assert(aavalidate_(node, msg)))
+#define aavalidate(node, msg) (rassert(aavalidate_(node, msg)))
 static bool aavalidate_(const AAnode* node, const char* msg);
 #else
 #define aavalidate(node, msg) (void)0
@@ -60,8 +60,8 @@ static bool aavalidate_(const AAnode* node, const char* msg);
 
 AAiter* AAiter_init(AAiter* iter, const AAtree* tree)
 {
-    assert(iter != NULL);
-    assert(tree != NULL);
+    rassert(iter != NULL);
+    rassert(tree != NULL);
 
     iter->tree = tree;
     iter->node = NULL;
@@ -72,8 +72,8 @@ AAiter* AAiter_init(AAiter* iter, const AAtree* tree)
 
 static AAnode* new_AAnode(AAnode* nil, void* data)
 {
-    assert(!(nil == NULL) || (data == NULL));
-    assert(!(data == NULL) || (nil == NULL));
+    rassert(!(nil == NULL) || (data == NULL));
+    rassert(!(data == NULL) || (nil == NULL));
 
     AAnode* node = memory_alloc_item(AAnode);
     if (node == NULL)
@@ -81,14 +81,14 @@ static AAnode* new_AAnode(AAnode* nil, void* data)
 
     if (nil == NULL)
     {
-        assert(data == NULL);
+        rassert(data == NULL);
         node->data = NULL;
         node->level = 0;
         node->parent = node->left = node->right = node;
     }
     else
     {
-        assert(data != NULL);
+        rassert(data != NULL);
         node->data = data;
         node->level = 1;
         node->parent = node->left = node->right = nil;
@@ -100,15 +100,15 @@ static AAnode* new_AAnode(AAnode* nil, void* data)
 
 void* AAnode_get_data(AAnode* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
     return node->data;
 }
 
 
 AAtree* new_AAtree(AAtree_item_cmp* cmp, AAtree_item_destroy* destroy)
 {
-    assert(cmp != NULL);
-    assert(destroy != NULL);
+    rassert(cmp != NULL);
+    rassert(destroy != NULL);
 
     AAtree* tree = memory_alloc_item(AAtree);
     if (tree == NULL)
@@ -132,8 +132,8 @@ AAtree* new_AAtree(AAtree_item_cmp* cmp, AAtree_item_destroy* destroy)
 
 bool AAtree_contains(const AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
+    rassert(tree != NULL);
+    rassert(key != NULL);
 
     return (AAtree_get_exact(tree, key) != NULL);
 }
@@ -141,9 +141,9 @@ bool AAtree_contains(const AAtree* tree, const void* key)
 
 bool AAtree_ins(AAtree* tree, void* data)
 {
-    assert(tree != NULL);
-    assert(data != NULL);
-    assert(!AAtree_contains(tree, data));
+    rassert(tree != NULL);
+    rassert(data != NULL);
+    rassert(!AAtree_contains(tree, data));
 
     AAnode* node = new_AAnode(tree->nil, data);
     if (node == NULL)
@@ -157,9 +157,9 @@ bool AAtree_ins(AAtree* tree, void* data)
 
 void AAtree_attach(AAtree* tree, AAnode* node)
 {
-    assert(tree != NULL);
-    assert(node != NULL);
-    assert(node->data != NULL);
+    rassert(tree != NULL);
+    rassert(node != NULL);
+    rassert(node->data != NULL);
 
     // Make the node ours
     node->parent = node->left = node->right = tree->nil;
@@ -175,11 +175,11 @@ void AAtree_attach(AAtree* tree, AAnode* node)
 
     AAnode* cur = tree->root;
     AAnode* prev = NULL;
-    assert(cur->data != NULL);
+    rassert(cur->data != NULL);
     int diff = 1;
     while (cur->level > 0 && diff != 0)
     {
-        assert(cur->data != NULL);
+        rassert(cur->data != NULL);
         diff = tree->cmp(node->data, cur->data);
         prev = cur;
 
@@ -189,14 +189,14 @@ void AAtree_attach(AAtree* tree, AAnode* node)
             cur = cur->right;
     }
 
-    assert(prev != NULL);
+    rassert(prev != NULL);
 
-    assert(diff != 0);
+    rassert(diff != 0);
 #if 0
     if (diff == 0)
     {
-        assert(cur != NULL);
-        assert(cur->data != NULL);
+        rassert(cur != NULL);
+        rassert(cur->data != NULL);
         tree->destroy(cur->data);
         cur->data = data;
         aavalidate(tree->root, "insert");
@@ -207,14 +207,14 @@ void AAtree_attach(AAtree* tree, AAnode* node)
     // Attach the new node
     if (diff < 0)
     {
-        assert(prev->left->level == 0);
+        rassert(prev->left->level == 0);
         prev->left = node;
         node->parent = prev;
     }
     else
     {
-        assert(diff > 0);
-        assert(prev->right->level == 0);
+        rassert(diff > 0);
+        rassert(prev->right->level == 0);
         prev->right = node;
         node->parent = prev;
     }
@@ -231,11 +231,11 @@ void AAtree_attach(AAtree* tree, AAnode* node)
             child = &parent->right;
         else
         {
-            assert(parent->level == 0);
+            rassert(parent->level == 0);
             child = &tree->root;
         }
 
-        assert(child != NULL);
+        rassert(child != NULL);
         cur = aaskew(cur);
         cur = aasplit(cur);
         aavalidate(cur, "balance");
@@ -250,9 +250,9 @@ void AAtree_attach(AAtree* tree, AAnode* node)
 
 void* AAiter_get_at_least(AAiter* iter, const void* key)
 {
-    assert(iter != NULL);
-    assert(key != NULL);
-    assert(iter->tree != NULL);
+    rassert(iter != NULL);
+    rassert(key != NULL);
+    rassert(iter->tree != NULL);
 
     const AAtree* tree = iter->tree;
     aavalidate(tree->root, "get");
@@ -263,7 +263,7 @@ void* AAiter_get_at_least(AAiter* iter, const void* key)
 
     while (cur->level > 0)
     {
-        assert(cur->data != NULL);
+        rassert(cur->data != NULL);
         int diff = tree->cmp(key, cur->data);
         if (diff < 0)
         {
@@ -288,8 +288,8 @@ void* AAiter_get_at_least(AAiter* iter, const void* key)
 
 void* AAtree_get_at_least(const AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
+    rassert(tree != NULL);
+    rassert(key != NULL);
 
     AAiter* iter = AAITER_AUTO;
     iter->tree = tree;
@@ -300,8 +300,8 @@ void* AAtree_get_at_least(const AAtree* tree, const void* key)
 
 void* AAtree_get_exact(const AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
+    rassert(tree != NULL);
+    rassert(key != NULL);
 
     AAiter* iter = AAITER_AUTO;
     iter->tree = tree;
@@ -315,9 +315,9 @@ void* AAtree_get_exact(const AAtree* tree, const void* key)
 
 void* AAiter_get_at_most(AAiter* iter, const void* key)
 {
-    assert(iter != NULL);
-    assert(key != NULL);
-    assert(iter->tree != NULL);
+    rassert(iter != NULL);
+    rassert(key != NULL);
+    rassert(iter->tree != NULL);
 
     const AAtree* tree = iter->tree;
     aavalidate(tree->root, "get");
@@ -328,7 +328,7 @@ void* AAiter_get_at_most(AAiter* iter, const void* key)
 
     while (cur->level > 0)
     {
-        assert(cur->data != NULL);
+        rassert(cur->data != NULL);
         int diff = tree->cmp(key, cur->data);
         if (diff < 0)
         {
@@ -353,8 +353,8 @@ void* AAiter_get_at_most(AAiter* iter, const void* key)
 
 void* AAtree_get_at_most(const AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
+    rassert(tree != NULL);
+    rassert(key != NULL);
 
     AAiter* iter = AAITER_AUTO;
     iter->tree = tree;
@@ -365,8 +365,8 @@ void* AAtree_get_at_most(const AAtree* tree, const void* key)
 
 void* AAiter_get_next(AAiter* iter)
 {
-    assert(iter != NULL);
-    assert(iter->tree != NULL);
+    rassert(iter != NULL);
+    rassert(iter->tree != NULL);
 
     if (iter->node == NULL)
         return NULL;
@@ -385,8 +385,8 @@ void* AAiter_get_next(AAiter* iter)
 
 void* AAiter_get_prev(AAiter* iter)
 {
-    assert(iter != NULL);
-    assert(iter->tree != NULL);
+    rassert(iter != NULL);
+    rassert(iter->tree != NULL);
 
     if (iter->node == NULL)
         return NULL;
@@ -405,9 +405,9 @@ void* AAiter_get_prev(AAiter* iter)
 
 AAnode* AAtree_detach(AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
-    assert(tree->root->parent == tree->nil);
+    rassert(tree != NULL);
+    rassert(key != NULL);
+    rassert(tree->root->parent == tree->nil);
 
     if (tree->root->level == 0)
         return NULL;
@@ -423,7 +423,7 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
             cur = cur->right;
     }
 
-    assert(cur != NULL);
+    rassert(cur != NULL);
     if (cur->level == 0)
         return NULL;
 
@@ -433,17 +433,17 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
 
     if (cur->left->level != 0 && cur->right->level != 0)
     {
-        assert(cur->left->level > 0);
-        assert(cur->right->level > 0);
+        rassert(cur->left->level > 0);
+        rassert(cur->right->level > 0);
         AAnode* pred = aapred(cur);
-        assert(pred != NULL);
-        assert(pred->right->level == 0);
+        rassert(pred != NULL);
+        rassert(pred->right->level == 0);
         cur->data = pred->data;
         pred->data = NULL;
         cur = pred;
     }
 
-    assert(cur->left->level == 0 || cur->right->level == 0);
+    rassert(cur->left->level == 0 || cur->right->level == 0);
     AAnode** child = NULL;
     AAnode* parent = cur->parent;
     if (cur == cur->parent->left)
@@ -456,15 +456,15 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
     }
     else
     {
-        assert(cur == tree->root);
+        rassert(cur == tree->root);
         child = &tree->root;
         parent = tree->nil;
     }
 
-    assert(child != NULL);
+    rassert(child != NULL);
     if (cur->left->level > 0)
     {
-        assert(cur->right->level == 0);
+        rassert(cur->right->level == 0);
         *child = cur->left;
         cur->left->parent = parent;
     }
@@ -494,7 +494,7 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
             child = &parent->right;
         else
         {
-            assert(parent->level == 0);
+            rassert(parent->level == 0);
             child = &tree->root;
         }
 
@@ -505,7 +505,7 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
             if (cur->right->level > cur->level)
                 cur->right->level = cur->level;
 
-            assert(child != NULL);
+            rassert(child != NULL);
             cur = aaskew(cur);
             cur = aasplit(cur);
             *child = cur;
@@ -522,9 +522,9 @@ AAnode* AAtree_detach(AAtree* tree, const void* key)
 
 void* AAtree_remove(AAtree* tree, const void* key)
 {
-    assert(tree != NULL);
-    assert(key != NULL);
-    assert(tree->root->parent == tree->nil);
+    rassert(tree != NULL);
+    rassert(key != NULL);
+    rassert(tree->root->parent == tree->nil);
 
     AAnode* node = AAtree_detach(tree, key);
     if (node == NULL)
@@ -539,7 +539,7 @@ void* AAtree_remove(AAtree* tree, const void* key)
 
 void AAtree_clear(AAtree* tree)
 {
-    assert(tree != NULL);
+    rassert(tree != NULL);
     aavalidate(tree->root, "clear");
 
     if (tree->root != tree->nil)
@@ -568,8 +568,8 @@ void del_AAtree(AAtree* tree)
 
 static AAnode* aapred(AAnode* node)
 {
-    assert(node != NULL);
-    assert(node->level > 0);
+    rassert(node != NULL);
+    rassert(node->level > 0);
 
     if (node->left->level > 0)
     {
@@ -595,7 +595,7 @@ static AAnode* aapred(AAnode* node)
 
 static AAnode* aasucc(AAnode* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
 
     if (node->level == 0)
         return node;
@@ -623,7 +623,7 @@ static AAnode* aasucc(AAnode* node)
 
 static AAnode* aaskew(AAnode* root)
 {
-    assert(root != NULL);
+    rassert(root != NULL);
 
     if (root->level == 0)
         return root;
@@ -647,7 +647,7 @@ static AAnode* aaskew(AAnode* root)
 
 static AAnode* aasplit(AAnode* root)
 {
-    assert(root != NULL);
+    rassert(root != NULL);
 
     if (root->level == 0)
         return root;
@@ -671,8 +671,8 @@ static AAnode* aasplit(AAnode* root)
 
 static void aafree(AAnode* node, void (*destroy)(void*))
 {
-    assert(node != NULL);
-    assert(destroy != NULL);
+    rassert(node != NULL);
+    rassert(destroy != NULL);
 
     if (node->level == 0)
         return;

--- a/src/lib/containers/Bit_array.c
+++ b/src/lib/containers/Bit_array.c
@@ -43,7 +43,7 @@ static int64_t bit_offset(int64_t bit_index)
 
 Bit_array* new_Bit_array(int64_t size)
 {
-    assert(size > 0);
+    rassert(size > 0);
 
     Bit_array* ba = memory_alloc_item(Bit_array);
     if (ba == NULL)
@@ -64,7 +64,7 @@ Bit_array* new_Bit_array(int64_t size)
 
 void Bit_array_clear(Bit_array* ba)
 {
-    assert(ba != NULL);
+    rassert(ba != NULL);
 
     memset(ba->bits, 0, (size_t)byte_index(ba->size));
 
@@ -74,11 +74,11 @@ void Bit_array_clear(Bit_array* ba)
 
 void Bit_array_set(Bit_array* ba, int64_t index, bool value)
 {
-    assert(ba != NULL);
-    assert(index < ba->size);
+    rassert(ba != NULL);
+    rassert(index < ba->size);
 
     const uint8_t mask = (uint8_t)(1 << bit_offset(index));
-    assert(mask != 0);
+    rassert(mask != 0);
 
     if (value)
         ba->bits[byte_index(index)] |= mask;
@@ -91,11 +91,11 @@ void Bit_array_set(Bit_array* ba, int64_t index, bool value)
 
 bool Bit_array_get(const Bit_array* ba, int64_t index)
 {
-    assert(ba != NULL);
-    assert(index < ba->size);
+    rassert(ba != NULL);
+    rassert(index < ba->size);
 
     const uint8_t mask = (uint8_t)(1 << bit_offset(index));
-    assert(mask != 0);
+    rassert(mask != 0);
 
     return (ba->bits[byte_index(index)] & mask) != 0;
 }

--- a/src/lib/containers/Etable.c
+++ b/src/lib/containers/Etable.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -31,7 +31,7 @@ struct Etable
 
 Etable* new_Etable(int size, void (*destroy)(void*))
 {
-    assert(size > 0);
+    rassert(size > 0);
 
     Etable* table = memory_alloc_item(Etable);
     if (table == NULL)
@@ -60,14 +60,14 @@ Etable* new_Etable(int size, void (*destroy)(void*))
 
 bool Etable_set(Etable* table, int index, void* el)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
-    assert(el != NULL);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
+    rassert(el != NULL);
 
 #ifndef NDEBUG
     for (int i = 0; i < table->res; ++i)
-        assert(table->els[i] != el);
+        rassert(table->els[i] != el);
 #endif
 
     if (index >= table->res)
@@ -98,9 +98,9 @@ bool Etable_set(Etable* table, int index, void* el)
 
 void* Etable_get(Etable* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     if (index >= table->res)
         return NULL;
@@ -111,9 +111,9 @@ void* Etable_get(Etable* table, int index)
 
 void Etable_remove(Etable* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     if (index >= table->res || table->els[index] == NULL)
         return;
@@ -127,7 +127,7 @@ void Etable_remove(Etable* table, int index)
 
 void Etable_clear(Etable* table)
 {
-    assert(table != NULL);
+    rassert(table != NULL);
 
     for (int i = 0; i < table->res; ++i)
     {

--- a/src/lib/containers/Vector.c
+++ b/src/lib/containers/Vector.c
@@ -37,7 +37,7 @@ static bool Vector_set_capacity(Vector* v, int64_t cap);
 
 Vector* new_Vector(int64_t elem_size)
 {
-    assert(elem_size > 0);
+    rassert(elem_size > 0);
 
     Vector* v = memory_alloc_item(Vector);
     if (v == NULL)
@@ -59,16 +59,16 @@ Vector* new_Vector(int64_t elem_size)
 
 int64_t Vector_size(const Vector* v)
 {
-    assert(v != NULL);
+    rassert(v != NULL);
     return v->size;
 }
 
 
 void Vector_get(const Vector* v, int64_t index, void* dest)
 {
-    assert(v != NULL);
-    assert(index < v->size);
-    assert(dest != NULL);
+    rassert(v != NULL);
+    rassert(index < v->size);
+    rassert(dest != NULL);
 
     memcpy(dest, v->elems + (v->elem_size * index), (size_t)v->elem_size);
 
@@ -78,8 +78,8 @@ void Vector_get(const Vector* v, int64_t index, void* dest)
 
 void* Vector_get_ref(const Vector* v, int64_t index)
 {
-    assert(v != NULL);
-    assert(index < v->size);
+    rassert(v != NULL);
+    rassert(index < v->size);
 
     return v->elems + (v->elem_size * index);
 }
@@ -87,12 +87,12 @@ void* Vector_get_ref(const Vector* v, int64_t index)
 
 bool Vector_append(Vector* v, const void* elem)
 {
-    assert(v != NULL);
-    assert(elem != NULL);
+    rassert(v != NULL);
+    rassert(elem != NULL);
 
     if (v->size >= v->cap)
     {
-        assert(v->size == v->cap);
+        rassert(v->size == v->cap);
         if (!Vector_set_capacity(v, v->cap * 2))
             return false;
     }
@@ -106,8 +106,8 @@ bool Vector_append(Vector* v, const void* elem)
 
 static bool Vector_set_capacity(Vector* v, int64_t cap)
 {
-    assert(v != NULL);
-    assert(cap > 0);
+    rassert(v != NULL);
+    rassert(cap > 0);
 
     if (cap == v->cap)
         return true;

--- a/src/lib/debug/assert.c
+++ b/src/lib/debug/assert.c
@@ -29,8 +29,6 @@ void assert_suppress_messages(void)
 }
 
 
-#ifndef NDEBUG
-
 #if defined(HAS_EXECINFO) && !defined(SILENT_ASSERT)
 
 #include <execinfo.h>
@@ -95,7 +93,5 @@ void assert_print_msg(
 }
 
 #endif // SILENT_ASSERT
-
-#endif // NDEBUG
 
 

--- a/src/lib/debug/assert.h
+++ b/src/lib/debug/assert.h
@@ -39,12 +39,7 @@ void assert_suppress_messages(void);
 #endif
 
 
-/**
- * This is an internal implementation of assert.
- */
-
-
-#if !defined(NDEBUG) && defined(HAS_EXECINFO) && !defined(SILENT_ASSERT)
+#if defined(HAS_EXECINFO) && !defined(SILENT_ASSERT)
 /**
  * Print a backtrace of the execution.
  */
@@ -57,7 +52,7 @@ void assert_print_backtrace(void);
 #endif // !HAS_EXECINFO || SILENT_ASSERT
 
 
-#if !defined(NDEBUG) && !defined(SILENT_ASSERT)
+#ifndef SILENT_ASSERT
 /**
  * Print a message of failed assertion.
  *
@@ -79,9 +74,8 @@ void assert_print_msg(
 #endif // SILENT_ASSERT
 
 
-#ifndef NDEBUG
-
-#define assert(expr)                                               \
+// Release assert that is always compiled and should be used in most cases.
+#define rassert(expr)                                              \
     (                                                              \
         (expr) ?                                                   \
             ignore(0)                                              \
@@ -93,11 +87,13 @@ void assert_print_msg(
         )                                                          \
     )
 
-#else // NDEBUG
 
-#define assert(expr) ignore(expr)
-
-#endif // NDEBUG
+// Debug assert that should only be used in performance-critical code.
+#ifndef NDEBUG
+#define dassert(expr) rassert(expr)
+#else
+#define dassert(expr) ignore(expr)
+#endif
 
 
 #endif // KQT_ASSERT_H

--- a/src/lib/debug/assert.h
+++ b/src/lib/debug/assert.h
@@ -90,7 +90,7 @@ void assert_print_msg(
 
 // Debug assert that should only be used in performance-critical code.
 #ifndef NDEBUG
-#define dassert(expr) rassert(expr)
+#define dassert rassert
 #else
 #define dassert(expr) ignore(expr)
 #endif

--- a/src/lib/events.c
+++ b/src/lib/events.c
@@ -90,7 +90,7 @@ const char* kqt_get_event_arg_type(const char* event_name)
                     return "realtime";
 
                 default:
-                    assert(false);
+                    rassert(false);
             }
         }
     }

--- a/src/lib/expr.c
+++ b/src/lib/expr.c
@@ -159,9 +159,9 @@ static Func_desc funcs[] =
 bool evaluate_expr(
         Streader* sr, Env_state* estate, const Value* meta, Value* res, Random* rand)
 {
-    assert(sr != NULL);
-    assert(res != NULL);
-    assert(rand != NULL);
+    rassert(sr != NULL);
+    rassert(res != NULL);
+    rassert(rand != NULL);
 
     if (!Streader_match_char(sr, '"'))
         return false;
@@ -191,7 +191,7 @@ bool evaluate_expr(
     {                                                 \
         if ((si) >= STACK_SIZE)                       \
         {                                             \
-            assert((si) == STACK_SIZE);               \
+            rassert((si) == STACK_SIZE);              \
             Streader_set_error(sr, "Stack overflow"); \
             return false;                             \
         }                                             \
@@ -210,17 +210,17 @@ static bool evaluate_expr_(
         bool func_arg,
         Random* rand)
 {
-    assert(sr != NULL);
-    assert(val_stack != NULL);
-    assert(vsi >= 0);
-    assert(vsi <= STACK_SIZE);
-    assert(op_stack != NULL);
-    assert(osi >= 0);
-    assert(osi <= STACK_SIZE);
-    assert(meta != NULL);
-    assert(res != NULL);
-    assert(depth >= 0);
-    assert(rand != NULL);
+    rassert(sr != NULL);
+    rassert(val_stack != NULL);
+    rassert(vsi >= 0);
+    rassert(vsi <= STACK_SIZE);
+    rassert(op_stack != NULL);
+    rassert(osi >= 0);
+    rassert(osi <= STACK_SIZE);
+    rassert(meta != NULL);
+    rassert(res != NULL);
+    rassert(depth >= 0);
+    rassert(rand != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -263,7 +263,7 @@ static bool evaluate_expr_(
                         false, rand))
                 return false;
 
-            assert(operand->type != VALUE_TYPE_NONE);
+            rassert(operand->type != VALUE_TYPE_NONE);
             if (!handle_unary(operand, found_not, found_minus, sr))
                 return false;
 
@@ -281,7 +281,7 @@ static bool evaluate_expr_(
             }
 
             check_stack(vsi);
-            assert(func != NULL);
+            rassert(func != NULL);
             Value func_args[FUNC_ARGS_MAX] = { { .type = VALUE_TYPE_NONE } };
             if (!Streader_match_char(sr, '('))
                 return false;
@@ -297,7 +297,7 @@ static bool evaluate_expr_(
                                 true, rand))
                         return false;
 
-                    assert(func_args[i].type != VALUE_TYPE_NONE);
+                    rassert(func_args[i].type != VALUE_TYPE_NONE);
                     if (Streader_try_match_char(sr, ')'))
                     {
                         ++i;
@@ -314,11 +314,11 @@ static bool evaluate_expr_(
 
             if (!func(func_args, operand, rand, sr))
             {
-                assert(Streader_is_error_set(sr));
+                rassert(Streader_is_error_set(sr));
                 return false;
             }
 
-            assert(operand->type != VALUE_TYPE_NONE);
+            rassert(operand->type != VALUE_TYPE_NONE);
             found_not = found_minus = false;
             memcpy(&val_stack[vsi], operand, sizeof(Value));
             ++vsi;
@@ -332,7 +332,7 @@ static bool evaluate_expr_(
                 return false;
             }
 
-            assert(operand->type != VALUE_TYPE_NONE);
+            rassert(operand->type != VALUE_TYPE_NONE);
             if (!handle_unary(operand, found_not, found_minus, sr))
                 return false;
 
@@ -345,7 +345,7 @@ static bool evaluate_expr_(
         }
         else if (Operator_from_token(op, token))
         {
-            assert(op->name != NULL);
+            rassert(op->name != NULL);
             if (expect_operand)
             {
                 if (string_eq(op->name, "!"))
@@ -375,8 +375,8 @@ static bool evaluate_expr_(
             while (osi > orig_osi && op->preced <= op_stack[osi - 1].preced)
             {
                 Operator* top = &op_stack[osi - 1];
-                assert(top->name != NULL);
-                assert(top->func != NULL);
+                rassert(top->name != NULL);
+                rassert(top->func != NULL);
 
                 if (vsi < 2)
                 {
@@ -391,12 +391,12 @@ static bool evaluate_expr_(
                             result,
                             sr))
                 {
-                    assert(Streader_is_error_set(sr));
+                    rassert(Streader_is_error_set(sr));
                     return false;
                 }
 
                 //Operator_print(top);
-                assert(result->type != VALUE_TYPE_NONE);
+                rassert(result->type != VALUE_TYPE_NONE);
                 val_stack[vsi - 2].type = VALUE_TYPE_NONE;
                 val_stack[vsi - 1].type = VALUE_TYPE_NONE;
                 --vsi;
@@ -422,11 +422,11 @@ static bool evaluate_expr_(
     if (Streader_is_error_set(sr))
         return false;
 
-    assert(string_eq(token, "") || string_eq(token, ")") ||
+    rassert(string_eq(token, "") || string_eq(token, ")") ||
             (func_arg && string_eq(token, ",")));
     if (vsi <= orig_vsi)
     {
-        assert(vsi == orig_vsi);
+        rassert(vsi == orig_vsi);
         Streader_set_error(sr, "Empty expression");
         return false;
     }
@@ -443,8 +443,8 @@ static bool evaluate_expr_(
     while (osi > orig_osi)
     {
         Operator* top = &op_stack[osi - 1];
-        assert(top->name != NULL);
-        assert(top->func != NULL);
+        rassert(top->name != NULL);
+        rassert(top->func != NULL);
 
         if (vsi < 2)
         {
@@ -456,12 +456,12 @@ static bool evaluate_expr_(
         if (!top->func(&val_stack[vsi - 2], &val_stack[vsi - 1],
                        result, sr))
         {
-            assert(Streader_is_error_set(sr));
+            rassert(Streader_is_error_set(sr));
             return false;
         }
 
         //Operator_print(top);
-        assert(result->type != VALUE_TYPE_NONE);
+        rassert(result->type != VALUE_TYPE_NONE);
         val_stack[vsi - 2].type = val_stack[vsi - 1].type = VALUE_TYPE_NONE;
         --vsi;
         memcpy(&val_stack[vsi - 1], result, sizeof(Value));
@@ -469,9 +469,9 @@ static bool evaluate_expr_(
         --osi;
     }
 
-    assert(vsi > orig_vsi);
+    rassert(vsi > orig_vsi);
     memcpy(res, &val_stack[vsi - 1], sizeof(Value));
-    assert(res->type != VALUE_TYPE_NONE);
+    rassert(res->type != VALUE_TYPE_NONE);
 
     if (func_arg)
         sr->pos = prev_pos;
@@ -484,8 +484,8 @@ static bool evaluate_expr_(
 
 static bool token_is_func(const char* token, Func* res)
 {
-    assert(token != NULL);
-    assert(res != NULL);
+    rassert(token != NULL);
+    rassert(res != NULL);
 
     for (int i = 0; funcs[i].name != NULL; ++i)
     {
@@ -502,9 +502,9 @@ static bool token_is_func(const char* token, Func* res)
 
 static bool handle_unary(Value* val, bool found_not, bool found_minus, Streader* sr)
 {
-    assert(val != NULL);
-    assert(!(found_not && found_minus));
-    assert(sr != NULL);
+    rassert(val != NULL);
+    rassert(!(found_not && found_minus));
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -524,7 +524,7 @@ static bool handle_unary(Value* val, bool found_not, bool found_minus, Streader*
         return true;
     }
 
-    assert(found_minus);
+    rassert(found_minus);
     switch (val->type)
     {
         case VALUE_TYPE_INT:
@@ -560,9 +560,9 @@ static bool handle_unary(Value* val, bool found_not, bool found_minus, Streader*
 static bool Value_from_token(
         Value* val, char* token, Env_state* estate, const Value* meta)
 {
-    assert(val != NULL);
-    assert(token != NULL);
-    assert(meta != NULL);
+    rassert(val != NULL);
+    rassert(token != NULL);
+    rassert(meta != NULL);
 
     if (isdigit(token[0]) || token[0] == '.')
     {
@@ -631,7 +631,7 @@ static bool Value_from_token(
         if (ev == NULL)
             return false;
 
-        assert(Env_var_get_type(ev) == VALUE_TYPE_BOOL ||
+        rassert(Env_var_get_type(ev) == VALUE_TYPE_BOOL ||
                 Env_var_get_type(ev) == VALUE_TYPE_INT ||
                 Env_var_get_type(ev) == VALUE_TYPE_FLOAT ||
                 Env_var_get_type(ev) == VALUE_TYPE_TSTAMP);
@@ -648,7 +648,7 @@ static bool Value_from_token(
 #if 0
 static void Value_print(Value* val)
 {
-    assert(val != NULL);
+    rassert(val != NULL);
 
     switch (val->type)
     {
@@ -665,7 +665,7 @@ static void Value_print(Value* val)
             fprintf(stderr, "%f", val->value.float_type);
         } break;
         default:
-            assert(false);
+            rassert(false);
     }
 
     fprintf(stderr, " ");
@@ -677,8 +677,8 @@ static void Value_print(Value* val)
 
 static bool Operator_from_token(Operator* op, char* token)
 {
-    assert(op != NULL);
-    assert(token != NULL);
+    rassert(op != NULL);
+    rassert(token != NULL);
 
     for (int i = 0; operators[i].name != NULL; ++i)
     {
@@ -696,8 +696,8 @@ static bool Operator_from_token(Operator* op, char* token)
 #if 0
 static void Operator_print(Operator* op)
 {
-    assert(op != NULL);
-    assert(op->name != NULL);
+    rassert(op != NULL);
+    rassert(op->name != NULL);
     fprintf(stderr, "%s ", op->name);
     return;
 }
@@ -706,8 +706,8 @@ static void Operator_print(Operator* op)
 
 static bool get_token(Streader* sr, char* result)
 {
-    assert(sr != NULL);
-    assert(result != NULL);
+    rassert(sr != NULL);
+    rassert(result != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -753,8 +753,8 @@ static bool get_token(Streader* sr, char* result)
 
 static bool get_num_token(Streader* sr, char* result)
 {
-    assert(sr != NULL);
-    assert(result != NULL);
+    rassert(sr != NULL);
+    rassert(result != NULL);
 
     const int64_t start_pos = sr->pos;
 
@@ -762,7 +762,7 @@ static bool get_num_token(Streader* sr, char* result)
         return false;
 
     const int64_t end_pos = sr->pos;
-    assert(end_pos >= start_pos);
+    rassert(end_pos >= start_pos);
 
     const int64_t len = end_pos - start_pos;
     if (len >= KQT_VAR_NAME_MAX - 1)
@@ -780,8 +780,8 @@ static bool get_num_token(Streader* sr, char* result)
 
 static bool get_str_token(Streader* sr, char* result)
 {
-    assert(sr != NULL);
-    assert(result != NULL);
+    rassert(sr != NULL);
+    rassert(result != NULL);
 
     // FIXME: ugly haxoring with Streader internals
     const char* str = &sr->str[sr->pos];
@@ -815,8 +815,8 @@ static bool get_str_token(Streader* sr, char* result)
 
 static bool get_var_token(Streader* sr, char* result)
 {
-    assert(sr != NULL);
-    assert(result != NULL);
+    rassert(sr != NULL);
+    rassert(result != NULL);
 
     // FIXME: ugly haxoring with Streader internals
     const char* str = &sr->str[sr->pos];
@@ -839,8 +839,8 @@ static bool get_var_token(Streader* sr, char* result)
 
 static bool get_op_token(Streader* sr, char* result)
 {
-    assert(sr != NULL);
-    assert(result != NULL);
+    rassert(sr != NULL);
+    rassert(result != NULL);
 
     static const char op_chars[] = "!=<>+-*/%^|&";
 
@@ -866,11 +866,11 @@ static bool get_op_token(Streader* sr, char* result)
 static bool promote_arithmetic_types(
         Value* pr_op1, Value* pr_op2, const Value* op1, const Value* op2, Streader* sr)
 {
-    assert(pr_op1 != NULL);
-    assert(pr_op2 != NULL);
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(sr != NULL);
+    rassert(pr_op1 != NULL);
+    rassert(pr_op2 != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -918,7 +918,7 @@ static bool promote_arithmetic_types(
         return false;
     }
 
-    assert(pr_op1->type == pr_op2->type);
+    rassert(pr_op1->type == pr_op2->type);
 
     return true;
 }
@@ -926,12 +926,12 @@ static bool promote_arithmetic_types(
 
 static bool op_eq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
-    assert(op1->type > VALUE_TYPE_NONE);
-    assert(op2->type > VALUE_TYPE_NONE);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
+    rassert(op1->type > VALUE_TYPE_NONE);
+    rassert(op2->type > VALUE_TYPE_NONE);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1000,7 +1000,7 @@ static bool op_eq(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1009,14 +1009,14 @@ static bool op_eq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_neq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (op_eq(op1, op2, res, sr))
     {
-        assert(res->type == VALUE_TYPE_BOOL);
+        rassert(res->type == VALUE_TYPE_BOOL);
         res->value.bool_type = !res->value.bool_type;
         return true;
     }
@@ -1027,10 +1027,10 @@ static bool op_neq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_leq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (!op_lt(op1, op2, res, sr))
         return false;
@@ -1044,10 +1044,10 @@ static bool op_leq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_geq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     return op_leq(op2, op1, res, sr);
 }
@@ -1055,10 +1055,10 @@ static bool op_geq(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_or(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1078,10 +1078,10 @@ static bool op_or(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_and(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1101,10 +1101,10 @@ static bool op_and(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_lt(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1146,7 +1146,7 @@ static bool op_lt(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1155,10 +1155,10 @@ static bool op_lt(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_gt(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     return op_lt(op2, op1, res, sr);
 }
@@ -1166,10 +1166,10 @@ static bool op_gt(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_add(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1206,7 +1206,7 @@ static bool op_add(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1215,10 +1215,10 @@ static bool op_add(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_sub(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1248,7 +1248,7 @@ static bool op_sub(const Value* op1, const Value* op2, Value* res, Streader* sr)
     }
     else
     {
-        assert(false);
+        rassert(false);
     }
 
     return op_add(op1, neg_op2, res, sr);
@@ -1257,10 +1257,10 @@ static bool op_sub(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_mul(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1298,7 +1298,7 @@ static bool op_mul(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1307,10 +1307,10 @@ static bool op_mul(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_div(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1376,7 +1376,7 @@ static bool op_div(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1385,10 +1385,10 @@ static bool op_div(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool op_mod(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1453,7 +1453,7 @@ static bool op_mod(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1462,13 +1462,13 @@ static bool op_mod(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool float_pow(const Value* pr_op1, const Value* pr_op2, Value* res, Streader* sr)
 {
-    assert(pr_op1 != NULL);
-    assert(pr_op1->type == VALUE_TYPE_FLOAT);
-    assert(pr_op2 != NULL);
-    assert(pr_op2->type == VALUE_TYPE_FLOAT);
-    assert(res != NULL);
-    assert(sr != NULL);
-    assert(!Streader_is_error_set(sr));
+    rassert(pr_op1 != NULL);
+    rassert(pr_op1->type == VALUE_TYPE_FLOAT);
+    rassert(pr_op2 != NULL);
+    rassert(pr_op2->type == VALUE_TYPE_FLOAT);
+    rassert(res != NULL);
+    rassert(sr != NULL);
+    rassert(!Streader_is_error_set(sr));
 
     if ((pr_op1->value.float_type == 0) && (pr_op2->value.float_type == 0))
     {
@@ -1485,10 +1485,10 @@ static bool float_pow(const Value* pr_op1, const Value* pr_op2, Value* res, Stre
 
 static bool op_pow(const Value* op1, const Value* op2, Value* res, Streader* sr)
 {
-    assert(op1 != NULL);
-    assert(op2 != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(op1 != NULL);
+    rassert(op2 != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1541,7 +1541,7 @@ static bool op_pow(const Value* op1, const Value* op2, Value* res, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return true;
@@ -1550,9 +1550,9 @@ static bool op_pow(const Value* op1, const Value* op2, Value* res, Streader* sr)
 
 static bool func_ts(const Value* args, Value* res, Random* rand, Streader* sr)
 {
-    assert(args != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(args != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
     ignore(rand);
 
     if (Streader_is_error_set(sr))
@@ -1631,10 +1631,10 @@ static bool func_ts(const Value* args, Value* res, Random* rand, Streader* sr)
 
 static bool func_rand(const Value* args, Value* res, Random* rand, Streader* sr)
 {
-    assert(args != NULL);
-    assert(res != NULL);
-    assert(rand != NULL);
-    assert(sr != NULL);
+    rassert(args != NULL);
+    rassert(res != NULL);
+    rassert(rand != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1665,9 +1665,9 @@ static bool func_rand(const Value* args, Value* res, Random* rand, Streader* sr)
 
 static bool func_pat(const Value* args, Value* res, Random* rand, Streader* sr)
 {
-    assert(args != NULL);
-    assert(res != NULL);
-    assert(sr != NULL);
+    rassert(args != NULL);
+    rassert(res != NULL);
+    rassert(sr != NULL);
     ignore(rand);
 
     if (Streader_is_error_set(sr))

--- a/src/lib/expr.c
+++ b/src/lib/expr.c
@@ -195,7 +195,7 @@ bool evaluate_expr(
             Streader_set_error(sr, "Stack overflow"); \
             return false;                             \
         }                                             \
-    } else (void)0
+    } else ignore(0)
 
 static bool evaluate_expr_(
         Streader* sr,

--- a/src/lib/init/Au_table.c
+++ b/src/lib/init/Au_table.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -32,7 +32,7 @@ struct Au_table
 
 Au_table* new_Au_table(int size)
 {
-    assert(size > 0);
+    rassert(size > 0);
 
     Au_table* table = memory_alloc_item(Au_table);
     if (table == NULL)
@@ -53,10 +53,10 @@ Au_table* new_Au_table(int size)
 
 bool Au_table_set(Au_table* table, int index, Audio_unit* au)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
-    assert(au != NULL);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
+    rassert(au != NULL);
 
     return Etable_set(table->aus, index, au);
 }
@@ -64,9 +64,9 @@ bool Au_table_set(Au_table* table, int index, Audio_unit* au)
 
 Audio_unit* Au_table_get(Au_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     return Etable_get(table->aus, index);
 }
@@ -74,9 +74,9 @@ Audio_unit* Au_table_get(Au_table* table, int index)
 
 void Au_table_remove(Au_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     Etable_remove(table->aus, index);
 
@@ -86,7 +86,7 @@ void Au_table_remove(Au_table* table, int index)
 
 void Au_table_clear(Au_table* table)
 {
-    assert(table != NULL);
+    rassert(table != NULL);
     Etable_clear(table->aus);
     return;
 }

--- a/src/lib/init/Bind.c
+++ b/src/lib/init/Bind.c
@@ -117,8 +117,8 @@ typedef struct bedata
 
 static bool read_bind_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     bedata* bd = userdata;
@@ -159,8 +159,8 @@ static bool read_bind_entry(Streader* sr, int32_t index, void* userdata)
 
 Bind* new_Bind(Streader* sr, const Event_names* names)
 {
-    assert(sr != NULL);
-    assert(names != NULL);
+    rassert(sr != NULL);
+    rassert(names != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -205,7 +205,7 @@ Bind* new_Bind(Streader* sr, const Event_names* names)
 
 Event_cache* Bind_create_cache(const Bind* map)
 {
-    assert(map != NULL);
+    rassert(map != NULL);
 
     Event_cache* cache = new_Event_cache();
     if (cache == NULL)
@@ -245,10 +245,10 @@ Target_event* Bind_get_first(
         const Value* value,
         Random* rand)
 {
-    assert(map != NULL);
-    assert(cache != NULL);
-    assert(event_name != NULL);
-    assert(value != NULL);
+    rassert(map != NULL);
+    rassert(cache != NULL);
+    rassert(event_name != NULL);
+    rassert(value != NULL);
 
     Event_cache_update(cache, event_name, value);
 
@@ -299,20 +299,20 @@ static bool Bind_dfs(const Bind* map, char* name);
 
 static bool Bind_is_cyclic(const Bind* map)
 {
-    assert(map != NULL);
+    rassert(map != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, map->cblists);
     Cblist* cblist = AAiter_get_at_least(iter, "");
     while (cblist != NULL)
     {
-        assert(cblist->source_state != SOURCE_STATE_REACHED);
+        rassert(cblist->source_state != SOURCE_STATE_REACHED);
         if (cblist->source_state == SOURCE_STATE_VISITED)
         {
             cblist = AAiter_get_next(iter);
             continue;
         }
 
-        assert(cblist->source_state == SOURCE_STATE_NEW);
+        rassert(cblist->source_state == SOURCE_STATE_NEW);
         if (Bind_dfs(map, cblist->event_name))
             return true;
 
@@ -325,8 +325,8 @@ static bool Bind_is_cyclic(const Bind* map)
 
 static bool Bind_dfs(const Bind* map, char* name)
 {
-    assert(map != NULL);
-    assert(name != NULL);
+    rassert(map != NULL);
+    rassert(name != NULL);
 
     Cblist* cblist = AAtree_get_exact(map->cblists, name);
     if (cblist == NULL || cblist->source_state == SOURCE_STATE_VISITED)
@@ -335,7 +335,7 @@ static bool Bind_dfs(const Bind* map, char* name)
     if (cblist->source_state == SOURCE_STATE_REACHED)
         return true;
 
-    assert(cblist->source_state == SOURCE_STATE_NEW);
+    rassert(cblist->source_state == SOURCE_STATE_NEW);
     cblist->source_state = SOURCE_STATE_REACHED;
 
     Cblist_item* item = cblist->first;
@@ -348,7 +348,7 @@ static bool Bind_dfs(const Bind* map, char* name)
                     STREADER_AUTO, event->desc, (int64_t)strlen(event->desc));
             char next_name[EVENT_NAME_MAX + 1] = "";
             Streader_readf(sr, "[%s", READF_STR(EVENT_NAME_MAX, next_name));
-            assert(!Streader_is_error_set(sr));
+            rassert(!Streader_is_error_set(sr));
 
             if (Bind_dfs(map, next_name))
                 return true;
@@ -367,8 +367,8 @@ static bool Bind_dfs(const Bind* map, char* name)
 
 static bool read_constraint(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     Cblist_item* item = userdata;
@@ -385,9 +385,9 @@ static bool read_constraint(Streader* sr, int32_t index, void* userdata)
 
 static bool read_constraints(Streader* sr, Bind* map, Cblist_item* item)
 {
-    assert(sr != NULL);
-    assert(map != NULL);
-    assert(item != NULL);
+    rassert(sr != NULL);
+    rassert(map != NULL);
+    rassert(item != NULL);
 
     return Streader_read_list(sr, read_constraint, item);
 }
@@ -401,8 +401,8 @@ typedef struct edata
 
 static bool read_event(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     edata* ed = userdata;
@@ -413,12 +413,12 @@ static bool read_event(Streader* sr, int32_t index, void* userdata)
 
     if (ed->item->last_event == NULL)
     {
-        assert(ed->item->first_event == NULL);
+        rassert(ed->item->first_event == NULL);
         ed->item->first_event = ed->item->last_event = event;
     }
     else
     {
-        assert(ed->item->first_event != NULL);
+        rassert(ed->item->first_event != NULL);
         ed->item->last_event->next = event;
         ed->item->last_event = event;
     }
@@ -429,9 +429,9 @@ static bool read_event(Streader* sr, int32_t index, void* userdata)
 static bool read_events(
         Streader* sr, Cblist_item* item, const Event_names* names)
 {
-    assert(sr != NULL);
-    assert(item != NULL);
-    assert(names != NULL);
+    rassert(sr != NULL);
+    rassert(item != NULL);
+    rassert(names != NULL);
 
     edata* ed = &(edata){ .item = item, .names = names, };
 
@@ -441,7 +441,7 @@ static bool read_events(
 
 static Cblist* new_Cblist(char* event_name)
 {
-    assert(event_name != NULL);
+    rassert(event_name != NULL);
 
     Cblist* list = memory_alloc_item(Cblist);
     if (list == NULL)
@@ -458,12 +458,12 @@ static Cblist* new_Cblist(char* event_name)
 
 static void Cblist_append(Cblist* list, Cblist_item* item)
 {
-    assert(list != NULL);
-    assert(item != NULL);
+    rassert(list != NULL);
+    rassert(item != NULL);
 
     if (list->last == NULL)
     {
-        assert(list->first == NULL);
+        rassert(list->first == NULL);
         list->first = list->last = item;
         return;
     }
@@ -538,7 +538,7 @@ static void del_Cblist_item(Cblist_item* item)
 
 static Constraint* new_Constraint(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -575,8 +575,8 @@ static Constraint* new_Constraint(Streader* sr)
         return NULL;
     }
 
-    assert(expr_end != NULL);
-    assert(expr_end > expr);
+    rassert(expr_end != NULL);
+    rassert(expr_end > expr);
     const ptrdiff_t len = expr_end - expr;
 
     c->expr = memory_calloc_items(char, len + 1);
@@ -597,13 +597,13 @@ static Constraint* new_Constraint(Streader* sr)
 static bool Constraint_match(
         Constraint* constraint, Event_cache* cache, Env_state* estate, Random* rand)
 {
-    assert(constraint != NULL);
-    assert(cache != NULL);
-    assert(estate != NULL);
-    assert(rand != NULL);
+    rassert(constraint != NULL);
+    rassert(cache != NULL);
+    rassert(estate != NULL);
+    rassert(rand != NULL);
 
     const Value* value = Event_cache_get_value(cache, constraint->event_name);
-    assert(value != NULL);
+    rassert(value != NULL);
 
     Value* result = VALUE_AUTO;
     Streader* sr = Streader_init(
@@ -632,8 +632,8 @@ static void del_Constraint(Constraint* constraint)
 
 static Target_event* new_Target_event(Streader* sr, const Event_names* names)
 {
-    assert(sr != NULL);
-    assert(names != NULL);
+    rassert(sr != NULL);
+    rassert(names != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -701,7 +701,7 @@ static Target_event* new_Target_event(Streader* sr, const Event_names* names)
     }
 
     const ptrdiff_t len = desc_end - desc;
-    assert(len > 0);
+    rassert(len > 0);
     event->desc = memory_alloc_items(char, len + 1);
     if (event->desc == NULL)
     {

--- a/src/lib/init/Connections.c
+++ b/src/lib/init/Connections.c
@@ -87,8 +87,8 @@ typedef struct read_conn_data
 
 static bool read_connection(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     read_conn_data* rcdata = userdata;
@@ -154,8 +154,8 @@ static bool read_connection(Streader* sr, int32_t index, void* userdata)
     }
     Device_node* dest_node = AAtree_get_exact(rcdata->graph->nodes, dest_name);
 
-    assert(src_node != NULL);
-    assert(dest_node != NULL);
+    rassert(src_node != NULL);
+    rassert(dest_node != NULL);
     mem_error_if(
             !Device_node_connect(dest_node, dest_port, src_node, src_port),
             rcdata->graph,
@@ -168,9 +168,9 @@ static bool read_connection(Streader* sr, int32_t index, void* userdata)
 Connections* new_Connections_from_string(
         Streader* sr, Connection_level level, Au_table* au_table, Device* master)
 {
-    assert(sr != NULL);
-    assert(au_table != NULL);
-    assert(master != NULL);
+    rassert(sr != NULL);
+    rassert(au_table != NULL);
+    rassert(master != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -228,8 +228,8 @@ Connections* new_Connections_from_string(
 bool Connections_check_connections(
         const Connections* graph, char err[DEVICE_CONNECTION_ERROR_LENGTH_MAX])
 {
-    assert(graph != NULL);
-    assert(err != NULL);
+    rassert(graph != NULL);
+    rassert(err != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, graph->nodes);
 
@@ -248,15 +248,15 @@ bool Connections_check_connections(
 
 Device_node* Connections_get_master(Connections* graph)
 {
-    assert(graph != NULL);
+    rassert(graph != NULL);
     return AAtree_get_exact(graph->nodes, "");
 }
 
 
 bool Connections_prepare(const Connections* graph, Device_states* dstates)
 {
-    assert(graph != NULL);
-    assert(dstates != NULL);
+    rassert(graph != NULL);
+    rassert(dstates != NULL);
 
     return Connections_init_buffers(graph, dstates);
 }
@@ -264,11 +264,11 @@ bool Connections_prepare(const Connections* graph, Device_states* dstates)
 
 bool Connections_init_buffers(const Connections* graph, Device_states* dstates)
 {
-    assert(graph != NULL);
-    assert(dstates != NULL);
+    rassert(graph != NULL);
+    rassert(dstates != NULL);
 
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     Device_states_reset_node_states(dstates);
     if (!Device_node_init_buffers_simple(master, dstates))
         return false;
@@ -284,12 +284,12 @@ void Connections_clear_buffers(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(graph != NULL);
-    assert(dstates != NULL);
-    assert(buf_start >= 0);
+    rassert(graph != NULL);
+    rassert(dstates != NULL);
+    rassert(buf_start >= 0);
 
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     if (buf_start >= buf_stop)
         return;
 
@@ -310,17 +310,17 @@ int32_t Connections_process_voice_group(
         int32_t audio_rate,
         double tempo)
 {
-    assert(graph != NULL);
-    assert(vgroup != NULL);
-    assert(dstates != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
-    assert(tempo > 0);
+    rassert(graph != NULL);
+    rassert(vgroup != NULL);
+    rassert(dstates != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
+    rassert(tempo > 0);
 
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     if (buf_start >= buf_stop)
         return buf_start;
 
@@ -338,14 +338,14 @@ void Connections_mix_voice_signals(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(graph != NULL);
-    assert(vgroup != NULL);
-    assert(dstates != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(graph != NULL);
+    rassert(vgroup != NULL);
+    rassert(dstates != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     if (buf_start >= buf_stop)
         return;
 
@@ -367,16 +367,16 @@ void Connections_process_mixed_signals(
         int32_t audio_rate,
         double tempo)
 {
-    assert(graph != NULL);
-    assert(dstates != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(audio_rate > 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(graph != NULL);
+    rassert(dstates != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(audio_rate > 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     if (buf_start >= buf_stop)
         return;
 
@@ -402,7 +402,7 @@ void Connections_process_mixed_signals(
 
 static bool Connections_is_cyclic(const Connections* graph)
 {
-    assert(graph != NULL);
+    rassert(graph != NULL);
 
     // Reset testing states
     {
@@ -436,12 +436,12 @@ static bool Connections_is_cyclic(const Connections* graph)
 
 void Connections_print(const Connections* graph, FILE* out)
 {
-    assert(graph != NULL);
-    assert(out != NULL);
+    rassert(graph != NULL);
+    rassert(out != NULL);
 
 //    Connections_reset(graph);
     const Device_node* master = AAtree_get_exact(graph->nodes, "");
-    assert(master != NULL);
+    rassert(master != NULL);
     Device_node_print(master, out);
     fprintf(out, "\n");
 
@@ -463,7 +463,7 @@ void del_Connections(Connections* graph)
 
 static int read_index(char* str)
 {
-    assert(str != NULL);
+    rassert(str != NULL);
 
     static const char* hex_digits = "0123456789abcdef";
     if (strspn(str, hex_digits) != 2)
@@ -478,9 +478,9 @@ static int read_index(char* str)
 static int validate_connection_path(
         Streader* sr, char* str, Connection_level level, Device_port_type type)
 {
-    assert(sr != NULL);
-    assert(str != NULL);
-    assert(type < DEVICE_PORT_TYPES);
+    rassert(sr != NULL);
+    rassert(str != NULL);
+    rassert(type < DEVICE_PORT_TYPES);
 
     if (Streader_is_error_set(sr))
         return -1;
@@ -602,7 +602,7 @@ static int validate_connection_path(
         }
         else
         {
-            assert(type == DEVICE_PORT_TYPE_SEND);
+            rassert(type == DEVICE_PORT_TYPE_SEND);
             bool can_send = (string_has_prefix(str, "out_") && !root) ||
                             (string_has_prefix(str, "in_") && root);
             if (!can_send)

--- a/src/lib/init/Connections.c
+++ b/src/lib/init/Connections.c
@@ -75,7 +75,7 @@ static int validate_connection_path(
             del_Connections(graph);                                   \
             return NULL;                                              \
         }                                                             \
-    } else (void)0
+    } else ignore(0)
 
 typedef struct read_conn_data
 {

--- a/src/lib/init/Device_node.c
+++ b/src/lib/init/Device_node.c
@@ -73,9 +73,9 @@ Processor* Device_node_get_processor_mut(const Device_node* node);
 
 Device_node* new_Device_node(const char* name, Au_table* au_table, const Device* master)
 {
-    assert(name != NULL);
-    assert(au_table != NULL);
-    assert(master != NULL);
+    rassert(name != NULL);
+    rassert(au_table != NULL);
+    rassert(master != NULL);
 
     Device_node* node = memory_alloc_item(Device_node);
     if (node == NULL)
@@ -92,15 +92,15 @@ Device_node* new_Device_node(const char* name, Au_table* au_table, const Device*
     {
         node->type = DEVICE_TYPE_AU;
         node->index = string_extract_index(node->name, "au_", 2, NULL);
-        assert(node->index >= 0);
-        assert(node->index < KQT_AUDIO_UNITS_MAX);
+        rassert(node->index >= 0);
+        rassert(node->index < KQT_AUDIO_UNITS_MAX);
     }
     else if (string_has_prefix(node->name, "proc_"))
     {
         node->type = DEVICE_TYPE_PROCESSOR;
         node->index = string_extract_index(node->name, "proc_", 2, NULL);
-        assert(node->index >= 0);
-        assert(node->index < KQT_PROCESSORS_MAX);
+        rassert(node->index >= 0);
+        rassert(node->index < KQT_PROCESSORS_MAX);
     }
     else if (string_eq(node->name, "Iin"))
     {
@@ -109,7 +109,7 @@ Device_node* new_Device_node(const char* name, Au_table* au_table, const Device*
     }
     else
     {
-        assert(false);
+        rassert(false);
     }
 
     node->cycle_test_state = DEVICE_NODE_STATE_NEW;
@@ -130,8 +130,8 @@ Device_node* new_Device_node(const char* name, Au_table* au_table, const Device*
 
 int Device_node_cmp(const Device_node* n1, const Device_node* n2)
 {
-    assert(n1 != NULL);
-    assert(n2 != NULL);
+    rassert(n1 != NULL);
+    rassert(n2 != NULL);
 
     return strcmp(n1->name, n2->name);
 }
@@ -140,8 +140,8 @@ int Device_node_cmp(const Device_node* n1, const Device_node* n2)
 bool Device_node_check_connections(
         const Device_node* node, char err[DEVICE_CONNECTION_ERROR_LENGTH_MAX])
 {
-    assert(node != NULL);
-    assert(err != NULL);
+    rassert(node != NULL);
+    rassert(err != NULL);
 
     static const char* master_name = "master";
 
@@ -220,8 +220,8 @@ bool Device_node_check_connections(
 
 bool Device_node_init_buffers_simple(const Device_node* node, Device_states* dstates)
 {
-    assert(node != NULL);
-    assert(dstates != NULL);
+    rassert(node != NULL);
+    rassert(dstates != NULL);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -229,7 +229,7 @@ bool Device_node_init_buffers_simple(const Device_node* node, Device_states* dst
 
     Device_state* node_dstate =
         Device_states_get_state(dstates, Device_get_id(node_device));
-    assert(Device_state_get_node_state(node_dstate) != DEVICE_NODE_STATE_REACHED);
+    rassert(Device_state_get_node_state(node_dstate) != DEVICE_NODE_STATE_REACHED);
 
     if (Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED)
         return true;
@@ -241,7 +241,7 @@ bool Device_node_init_buffers_simple(const Device_node* node, Device_states* dst
         Connection* edge = node->receive[port];
         while (edge != NULL)
         {
-            assert(edge->node != NULL);
+            rassert(edge->node != NULL);
             const Device* send_device = Device_node_get_device(edge->node);
             if (send_device == NULL ||
                     !Device_has_complete_type(send_device) ||
@@ -294,8 +294,8 @@ bool Device_node_init_buffers_simple(const Device_node* node, Device_states* dst
 
 bool Device_node_init_effect_buffers(const Device_node* node, Device_states* dstates)
 {
-    assert(node != NULL);
-    assert(dstates != NULL);
+    rassert(node != NULL);
+    rassert(dstates != NULL);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -306,7 +306,7 @@ bool Device_node_init_effect_buffers(const Device_node* node, Device_states* dst
 
     if (Device_state_get_node_state(node_dstate) > DEVICE_NODE_STATE_NEW)
     {
-        assert(Device_state_get_node_state(node_dstate) != DEVICE_NODE_STATE_REACHED);
+        rassert(Device_state_get_node_state(node_dstate) != DEVICE_NODE_STATE_REACHED);
         return true;
     }
 
@@ -354,9 +354,9 @@ void Device_node_clear_buffers(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(node != NULL);
-    assert(dstates != NULL);
-    assert(buf_start >= 0);
+    rassert(node != NULL);
+    rassert(dstates != NULL);
+    rassert(buf_start >= 0);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -367,7 +367,7 @@ void Device_node_clear_buffers(
 
     if (Device_state_get_node_state(node_dstate) > DEVICE_NODE_STATE_NEW)
     {
-        assert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
+        rassert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
         return;
     }
 
@@ -403,8 +403,8 @@ void Device_node_clear_buffers(
 
 void Device_node_reset_subgraph(const Device_node* node, Device_states* dstates)
 {
-    assert(node != NULL);
-    assert(dstates != NULL);
+    rassert(node != NULL);
+    rassert(dstates != NULL);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -415,7 +415,7 @@ void Device_node_reset_subgraph(const Device_node* node, Device_states* dstates)
 
     if (Device_state_get_node_state(node_dstate) < DEVICE_NODE_STATE_VISITED)
     {
-        assert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_NEW);
+        rassert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_NEW);
         return;
     }
 
@@ -456,14 +456,14 @@ int32_t Device_node_process_voice_group(
         int32_t audio_rate,
         double tempo)
 {
-    assert(node != NULL);
-    assert(vgroup != NULL);
-    assert(dstates != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
-    assert(tempo > 0);
+    rassert(node != NULL);
+    rassert(vgroup != NULL);
+    rassert(dstates != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
+    rassert(tempo > 0);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -474,7 +474,7 @@ int32_t Device_node_process_voice_group(
 
     if (Device_state_get_node_state(node_dstate) > DEVICE_NODE_STATE_NEW)
     {
-        assert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
+        rassert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
         return buf_start;
     }
 
@@ -581,11 +581,11 @@ void Device_node_mix_voice_signals(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(node != NULL);
-    assert(vgroup != NULL);
-    assert(dstates != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= buf_start);
+    rassert(node != NULL);
+    rassert(vgroup != NULL);
+    rassert(dstates != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= buf_start);
 
     const Device* node_device = Device_node_get_device(node);
     if (node_device == NULL)
@@ -596,7 +596,7 @@ void Device_node_mix_voice_signals(
 
     if (Device_state_get_node_state(node_dstate) > DEVICE_NODE_STATE_NEW)
     {
-        assert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
+        rassert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
         return;
     }
 
@@ -654,14 +654,14 @@ void Device_node_process_mixed_signals(
         int32_t audio_rate,
         double tempo)
 {
-    assert(node != NULL);
-    assert(dstates != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(node != NULL);
+    rassert(dstates != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     const Device* node_device = Device_node_get_device(node);
     if ((node_device == NULL) || !Device_is_existent(node_device))
@@ -673,7 +673,7 @@ void Device_node_process_mixed_signals(
     //fprintf(stderr, "Entering node %p %s\n", (void*)node, node->name);
     if (Device_state_get_node_state(node_dstate) > DEVICE_NODE_STATE_NEW)
     {
-        assert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
+        rassert(Device_state_get_node_state(node_dstate) == DEVICE_NODE_STATE_VISITED);
         return;
     }
 
@@ -749,15 +749,15 @@ void Device_node_process_mixed_signals(
 
 const char* Device_node_get_name(const Device_node* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
     return node->name;
 }
 
 
 Processor* Device_node_get_processor_mut(const Device_node* node)
 {
-    assert(node != NULL);
-    assert(node->type == DEVICE_TYPE_PROCESSOR);
+    rassert(node != NULL);
+    rassert(node->type == DEVICE_TYPE_PROCESSOR);
 
     Proc_table* procs = Audio_unit_get_procs((const Audio_unit*)node->master);
     return Proc_table_get_proc_mut(procs, node->index);
@@ -766,7 +766,7 @@ Processor* Device_node_get_processor_mut(const Device_node* node)
 
 const Device* Device_node_get_device(const Device_node* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
 
     if (node->type == DEVICE_TYPE_MASTER)
         return node->master;
@@ -777,7 +777,7 @@ const Device* Device_node_get_device(const Device_node* node)
                 (const Audio_unit*)node->master,
                 node->index);
 
-    assert(false);
+    rassert(false);
     return NULL;
 }
 
@@ -785,12 +785,12 @@ const Device* Device_node_get_device(const Device_node* node)
 bool Device_node_connect(
         Device_node* receiver, int rec_port, Device_node* sender, int send_port)
 {
-    assert(receiver != NULL);
-    assert(rec_port >= 0);
-    assert(rec_port < KQT_DEVICE_PORTS_MAX);
-    assert(sender != NULL);
-    assert(send_port >= 0);
-    assert(send_port < KQT_DEVICE_PORTS_MAX);
+    rassert(receiver != NULL);
+    rassert(rec_port >= 0);
+    rassert(rec_port < KQT_DEVICE_PORTS_MAX);
+    rassert(sender != NULL);
+    rassert(send_port >= 0);
+    rassert(send_port < KQT_DEVICE_PORTS_MAX);
 
     Connection* receive_edge = memory_alloc_item(Connection);
     if (receive_edge == NULL)
@@ -819,7 +819,7 @@ bool Device_node_connect(
 
 void Device_node_reset_cycle_test_state(Device_node* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
     node->cycle_test_state = DEVICE_NODE_STATE_NEW;
     return;
 }
@@ -827,7 +827,7 @@ void Device_node_reset_cycle_test_state(Device_node* node)
 
 bool Device_node_cycle_in_path(Device_node* node)
 {
-    assert(node != NULL);
+    rassert(node != NULL);
 
     if (node->cycle_test_state == DEVICE_NODE_STATE_VISITED)
         return false;
@@ -855,8 +855,8 @@ bool Device_node_cycle_in_path(Device_node* node)
 
 void Device_node_print(const Device_node* node, FILE* out)
 {
-    assert(node != NULL);
-    assert(out != NULL);
+    rassert(node != NULL);
+    rassert(out != NULL);
 
     static const char* states[] =
     {
@@ -907,7 +907,7 @@ void Device_node_print(const Device_node* node, FILE* out)
         Connection* edge = node->receive[port];
         while (edge != NULL)
         {
-            assert(edge->node->send[edge->port] != NULL);
+            rassert(edge->node->send[edge->port] != NULL);
             if (node == edge->node->send[edge->port]->node)
                 Device_node_print(edge->node, out);
 

--- a/src/lib/init/Env_var.c
+++ b/src/lib/init/Env_var.c
@@ -35,10 +35,10 @@ struct Env_var
 
 Env_var* new_Env_var(Value_type type, const char* name)
 {
-    assert((type == VALUE_TYPE_BOOL) || (type == VALUE_TYPE_INT) ||
+    rassert((type == VALUE_TYPE_BOOL) || (type == VALUE_TYPE_INT) ||
             (type == VALUE_TYPE_FLOAT) || (type == VALUE_TYPE_TSTAMP));
-    assert(name != NULL);
-    assert(is_valid_var_name(name));
+    rassert(name != NULL);
+    rassert(is_valid_var_name(name));
 
     Env_var* var = memory_alloc_item(Env_var);
     if (var == NULL)
@@ -53,7 +53,7 @@ Env_var* new_Env_var(Value_type type, const char* name)
 
 Env_var* new_Env_var_from_string(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -131,23 +131,23 @@ Env_var* new_Env_var_from_string(Streader* sr)
 
 Value_type Env_var_get_type(const Env_var* var)
 {
-    assert(var != NULL);
+    rassert(var != NULL);
     return var->value.type;
 }
 
 
 const char* Env_var_get_name(const Env_var* var)
 {
-    assert(var != NULL);
+    rassert(var != NULL);
     return var->name;
 }
 
 
 void Env_var_set_value(Env_var* var, const Value* value)
 {
-    assert(var != NULL);
-    assert(value != NULL);
-    assert(var->value.type == value->type);
+    rassert(var != NULL);
+    rassert(value != NULL);
+    rassert(var->value.type == value->type);
 
     Value_copy(&var->value, value);
 
@@ -157,7 +157,7 @@ void Env_var_set_value(Env_var* var, const Value* value)
 
 const Value* Env_var_get_value(const Env_var* var)
 {
-    assert(var != NULL);
+    rassert(var != NULL);
     return &var->value;
 }
 

--- a/src/lib/init/Environment.c
+++ b/src/lib/init/Environment.c
@@ -31,8 +31,8 @@ struct Environment
 
 Environment_iter* Environment_iter_init(Environment_iter* iter, const Environment* env)
 {
-    assert(iter != NULL);
-    assert(env != NULL);
+    rassert(iter != NULL);
+    rassert(env != NULL);
 
     AAiter_init(&iter->iter, env->vars);
     iter->next = AAiter_get_at_least(&iter->iter, "");
@@ -43,7 +43,7 @@ Environment_iter* Environment_iter_init(Environment_iter* iter, const Environmen
 
 const char* Environment_iter_get_next_name(Environment_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     const char* next = iter->next;
     iter->next = AAiter_get_next(&iter->iter);
@@ -73,8 +73,8 @@ Environment* new_Environment(void)
 
 static bool read_env_var(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     AAtree* new_vars = userdata;
@@ -104,8 +104,8 @@ static bool read_env_var(Streader* sr, int32_t index, void* userdata)
 
 bool Environment_parse(Environment* env, Streader* sr)
 {
-    assert(env != NULL);
-    assert(sr != NULL);
+    rassert(env != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -141,8 +141,8 @@ bool Environment_parse(Environment* env, Streader* sr)
 
 const Env_var* Environment_get(const Environment* env, const char* name)
 {
-    assert(env != NULL);
-    assert(name != NULL);
+    rassert(env != NULL);
+    rassert(name != NULL);
 
     return AAtree_get_exact(env->vars, name);
 }

--- a/src/lib/init/Input_map.c
+++ b/src/lib/init/Input_map.c
@@ -34,10 +34,10 @@ typedef struct Entry
 
 static int Entry_cmp(const Entry* e1, const Entry* e2)
 {
-    assert(e1 != NULL);
-    assert(e1->input >= 0);
-    assert(e2 != NULL);
-    assert(e2->input >= 0);
+    rassert(e1 != NULL);
+    rassert(e1->input >= 0);
+    rassert(e2 != NULL);
+    rassert(e2->input >= 0);
 
     return e1->input - e2->input;
 }
@@ -53,8 +53,8 @@ struct Input_map
 
 static bool read_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
     ignore(index);
 
     Input_map* im = userdata;
@@ -118,9 +118,9 @@ static bool read_entry(Streader* sr, int32_t index, void* userdata)
 
 Input_map* new_Input_map(Streader* sr, int32_t num_inputs, int32_t num_outputs)
 {
-    assert(sr != NULL);
-    assert(num_inputs > 0);
-    assert(num_outputs > 0);
+    rassert(sr != NULL);
+    rassert(num_inputs > 0);
+    rassert(num_outputs > 0);
 
     Input_map* im = memory_alloc_item(Input_map);
     if (im == NULL)
@@ -150,8 +150,8 @@ Input_map* new_Input_map(Streader* sr, int32_t num_inputs, int32_t num_outputs)
 
 bool Input_map_is_valid(const Input_map* im, const Bit_array* existents)
 {
-    assert(im != NULL);
-    assert(existents != NULL);
+    rassert(im != NULL);
+    rassert(existents != NULL);
 
     const Entry* key = ENTRY_KEY(0);
     AAiter* iter = AAiter_init(AAITER_AUTO, im->map);
@@ -171,9 +171,9 @@ bool Input_map_is_valid(const Input_map* im, const Bit_array* existents)
 
 int32_t Input_map_get_device_index(const Input_map* im, int32_t input_id)
 {
-    assert(im != NULL);
-    assert(input_id >= 0);
-    assert(input_id < im->num_inputs);
+    rassert(im != NULL);
+    rassert(input_id >= 0);
+    rassert(input_id < im->num_inputs);
 
     const Entry* key = ENTRY_KEY(input_id);
     const Entry* result = AAtree_get_exact(im->map, key);

--- a/src/lib/init/Module.c
+++ b/src/lib/init/Module.c
@@ -101,8 +101,8 @@ Module* new_Module(void)
 
 bool Module_read_mixing_volume(Module* module, Streader* sr)
 {
-    assert(module != NULL);
-    assert(sr != NULL);
+    rassert(module != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -130,8 +130,8 @@ bool Module_read_mixing_volume(Module* module, Streader* sr)
 
 bool Module_parse_random_seed(Module* module, Streader* sr)
 {
-    assert(module != NULL);
-    assert(sr != NULL);
+    rassert(module != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -158,33 +158,33 @@ bool Module_parse_random_seed(Module* module, Streader* sr)
 
 const Track_list* Module_get_track_list(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
 
     if (!module->album_is_existent)
         return NULL;
 
-    assert(module->track_list != NULL);
+    rassert(module->track_list != NULL);
     return module->track_list;
 }
 
 
 const Order_list* Module_get_order_list(const Module* module, int song)
 {
-    assert(module != NULL);
-    assert(song >= 0);
-    assert(song < KQT_SONGS_MAX);
+    rassert(module != NULL);
+    rassert(song >= 0);
+    rassert(song < KQT_SONGS_MAX);
 
     if (!Song_table_get_existent(module->songs, song))
         return NULL;
 
-    assert(module->order_lists[song] != NULL);
+    rassert(module->order_lists[song] != NULL);
     return module->order_lists[song];
 }
 
 
 void Module_set_ch_defaults_list(Module* module, Channel_defaults_list* ch_defs)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
 
     del_Channel_defaults_list(module->ch_defs);
     module->ch_defs = ch_defs;
@@ -195,7 +195,7 @@ void Module_set_ch_defaults_list(Module* module, Channel_defaults_list* ch_defs)
 
 const Channel_defaults_list* Module_get_ch_defaults_list(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->ch_defs;
 }
 
@@ -204,10 +204,10 @@ const Pattern* Module_get_pattern(
         const Module* module,
         const Pat_inst_ref* piref)
 {
-    assert(module != NULL);
-    assert(piref != NULL);
-    assert(piref->pat >= 0);
-    assert(piref->pat < KQT_PATTERNS_MAX);
+    rassert(module != NULL);
+    rassert(piref != NULL);
+    rassert(piref->pat >= 0);
+    rassert(piref->pat < KQT_PATTERNS_MAX);
 
     if (!Pat_table_get_existent(module->pats, piref->pat))
         return NULL;
@@ -223,14 +223,14 @@ const Pattern* Module_get_pattern(
 bool Module_find_pattern_location(
         const Module* module, const Pat_inst_ref* piref, int* track, int* system)
 {
-    assert(module != NULL);
-    assert(piref != NULL);
-    assert(piref->pat >= 0);
-    assert(piref->pat < KQT_PATTERNS_MAX);
-    assert(piref->inst >= 0);
-    assert(piref->inst < KQT_PAT_INSTANCES_MAX);
-    assert(track != NULL);
-    assert(system != NULL);
+    rassert(module != NULL);
+    rassert(piref != NULL);
+    rassert(piref->pat >= 0);
+    rassert(piref->pat < KQT_PATTERNS_MAX);
+    rassert(piref->inst >= 0);
+    rassert(piref->inst < KQT_PAT_INSTANCES_MAX);
+    rassert(track != NULL);
+    rassert(system != NULL);
 
     if (module->track_list == NULL)
         return false;
@@ -246,12 +246,12 @@ bool Module_find_pattern_location(
             continue;
 
         const Order_list* ol = module->order_lists[si];
-        assert(ol != NULL);
+        rassert(ol != NULL);
 
         for (int i = 0; i < Order_list_get_len(ol); ++i)
         {
             const Pat_inst_ref* cur_piref = Order_list_get_pat_inst_ref(ol, i);
-            assert(cur_piref != NULL);
+            rassert(cur_piref != NULL);
 
             if (cur_piref->pat == piref->pat && cur_piref->inst == piref->inst)
             {
@@ -268,15 +268,15 @@ bool Module_find_pattern_location(
 
 const Connections* Module_get_connections(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->connections;
 }
 
 
 void Module_set_mix_vol(Module* module, double mix_vol)
 {
-    assert(module != NULL);
-    assert(isfinite(mix_vol) || mix_vol == -INFINITY);
+    rassert(module != NULL);
+    rassert(isfinite(mix_vol) || mix_vol == -INFINITY);
 
     module->mix_vol_dB = mix_vol;
     module->mix_vol = exp2(mix_vol / 6);
@@ -287,29 +287,29 @@ void Module_set_mix_vol(Module* module, double mix_vol)
 
 double Module_get_mix_vol(Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->mix_vol_dB;
 }
 
 
 Song_table* Module_get_songs(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->songs;
 }
 
 
 Pat_table* Module_get_pats(Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->pats;
 }
 
 
 static int32_t Module_get_au_index_from_input(const Module* module, int32_t input)
 {
-    assert(module != NULL);
-    assert(input >= 0);
+    rassert(module != NULL);
+    rassert(input >= 0);
 
     if (module->au_map == NULL)
         return -1;
@@ -320,24 +320,24 @@ static int32_t Module_get_au_index_from_input(const Module* module, int32_t inpu
 
 Audio_unit* Module_get_au_from_input(const Module* module, int32_t input)
 {
-    assert(module != NULL);
-    assert(input >= 0);
+    rassert(module != NULL);
+    rassert(input >= 0);
 
     const int32_t au_index = Module_get_au_index_from_input(module, input);
     if (au_index < 0)
         return NULL;
 
-    assert(Bit_array_get(module->au_controls, input));
-    assert(au_index < KQT_AUDIO_UNITS_MAX);
+    rassert(Bit_array_get(module->au_controls, input));
+    rassert(au_index < KQT_AUDIO_UNITS_MAX);
     return Au_table_get(module->au_table, au_index);
 }
 
 
 void Module_set_control(Module* module, int control, bool existent)
 {
-    assert(module != NULL);
-    assert(control >= 0);
-    assert(control < KQT_CONTROLS_MAX);
+    rassert(module != NULL);
+    rassert(control >= 0);
+    rassert(control < KQT_CONTROLS_MAX);
 
     Bit_array_set(module->au_controls, control, existent);
 
@@ -347,9 +347,9 @@ void Module_set_control(Module* module, int control, bool existent)
 
 bool Module_get_control(const Module* module, int control)
 {
-    assert(module != NULL);
-    assert(control >= 0);
-    assert(control < KQT_CONTROLS_MAX);
+    rassert(module != NULL);
+    rassert(control >= 0);
+    rassert(control < KQT_CONTROLS_MAX);
 
     return Bit_array_get(module->au_controls, control);
 }
@@ -357,8 +357,8 @@ bool Module_get_control(const Module* module, int control)
 
 bool Module_set_au_map(Module* module, Streader* sr)
 {
-    assert(module != NULL);
-    assert(sr != NULL);
+    rassert(module != NULL);
+    rassert(sr != NULL);
 
     Input_map* im = new_Input_map(sr, INT32_MAX, KQT_AUDIO_UNITS_MAX);
     if (im == NULL)
@@ -373,22 +373,22 @@ bool Module_set_au_map(Module* module, Streader* sr)
 
 Input_map* Module_get_au_map(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->au_map;
 }
 
 
 Au_table* Module_get_au_table(const Module* module)
 {
-    assert(module != NULL);
+    rassert(module != NULL);
     return module->au_table;
 }
 
 
 void Module_set_bind(Module* module, Bind* bind)
 {
-    assert(module != NULL);
-    assert(bind != NULL);
+    rassert(module != NULL);
+    rassert(bind != NULL);
 
     del_Bind(module->bind);
     module->bind = bind;
@@ -399,9 +399,9 @@ void Module_set_bind(Module* module, Bind* bind)
 
 const Tuning_table* Module_get_tuning_table(const Module* module, int index)
 {
-    assert(module != NULL);
-    assert(index >= 0);
-    assert(index < KQT_TUNING_TABLES_MAX);
+    rassert(module != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_TUNING_TABLES_MAX);
 
     return module->tuning_tables[index];
 }
@@ -409,9 +409,9 @@ const Tuning_table* Module_get_tuning_table(const Module* module, int index)
 
 void Module_set_tuning_table(Module* module, int index, Tuning_table* tt)
 {
-    assert(module != NULL);
-    assert(index >= 0);
-    assert(index < KQT_TUNING_TABLES_MAX);
+    rassert(module != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_TUNING_TABLES_MAX);
 
     del_Tuning_table(module->tuning_tables[index]);
     module->tuning_tables[index] = tt;

--- a/src/lib/init/Parse_manager.c
+++ b/src/lib/init/Parse_manager.c
@@ -78,7 +78,7 @@ static const struct
 
 static const Audio_unit* find_au(Handle* handle, int32_t au_index, int32_t sub_au_index)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Module* module = Handle_get_module(handle);
 
@@ -102,7 +102,7 @@ static const Audio_unit* find_au(Handle* handle, int32_t au_index, int32_t sub_a
 static bool is_au_in_conn_possible(
         Handle* handle, int32_t au_index, int32_t sub_au_index, int32_t port)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Audio_unit* au = find_au(handle, au_index, sub_au_index);
     if (au == NULL)
@@ -115,7 +115,7 @@ static bool is_au_in_conn_possible(
 static bool is_au_out_conn_possible(
         Handle* handle, int32_t au_index, int32_t sub_au_index, int32_t port)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Audio_unit* au = find_au(handle, au_index, sub_au_index);
     if (au == NULL)
@@ -128,7 +128,7 @@ static bool is_au_out_conn_possible(
 static const Processor* find_complete_proc(
         Handle* handle, int32_t au_index, int32_t sub_au_index, int32_t proc_index)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Audio_unit* au = find_au(handle, au_index, sub_au_index);
     if (au == NULL)
@@ -149,7 +149,7 @@ static bool is_proc_in_conn_possible(
         int32_t proc_index,
         int32_t port)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Processor* proc = find_complete_proc(
             handle, au_index, sub_au_index, proc_index);
@@ -168,7 +168,7 @@ static bool is_proc_out_conn_possible(
         int32_t proc_index,
         int32_t port)
 {
-    assert(handle != NULL);
+    rassert(handle != NULL);
 
     const Processor* proc = find_complete_proc(
             handle, au_index, sub_au_index, proc_index);
@@ -182,9 +182,9 @@ static bool is_proc_out_conn_possible(
 static bool is_connection_possible(
         Handle* handle, const char* keyp, const Key_indices indices)
 {
-    assert(handle != NULL);
-    assert(keyp != NULL);
-    assert(indices != NULL);
+    rassert(handle != NULL);
+    rassert(keyp != NULL);
+    rassert(indices != NULL);
 
     if (string_has_prefix(keyp, "au_XX/au_XX/proc_XX/in_XX/"))
         return is_proc_in_conn_possible(
@@ -212,10 +212,10 @@ static bool is_connection_possible(
 bool parse_data(Handle* handle, const char* key, const void* data, long length)
 {
 //    fprintf(stderr, "parsing %s\n", key);
-    assert(handle != NULL);
+    rassert(handle != NULL);
     check_key(handle, key, false);
-    assert(data != NULL || length == 0);
-    assert(length >= 0);
+    rassert(data != NULL || length == 0);
+    rassert(length >= 0);
 
     if (length == 0)
     {
@@ -231,11 +231,11 @@ bool parse_data(Handle* handle, const char* key, const void* data, long length)
     if (!extract_key_pattern(key, key_pattern, key_indices))
     {
         fprintf(stderr, "invalid key: %s\n", key);
-        assert(false);
+        rassert(false);
         return false;
     }
 
-    assert(strlen(key) == strlen(key_pattern));
+    rassert(strlen(key) == strlen(key_pattern));
 
     const bool was_connection_possible = is_connection_possible(
             handle, key_pattern, key_indices);
@@ -272,7 +272,7 @@ bool parse_data(Handle* handle, const char* key, const void* data, long length)
 
 static bool read_mixing_volume(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (!Module_read_mixing_volume(Handle_get_module(params->handle), params->sr))
     {
@@ -296,7 +296,7 @@ static bool read_mixing_volume(Reader_params* params)
 
 static bool read_out_port_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t out_port_index = -1;
     acquire_port_index(out_port_index, params, 0);
@@ -318,7 +318,7 @@ static bool read_out_port_manifest(Reader_params* params)
 
 static bool read_connections(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     Module* module = Handle_get_module(params->handle);
 
@@ -346,7 +346,7 @@ static bool read_connections(Reader_params* params)
 
 static bool read_control_map(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (!Module_set_au_map(Handle_get_module(params->handle), params->sr))
     {
@@ -360,7 +360,7 @@ static bool read_control_map(Reader_params* params)
 
 static bool read_control_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     const int32_t index = params->indices[0];
     if (index < 0 || index >= KQT_CONTROLS_MAX)
@@ -381,7 +381,7 @@ static bool read_control_manifest(Reader_params* params)
 
 static bool read_random_seed(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (!Module_parse_random_seed(Handle_get_module(params->handle), params->sr))
     {
@@ -395,7 +395,7 @@ static bool read_random_seed(Reader_params* params)
 
 static bool read_environment(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (!Environment_parse(Handle_get_module(params->handle)->env, params->sr))
     {
@@ -416,7 +416,7 @@ static bool read_environment(Reader_params* params)
 
 static bool read_bind(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     Bind* map = new_Bind(
             params->sr,
@@ -442,7 +442,7 @@ static bool read_bind(Reader_params* params)
 
 static bool read_ch_defaults(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     Channel_defaults_list* ch_defs = new_Channel_defaults_list(params->sr);
     if (ch_defs == NULL)
@@ -460,7 +460,7 @@ static bool read_ch_defaults(Reader_params* params)
 
 static bool read_album_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     const bool existent = read_default_manifest(params->sr);
     if (Streader_is_error_set(params->sr))
@@ -477,7 +477,7 @@ static bool read_album_manifest(Reader_params* params)
 
 static bool read_album_tracks(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     Track_list* tl = new_Track_list(params->sr);
     if (tl == NULL)
@@ -497,10 +497,10 @@ static bool read_album_tracks(Reader_params* params)
 
 static Audio_unit* add_audio_unit(Handle* handle, Au_table* au_table, int index)
 {
-    assert(handle != NULL);
-    assert(au_table != NULL);
-    assert(index >= 0);
-    assert(index < KQT_AUDIO_UNITS_MAX);
+    rassert(handle != NULL);
+    rassert(au_table != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_AUDIO_UNITS_MAX);
 
     static const char* memory_error_str =
         "Couldn't allocate memory for a new audio unit";
@@ -529,7 +529,7 @@ static Audio_unit* add_audio_unit(Handle* handle, Au_table* au_table, int index)
     };
     for (int i = 0; i < 3; ++i)
     {
-        assert(au_devices[i] != NULL);
+        rassert(au_devices[i] != NULL);
         Device_state* ds = Device_create_state(
                 au_devices[i],
                 Player_get_audio_rate(handle->player),
@@ -586,9 +586,9 @@ typedef struct amdata
 
 static bool read_au_manifest_entry(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     amdata* d = userdata;
 
@@ -620,7 +620,7 @@ static bool read_au_manifest_entry(Streader* sr, const char* key, void* userdata
 
 static bool read_any_au_manifest(Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_au_index(index, params, level);
@@ -651,7 +651,7 @@ static bool read_any_au_manifest(Reader_params* params, Au_table* au_table, int 
 static bool read_any_au_in_port_manifest(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -678,7 +678,7 @@ static bool read_any_au_in_port_manifest(
 static bool read_any_au_out_port_manifest(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -704,7 +704,7 @@ static bool read_any_au_out_port_manifest(
 
 static bool read_any_au_connections(Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_au_index(index, params, level);
@@ -738,7 +738,7 @@ static bool read_any_au_connections(Reader_params* params, Au_table* au_table, i
 static bool read_any_au_control_vars(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_au_index(index, params, level);
@@ -779,7 +779,7 @@ static bool read_any_au_control_vars(
 static bool read_any_au_streams(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_au_index(index, params, level);
@@ -820,7 +820,7 @@ static bool read_any_au_streams(
 static bool read_any_au_hit_manifest(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (level > 0)
         return true;
@@ -851,7 +851,7 @@ static bool read_any_au_hit_manifest(
 static bool read_any_au_hit_proc_filter(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (level > 0)
         return true;
@@ -889,7 +889,7 @@ static bool read_any_au_hit_proc_filter(
 static bool read_any_au_expressions(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (level > 0)
         return true;
@@ -923,11 +923,11 @@ static bool read_any_au_expressions(
 static Processor* add_processor(
         Handle* handle, Audio_unit* au, Proc_table* proc_table, int proc_index)
 {
-    assert(handle != NULL);
-    assert(au != NULL);
-    assert(proc_table != NULL);
-    assert(proc_index >= 0);
-    assert(proc_index < KQT_PROCESSORS_MAX);
+    rassert(handle != NULL);
+    rassert(au != NULL);
+    rassert(proc_table != NULL);
+    rassert(proc_index >= 0);
+    rassert(proc_index < KQT_PROCESSORS_MAX);
 
     static const char* memory_error_str =
         "Couldn't allocate memory for a new processor";
@@ -963,7 +963,7 @@ static Processor* add_processor(
 static bool read_any_proc_in_port_manifest(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -997,7 +997,7 @@ static bool read_any_proc_in_port_manifest(
 static bool read_any_proc_out_port_manifest(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -1037,9 +1037,9 @@ typedef struct pmdata
 
 static bool read_proc_manifest_entry(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     pmdata* d = userdata;
 
@@ -1064,7 +1064,7 @@ static bool read_proc_manifest_entry(Streader* sr, const char* key, void* userda
 
 static bool read_any_proc_manifest(Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -1110,7 +1110,7 @@ static bool read_any_proc_manifest(Reader_params* params, Au_table* au_table, in
     if (d->cons == NULL)
         return false;
 
-    assert(d->cons != NULL);
+    rassert(d->cons != NULL);
     Device_impl* proc_impl = d->cons();
     if (proc_impl == NULL)
     {
@@ -1180,8 +1180,8 @@ static bool read_any_proc_manifest(Reader_params* params, Au_table* au_table, in
 static bool read_any_proc_signal_type(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
-    assert(au_table != NULL);
+    rassert(params != NULL);
+    rassert(au_table != NULL);
 
     int32_t au_index = -1;
     acquire_au_index(au_index, params, level);
@@ -1229,7 +1229,7 @@ static bool read_any_proc_signal_type(
 static bool read_any_proc_impl_conf_key(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (!key_is_device_param(params->subkey))
         return true;
@@ -1267,8 +1267,8 @@ static bool read_any_proc_impl_conf_key(
 static bool read_any_proc_impl_key(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
-    assert(strlen(params->subkey) < KQT_KEY_LENGTH_MAX - 2);
+    rassert(params != NULL);
+    rassert(strlen(params->subkey) < KQT_KEY_LENGTH_MAX - 2);
 
     char hack_subkey[KQT_KEY_LENGTH_MAX] = "i/";
     strcat(hack_subkey, params->subkey);
@@ -1282,8 +1282,8 @@ static bool read_any_proc_impl_key(
 static bool read_any_proc_conf_key(
         Reader_params* params, Au_table* au_table, int level)
 {
-    assert(params != NULL);
-    assert(strlen(params->subkey) < KQT_KEY_LENGTH_MAX - 2);
+    rassert(params != NULL);
+    rassert(strlen(params->subkey) < KQT_KEY_LENGTH_MAX - 2);
 
     char hack_subkey[KQT_KEY_LENGTH_MAX] = "c/";
     strcat(hack_subkey, params->subkey);
@@ -1297,7 +1297,7 @@ static bool read_any_proc_conf_key(
 #define MAKE_AU_EFFECT_READER(base_name)                                \
     static bool read_au_ ## base_name(Reader_params* params)            \
     {                                                                   \
-        assert(params != NULL);                                         \
+        rassert(params != NULL);                                        \
                                                                         \
         int32_t top_au_index = -1;                                      \
         acquire_au_index(top_au_index, params, 0);                      \
@@ -1316,7 +1316,7 @@ static bool read_any_proc_conf_key(
 #define MAKE_GLOBAL_AU_READER(base_name)                    \
     static bool read_ ## base_name(Reader_params* params)   \
     {                                                       \
-        assert(params != NULL);                             \
+        rassert(params != NULL);                            \
                                                             \
         Module* module = Handle_get_module(params->handle); \
         Au_table* au_table = Module_get_au_table(module);   \
@@ -1365,7 +1365,7 @@ static bool read_any_proc_conf_key(
 
 static bool read_pattern_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_pattern_index(index, params);
@@ -1386,7 +1386,7 @@ static bool read_pattern_manifest(Reader_params* params)
 
 static bool read_pattern_length(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_pattern_index(index, params);
@@ -1406,7 +1406,7 @@ static bool read_pattern_length(Reader_params* params)
 
 static bool read_column(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t pat_index = -1;
     acquire_pattern_index(pat_index, params);
@@ -1441,7 +1441,7 @@ static bool read_column(Reader_params* params)
 
 static bool read_pat_instance_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t pat_index = -1;
     acquire_pattern_index(pat_index, params);
@@ -1468,7 +1468,7 @@ static bool read_pat_instance_manifest(Reader_params* params)
 
 static bool read_tuning_table(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     const int32_t index = params->indices[0];
 
@@ -1512,7 +1512,7 @@ static bool read_tuning_table(Reader_params* params)
 
 static bool read_song_manifest(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_song_index(index, params);
@@ -1533,9 +1533,9 @@ static bool read_song_manifest(Reader_params* params)
 
 static Song* add_song(Handle* handle, int index)
 {
-    assert(handle != NULL);
-    assert(index >= 0);
-    assert(index < KQT_SONGS_MAX);
+    rassert(handle != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_SONGS_MAX);
 
     Song_table* st = Module_get_songs(Handle_get_module(handle));
     Song* song = Song_table_get(st, index);
@@ -1567,7 +1567,7 @@ static Song* add_song(Handle* handle, int index)
 
 static bool read_song_tempo(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_song_index(index, params);
@@ -1581,7 +1581,7 @@ static bool read_song_tempo(Reader_params* params)
 
 static bool read_song_order_list(Reader_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     int32_t index = -1;
     acquire_song_index(index, params);

--- a/src/lib/init/Parse_manager.c
+++ b/src/lib/init/Parse_manager.c
@@ -73,7 +73,7 @@ static const struct
                     (params)->handle, &(params)->sr->error);                     \
         else                                                                     \
             Handle_set_error_from_Error((params)->handle, &(params)->sr->error); \
-    } else (void)0
+    } else ignore(0)
 
 
 static const Audio_unit* find_au(Handle* handle, int32_t au_index, int32_t sub_au_index)
@@ -291,7 +291,7 @@ static bool read_mixing_volume(Reader_params* params)
         if ((index) < 0 || (index) >= KQT_DEVICE_PORTS_MAX) \
             return true;                                    \
     }                                                       \
-    else (void)0
+    else ignore(0)
 
 
 static bool read_out_port_manifest(Reader_params* params)
@@ -564,7 +564,7 @@ static Audio_unit* add_audio_unit(Handle* handle, Au_table* au_table, int index)
         if ((index) < 0 || (index) >= KQT_AUDIO_UNITS_MAX) \
             return true;                                   \
     }                                                      \
-    else (void)0
+    else ignore(0)
 
 
 #define acquire_au(au, handle, au_table, index)               \
@@ -574,7 +574,7 @@ static Audio_unit* add_audio_unit(Handle* handle, Au_table* au_table, int index)
         if ((au) == NULL)                                     \
             return false;                                     \
     }                                                         \
-    else (void)0
+    else ignore(0)
 
 
 typedef struct amdata
@@ -957,7 +957,7 @@ static Processor* add_processor(
         if ((index) < 0 || (index) >= KQT_PROCESSORS_MAX) \
             return true;                                  \
     }                                                     \
-    else (void)0
+    else ignore(0)
 
 
 static bool read_any_proc_in_port_manifest(
@@ -1350,7 +1350,7 @@ static bool read_any_proc_conf_key(
                 return false;                                           \
             }                                                           \
         }                                                               \
-    } else (void)0
+    } else ignore(0)
 
 
 #define acquire_pattern_index(index, params)            \
@@ -1360,7 +1360,7 @@ static bool read_any_proc_conf_key(
         if ((index) < 0 || (index) >= KQT_PATTERNS_MAX) \
             return true;                                \
     }                                                   \
-    else (void)0
+    else ignore(0)
 
 
 static bool read_pattern_manifest(Reader_params* params)
@@ -1507,7 +1507,7 @@ static bool read_tuning_table(Reader_params* params)
         if ((index) < 0 || (index) >= KQT_SONGS_MAX) \
             return true;                             \
     }                                                \
-    else (void)0
+    else ignore(0)
 
 
 static bool read_song_manifest(Reader_params* params)

--- a/src/lib/init/Tuning_table.c
+++ b/src/lib/init/Tuning_table.c
@@ -42,8 +42,8 @@ typedef struct pitch_index
 
 static int pitch_index_cmp(const pitch_index* pi1, const pitch_index* pi2)
 {
-    assert(pi1 != NULL);
-    assert(pi2 != NULL);
+    rassert(pi1 != NULL);
+    rassert(pi2 != NULL);
 
     if (pi1->cents < pi2->cents)
         return -1;
@@ -55,7 +55,7 @@ static int pitch_index_cmp(const pitch_index* pi1, const pitch_index* pi2)
 
 static bool Tuning_table_build_pitch_map(Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
 
     AAtree* pitch_map = new_AAtree(
             (AAtree_item_cmp*)pitch_index_cmp, (AAtree_item_destroy*)memory_free);
@@ -120,9 +120,9 @@ void Tuning_table_set_octave_width(Tuning_table* tt, double octave_width);
 
 static Tuning_table* new_Tuning_table(double ref_pitch, double octave_width)
 {
-    assert(ref_pitch > 0);
-    assert(isfinite(octave_width));
-    assert(octave_width > 0);
+    rassert(ref_pitch > 0);
+    rassert(isfinite(octave_width));
+    rassert(octave_width > 0);
 
     Tuning_table* tt = memory_alloc_item(Tuning_table);
     if (tt == NULL)
@@ -151,8 +151,8 @@ static Tuning_table* new_Tuning_table(double ref_pitch, double octave_width)
 
 static bool Streader_read_tuning(Streader* sr, double* cents)
 {
-    assert(sr != NULL);
-    assert(cents != NULL);
+    rassert(sr != NULL);
+    rassert(cents != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -195,8 +195,8 @@ static bool Streader_read_tuning(Streader* sr, double* cents)
 
 static bool read_note(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     if (index >= KQT_TUNING_TABLE_NOTES_MAX)
     {
@@ -217,9 +217,9 @@ static bool read_note(Streader* sr, int32_t index, void* userdata)
 
 static bool read_tuning_table_item(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Tuning_table* tt = userdata;
 
@@ -315,7 +315,7 @@ static bool read_tuning_table_item(Streader* sr, const char* key, void* userdata
 
 Tuning_table* new_Tuning_table_from_string(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -359,37 +359,37 @@ Tuning_table* new_Tuning_table_from_string(Streader* sr)
 
 int Tuning_table_get_note_count(const Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
     return tt->note_count;
 }
 
 
 int Tuning_table_get_ref_note(const Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
     return tt->ref_note;
 }
 
 
 double Tuning_table_get_ref_pitch(const Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
     return tt->ref_pitch;
 }
 
 
 double Tuning_table_get_global_offset(const Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
     return tt->global_offset;
 }
 
 
 void Tuning_table_set_octave_width(Tuning_table* tt, double octave_width)
 {
-    assert(tt != NULL);
-    assert(isfinite(octave_width));
-    assert(octave_width > 0);
+    rassert(tt != NULL);
+    rassert(isfinite(octave_width));
+    rassert(octave_width > 0);
 
     tt->octave_width = octave_width;
     for (int i = 0; i < KQT_TUNING_TABLE_OCTAVES; ++i)
@@ -404,18 +404,18 @@ void Tuning_table_set_octave_width(Tuning_table* tt, double octave_width)
 
 double Tuning_table_get_octave_width(const Tuning_table* tt)
 {
-    assert(tt != NULL);
+    rassert(tt != NULL);
     return tt->octave_width;
 }
 
 
 static void Tuning_table_set_note_cents(Tuning_table* tt, int index, double cents)
 {
-    assert(tt != NULL);
-    assert(index >= 0);
-    assert(index < KQT_TUNING_TABLE_NOTES_MAX);
-    assert(index <= tt->note_count);
-    assert(isfinite(cents));
+    rassert(tt != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_TUNING_TABLE_NOTES_MAX);
+    rassert(index <= tt->note_count);
+    rassert(isfinite(cents));
 
     tt->note_offsets[index] = cents;
 
@@ -428,9 +428,9 @@ static void Tuning_table_set_note_cents(Tuning_table* tt, int index, double cent
 
 double Tuning_table_get_pitch_offset(const Tuning_table* tt, int index)
 {
-    assert(tt != NULL);
-    assert(index >= 0);
-    assert(index < Tuning_table_get_note_count(tt));
+    rassert(tt != NULL);
+    rassert(index >= 0);
+    rassert(index < Tuning_table_get_note_count(tt));
 
     return tt->note_offsets[index];
 }
@@ -438,17 +438,17 @@ double Tuning_table_get_pitch_offset(const Tuning_table* tt, int index)
 
 int Tuning_table_get_nearest_note_index(const Tuning_table* tt, double cents)
 {
-    assert(tt != NULL);
-    assert(tt->note_count > 0);
-    assert(tt->pitch_map != NULL);
-    assert(isfinite(cents));
+    rassert(tt != NULL);
+    rassert(tt->note_count > 0);
+    rassert(tt->pitch_map != NULL);
+    rassert(isfinite(cents));
 
     pitch_index* key = &(pitch_index){ .cents = cents };
     pitch_index* pi_upper = AAtree_get_at_least(tt->pitch_map, key);
     pitch_index* pi_lower = AAtree_get_at_most(tt->pitch_map, key);
     pitch_index* pi = NULL;
 
-    assert(pi_upper != NULL || pi_lower != NULL);
+    rassert(pi_upper != NULL || pi_lower != NULL);
 
     if (pi_lower == NULL)
         pi = pi_upper;

--- a/src/lib/init/devices/Au_control_vars.c
+++ b/src/lib/init/devices/Au_control_vars.c
@@ -140,7 +140,7 @@ static Value_type get_value_type_from_var_entry_type(Var_entry_type var_entry_ty
         case VAR_ENTRY_TSTAMP: return VALUE_TYPE_TSTAMP;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return VALUE_TYPE_NONE;
@@ -150,8 +150,8 @@ static Value_type get_value_type_from_var_entry_type(Var_entry_type var_entry_ty
 Au_control_var_iter* Au_control_var_iter_init(
         Au_control_var_iter* iter, const Au_control_vars* aucv)
 {
-    assert(iter != NULL);
-    assert(aucv != NULL);
+    rassert(iter != NULL);
+    rassert(aucv != NULL);
 
     // Get the first entry
     AAiter_init(&iter->iter, aucv->vars);
@@ -174,9 +174,9 @@ Au_control_var_iter* Au_control_var_iter_init(
 void Au_control_var_iter_get_next_var_info(
         Au_control_var_iter* iter, const char** out_var_name, Value_type* out_var_type)
 {
-    assert(iter != NULL);
-    assert(out_var_name != NULL);
-    assert(out_var_type != NULL);
+    rassert(iter != NULL);
+    rassert(out_var_name != NULL);
+    rassert(out_var_type != NULL);
 
     *out_var_name = iter->next_var_name;
     *out_var_type = iter->next_var_type;
@@ -207,9 +207,9 @@ static bool Au_control_binding_iter_init_common(
         const char* var_name,
         Iter_mode iter_mode)
 {
-    assert(iter != NULL);
-    assert(aucv != NULL);
-    assert(var_name != NULL);
+    rassert(iter != NULL);
+    rassert(aucv != NULL);
+    rassert(var_name != NULL);
 
     const Var_entry* var_entry = AAtree_get_exact(aucv->vars, var_name);
     if (var_entry == NULL)
@@ -228,8 +228,8 @@ static bool Au_control_binding_iter_init_common(
 
 static void Au_control_binding_iter_update(Au_control_binding_iter* iter)
 {
-    assert(iter != NULL);
-    assert(iter->iter != NULL);
+    rassert(iter != NULL);
+    rassert(iter->iter != NULL);
 
     iter->target_dev_type = iter->iter->target_dev_type;
     iter->target_dev_index = iter->iter->target_dev_index;
@@ -244,10 +244,10 @@ static void Au_control_binding_iter_update(Au_control_binding_iter* iter)
 
         case ITER_MODE_SET_GENERIC:
         {
-            assert(iter->rand != NULL);
+            rassert(iter->rand != NULL);
 
             const char* expr = iter->iter->ext.expr_type.expression;
-            assert(expr != NULL);
+            rassert(expr != NULL);
 
             Streader* sr = Streader_init(STREADER_AUTO, expr, (int64_t)strlen(expr));
             Value* result = VALUE_AUTO;
@@ -267,7 +267,7 @@ static void Au_control_binding_iter_update(Au_control_binding_iter* iter)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return;
@@ -279,9 +279,9 @@ bool Au_control_binding_iter_init(
         const Au_control_vars* aucv,
         const char* var_name)
 {
-    assert(iter != NULL);
-    assert(aucv != NULL);
-    assert(var_name != NULL);
+    rassert(iter != NULL);
+    rassert(aucv != NULL);
+    rassert(var_name != NULL);
 
     iter->iter = NULL;
     iter->src_value.type = VALUE_TYPE_NONE;
@@ -304,12 +304,12 @@ bool Au_control_binding_iter_init_set_generic(
         const char* var_name,
         const Value* value)
 {
-    assert(iter != NULL);
-    assert(aucv != NULL);
-    assert(rand != NULL);
-    assert(var_name != NULL);
-    assert(value != NULL);
-    assert(Value_type_is_realtime(value->type));
+    rassert(iter != NULL);
+    rassert(aucv != NULL);
+    rassert(rand != NULL);
+    rassert(var_name != NULL);
+    rassert(value != NULL);
+    rassert(Value_type_is_realtime(value->type));
 
     iter->iter = NULL;
     Value_copy(&iter->src_value, value);
@@ -319,7 +319,7 @@ bool Au_control_binding_iter_init_set_generic(
         return false;
 
     const Var_entry* var_entry = AAtree_get_exact(aucv->vars, var_name);
-    assert(var_entry != NULL);
+    rassert(var_entry != NULL);
 
     // Try to convert input value to type expected by the variable entry
     if (!Value_convert(
@@ -338,8 +338,8 @@ bool Au_control_binding_iter_init_set_generic(
 
 bool Au_control_binding_iter_get_next_entry(Au_control_binding_iter* iter)
 {
-    assert(iter != NULL);
-    assert(iter->iter != NULL);
+    rassert(iter != NULL);
+    rassert(iter->iter != NULL);
 
     iter->iter = iter->iter->next;
 
@@ -358,7 +358,7 @@ static const char* mem_error_str =
 
 static Bind_entry* new_Bind_entry_common(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     char target_dev_name[16] = "";
     char target_var_name[KQT_VAR_NAME_MAX + 1] = "";
@@ -424,11 +424,11 @@ static Bind_entry* new_Bind_entry_common(Streader* sr)
 
 static bool read_binding_targets_generic(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
 
     Var_entry* entry = userdata;
-    assert(entry != NULL);
+    rassert(entry != NULL);
 
     if (!Streader_readf(sr, "["))
         return false;
@@ -440,7 +440,7 @@ static bool read_binding_targets_generic(Streader* sr, int32_t index, void* user
 
     if (entry->last_bind_entry == NULL)
     {
-        assert(entry->first_bind_entry == NULL);
+        rassert(entry->first_bind_entry == NULL);
         entry->first_bind_entry = bind_entry;
         entry->last_bind_entry = bind_entry;
     }
@@ -485,8 +485,8 @@ static bool read_binding_targets_generic(Streader* sr, int32_t index, void* user
         return false;
 
     // Allocate space for the expression string
-    assert(expr_end != NULL);
-    assert(expr_end > expr);
+    rassert(expr_end != NULL);
+    rassert(expr_end > expr);
     const ptrdiff_t expr_length = expr_end - expr;
 
     bind_entry->ext.expr_type.expression = memory_calloc_items(char, expr_length + 1);
@@ -506,11 +506,11 @@ static bool read_binding_targets_generic(Streader* sr, int32_t index, void* user
 
 static bool read_var_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
 
     Au_control_vars* acv = userdata;
-    assert(acv != NULL);
+    rassert(acv != NULL);
 
     // Read type and name
     char type_name[16] = "";
@@ -629,7 +629,7 @@ static bool read_var_entry(Streader* sr, int32_t index, void* userdata)
 
 Au_control_vars* new_Au_control_vars(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -663,11 +663,11 @@ Au_control_vars* new_Au_control_vars(Streader* sr)
 const Value* Au_control_vars_get_init_value(
         const Au_control_vars* aucv, const char* var_name)
 {
-    assert(aucv != NULL);
-    assert(var_name != NULL);
+    rassert(aucv != NULL);
+    rassert(var_name != NULL);
 
     const Var_entry* entry = AAtree_get_exact(aucv->vars, var_name);
-    assert(entry != NULL);
+    rassert(entry != NULL);
 
     return &entry->init_value;
 }

--- a/src/lib/init/devices/Au_expressions.c
+++ b/src/lib/init/devices/Au_expressions.c
@@ -38,7 +38,7 @@ typedef struct Entry
 
 static void del_Entry(Entry* entry)
 {
-    assert(entry != NULL);
+    rassert(entry != NULL);
 
     memory_free(entry->filter);
     memory_free(entry);
@@ -55,9 +55,9 @@ struct Au_expressions
 
 static bool read_expressions(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Au_expressions* ae = userdata;
 
@@ -95,7 +95,7 @@ static bool read_expressions(Streader* sr, const char* key, void* userdata)
 
 Au_expressions* new_Au_expressions(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -120,7 +120,7 @@ Au_expressions* new_Au_expressions(Streader* sr)
 
     if (!Streader_read_dict(sr, read_expressions, ae))
     {
-        assert(Streader_is_error_set(sr));
+        rassert(Streader_is_error_set(sr));
         del_Au_expressions(ae);
         return NULL;
     }
@@ -132,8 +132,8 @@ Au_expressions* new_Au_expressions(Streader* sr)
 const Param_proc_filter* Au_expressions_get_proc_filter(
         const Au_expressions* ae, const char* name)
 {
-    assert(ae != NULL);
-    assert(name != NULL);
+    rassert(ae != NULL);
+    rassert(name != NULL);
 
     if (strlen(name) >= KQT_VAR_NAME_MAX)
         return NULL;

--- a/src/lib/init/devices/Au_params.c
+++ b/src/lib/init/devices/Au_params.c
@@ -24,8 +24,8 @@
 
 Au_params* Au_params_init(Au_params* aup, uint32_t device_id)
 {
-    assert(aup != NULL);
-    assert(device_id > 0);
+    rassert(aup != NULL);
+    rassert(device_id > 0);
 
     aup->device_id = device_id;
 

--- a/src/lib/init/devices/Au_streams.c
+++ b/src/lib/init/devices/Au_streams.c
@@ -43,8 +43,8 @@ struct Au_streams
 Stream_target_dev_iter* Stream_target_dev_iter_init(
         Stream_target_dev_iter* iter, const Au_streams* streams)
 {
-    assert(iter != NULL);
-    assert(streams != NULL);
+    rassert(iter != NULL);
+    rassert(streams != NULL);
 
     AAiter_init(&iter->iter, streams->tree);
 
@@ -57,7 +57,7 @@ Stream_target_dev_iter* Stream_target_dev_iter_init(
 
 const char* Stream_target_dev_iter_get_next(Stream_target_dev_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     if (iter->next_name == NULL)
         return NULL;
@@ -73,11 +73,11 @@ const char* Stream_target_dev_iter_get_next(Stream_target_dev_iter* iter)
 
 static bool read_stream_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
 
     Au_streams* streams = userdata;
-    assert(streams != NULL);
+    rassert(streams != NULL);
 
     char stream_name[KQT_VAR_NAME_MAX + 1] = "";
     int64_t target_proc_index = -1;
@@ -170,9 +170,9 @@ Au_streams* new_Au_streams(Streader* sr)
 
 int Au_streams_get_target_proc_index(const Au_streams* streams, const char* stream_name)
 {
-    assert(streams != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(streams != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     const Entry* entry = AAtree_get_exact(streams->tree, stream_name);
     if (entry == NULL)

--- a/src/lib/init/devices/Audio_unit.c
+++ b/src/lib/init/devices/Audio_unit.c
@@ -48,7 +48,7 @@ typedef struct Hit_info
 
 static Hit_info* Hit_info_init(Hit_info* hit)
 {
-    assert(hit != NULL);
+    rassert(hit != NULL);
 
     hit->existence = false;
     hit->hit_proc_filter = NULL;
@@ -59,7 +59,7 @@ static Hit_info* Hit_info_init(Hit_info* hit)
 
 static void Hit_info_deinit(Hit_info* hit)
 {
-    assert(hit != NULL);
+    rassert(hit != NULL);
 
     del_Param_proc_filter(hit->hit_proc_filter);
     hit->hit_proc_filter = NULL;
@@ -181,8 +181,8 @@ Audio_unit* new_Audio_unit(void)
 
 void Audio_unit_set_type(Audio_unit* au, Au_type type)
 {
-    assert(au != NULL);
-    assert(type != AU_TYPE_INVALID);
+    rassert(au != NULL);
+    rassert(type != AU_TYPE_INVALID);
 
     au->type = type;
 
@@ -192,23 +192,23 @@ void Audio_unit_set_type(Audio_unit* au, Au_type type)
 
 Au_type Audio_unit_get_type(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->type;
 }
 
 
 Au_params* Audio_unit_get_params(Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return &au->params;
 }
 
 
 const Processor* Audio_unit_get_proc(const Audio_unit* au, int index)
 {
-    assert(au != NULL);
-    assert(index >= 0);
-    assert(index < KQT_PROCESSORS_MAX);
+    rassert(au != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_PROCESSORS_MAX);
 
     return Proc_table_get_proc(au->procs, index);
 }
@@ -216,17 +216,17 @@ const Processor* Audio_unit_get_proc(const Audio_unit* au, int index)
 
 Proc_table* Audio_unit_get_procs(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->procs;
 }
 
 
 const Audio_unit* Audio_unit_get_au(const Audio_unit* au, int index)
 {
-    assert(au != NULL);
-    assert(au->au_table != NULL);
-    assert(index >= 0);
-    assert(index < KQT_AUDIO_UNITS_MAX);
+    rassert(au != NULL);
+    rassert(au->au_table != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_AUDIO_UNITS_MAX);
 
     return Au_table_get(au->au_table, index);
 }
@@ -234,8 +234,8 @@ const Audio_unit* Audio_unit_get_au(const Audio_unit* au, int index)
 
 Au_table* Audio_unit_get_au_table(Audio_unit* au)
 {
-    assert(au != NULL);
-    assert(au->au_table != NULL);
+    rassert(au != NULL);
+    rassert(au->au_table != NULL);
 
     return au->au_table;
 }
@@ -243,7 +243,7 @@ Au_table* Audio_unit_get_au_table(Audio_unit* au)
 
 void Audio_unit_set_connections(Audio_unit* au, Connections* graph)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
 
     if (au->connections != NULL)
         del_Connections(au->connections);
@@ -255,22 +255,22 @@ void Audio_unit_set_connections(Audio_unit* au, Connections* graph)
 
 const Connections* Audio_unit_get_connections(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->connections;
 }
 
 
 Connections* Audio_unit_get_connections_mut(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->connections;
 }
 
 
 bool Audio_unit_prepare_connections(const Audio_unit* au, Device_states* states)
 {
-    assert(au != NULL);
-    assert(states != NULL);
+    rassert(au != NULL);
+    rassert(states != NULL);
 
     if (au->connections == NULL)
         return true;
@@ -281,21 +281,21 @@ bool Audio_unit_prepare_connections(const Audio_unit* au, Device_states* states)
 
 const Device* Audio_unit_get_input_interface(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return &au->in_iface->parent;
 }
 
 
 const Device* Audio_unit_get_output_interface(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return &au->out_iface->parent;
 }
 
 
 void Audio_unit_set_control_vars(Audio_unit* au, Au_control_vars* au_control_vars)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
 
     del_Au_control_vars(au->control_vars);
     au->control_vars = au_control_vars;
@@ -306,7 +306,7 @@ void Audio_unit_set_control_vars(Audio_unit* au, Au_control_vars* au_control_var
 
 void Audio_unit_set_streams(Audio_unit* au, Au_streams* au_streams)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
 
     del_Au_streams(au->streams);
     au->streams = au_streams;
@@ -317,16 +317,16 @@ void Audio_unit_set_streams(Audio_unit* au, Au_streams* au_streams)
 
 const Au_streams* Audio_unit_get_streams(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->streams;
 }
 
 
 void Audio_unit_set_hit_existence(Audio_unit* au, int index, bool existence)
 {
-    assert(au != NULL);
-    assert(index >= 0);
-    assert(index < KQT_HITS_MAX);
+    rassert(au != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_HITS_MAX);
 
     au->hits[index].existence = existence;
 
@@ -336,9 +336,9 @@ void Audio_unit_set_hit_existence(Audio_unit* au, int index, bool existence)
 
 bool Audio_unit_get_hit_existence(const Audio_unit* au, int index)
 {
-    assert(au != NULL);
-    assert(index >= 0);
-    assert(index < KQT_HITS_MAX);
+    rassert(au != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_HITS_MAX);
 
     return au->hits[index].existence;
 }
@@ -346,9 +346,9 @@ bool Audio_unit_get_hit_existence(const Audio_unit* au, int index)
 
 void Audio_unit_set_hit_proc_filter(Audio_unit* au, int index, Param_proc_filter* hpf)
 {
-    assert(au != NULL);
-    assert(index >= 0);
-    assert(index < KQT_HITS_MAX);
+    rassert(au != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_HITS_MAX);
 
     del_Param_proc_filter(au->hits[index].hit_proc_filter);
     au->hits[index].hit_proc_filter = hpf;
@@ -359,9 +359,9 @@ void Audio_unit_set_hit_proc_filter(Audio_unit* au, int index, Param_proc_filter
 
 const Param_proc_filter* Audio_unit_get_hit_proc_filter(const Audio_unit* au, int index)
 {
-    assert(au != NULL);
-    assert(index >= 0);
-    assert(index < KQT_HITS_MAX);
+    rassert(au != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_HITS_MAX);
 
     return au->hits[index].hit_proc_filter;
 }
@@ -369,7 +369,7 @@ const Param_proc_filter* Audio_unit_get_hit_proc_filter(const Audio_unit* au, in
 
 void Audio_unit_set_expressions(Audio_unit* au, Au_expressions* expressions)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
 
     del_Au_expressions(au->expressions);
     au->expressions = expressions;
@@ -380,7 +380,7 @@ void Audio_unit_set_expressions(Audio_unit* au, Au_expressions* expressions)
 
 const Au_expressions* Audio_unit_get_expressions(const Audio_unit* au)
 {
-    assert(au != NULL);
+    rassert(au != NULL);
     return au->expressions;
 }
 
@@ -390,8 +390,8 @@ static const Device* get_cv_target_device(
         const Au_control_binding_iter* iter,
         Device_control_var_mode mode)
 {
-    assert(au != NULL);
-    assert(iter != NULL);
+    rassert(au != NULL);
+    rassert(iter != NULL);
 
     const Device* target_dev = NULL;
     if ((mode == DEVICE_CONTROL_VAR_MODE_MIXED) &&
@@ -415,11 +415,11 @@ static void Audio_unit_init_control_var_generic(
         const char* var_name,
         Value_type var_type)
 {
-    assert(au != NULL);
-    assert(dstates != NULL);
-    assert(random != NULL);
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
-    assert(var_name != NULL);
+    rassert(au != NULL);
+    rassert(dstates != NULL);
+    rassert(random != NULL);
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
+    rassert(var_name != NULL);
 
     bool carried = false;
 
@@ -460,7 +460,7 @@ static void Audio_unit_init_control_var_generic(
             Channel_cv_state* cvstate = Channel_get_cv_state_mut(channel);
             const bool success =
                 Channel_cv_state_set_value(cvstate, var_name, init_value);
-            assert(success);
+            rassert(success);
         }
 
         Audio_unit_set_control_var_generic(
@@ -478,10 +478,10 @@ static void Audio_unit_init_control_vars(
         Random* random,
         Channel* channel)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(random != NULL);
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(random != NULL);
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
 
     const Audio_unit* au = (const Audio_unit*)device;
     if (au->control_vars == NULL)
@@ -513,12 +513,12 @@ static void Audio_unit_set_control_var_generic(
         const char* var_name,
         const Value* value)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(random != NULL);
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
-    assert(var_name != NULL);
-    assert(value != NULL);
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(random != NULL);
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
+    rassert(var_name != NULL);
+    rassert(value != NULL);
 
     const Audio_unit* au = (const Audio_unit*)device;
     if (au->control_vars == NULL)

--- a/src/lib/init/devices/Device.c
+++ b/src/lib/init/devices/Device.c
@@ -27,7 +27,7 @@
 
 bool Device_init(Device* device, bool req_impl)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
 
     static uint32_t id = 1;
     device->id = id;
@@ -66,21 +66,21 @@ bool Device_init(Device* device, bool req_impl)
 
 uint32_t Device_get_id(const Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     return device->id;
 }
 
 
 bool Device_has_complete_type(const Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     return !device->req_impl || (device->dimpl != NULL);
 }
 
 
 void Device_set_existent(Device* device, bool existent)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     device->existent = existent;
     return;
 }
@@ -88,15 +88,15 @@ void Device_set_existent(Device* device, bool existent)
 
 bool Device_is_existent(const Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     return device->existent;
 }
 
 
 void Device_set_impl(Device* device, Device_impl* dimpl)
 {
-    assert(device != NULL);
-    assert(dimpl != NULL);
+    rassert(device != NULL);
+    rassert(dimpl != NULL);
 
     del_Device_impl(device->dimpl);
 
@@ -109,7 +109,7 @@ void Device_set_impl(Device* device, Device_impl* dimpl)
 
 const Device_impl* Device_get_impl(const Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     return device->dimpl;
 }
 
@@ -117,10 +117,10 @@ const Device_impl* Device_get_impl(const Device* device)
 Device_state* Device_create_state(
         const Device* device, int32_t audio_rate, int32_t buffer_size)
 {
-    assert(device != NULL);
-    assert(device->create_state != NULL);
-    assert(audio_rate > 0);
-    assert(buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(device->create_state != NULL);
+    rassert(audio_rate > 0);
+    rassert(buffer_size >= 0);
 
     return device->create_state(device, audio_rate, buffer_size);
 }
@@ -129,7 +129,7 @@ Device_state* Device_create_state(
 void Device_set_state_creator(
         Device* device, Device_state* (*creator)(const Device*, int32_t, int32_t))
 {
-    assert(device != NULL);
+    rassert(device != NULL);
 
     if (creator != NULL)
         device->create_state = creator;
@@ -142,7 +142,7 @@ void Device_set_state_creator(
 
 void Device_set_mixed_signals(Device* device, bool enabled)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     device->enable_signal_support = enabled;
     return;
 }
@@ -150,7 +150,7 @@ void Device_set_mixed_signals(Device* device, bool enabled)
 
 bool Device_get_mixed_signals(const Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
     return device->enable_signal_support;
 }
 
@@ -158,8 +158,8 @@ bool Device_get_mixed_signals(const Device* device)
 void Device_register_set_control_var_generic(
         Device* device, Device_set_control_var_generic_func* set_func)
 {
-    assert(device != NULL);
-    assert(set_func != NULL);
+    rassert(device != NULL);
+    rassert(set_func != NULL);
 
     device->set_control_var_generic = set_func;
 
@@ -170,8 +170,8 @@ void Device_register_set_control_var_generic(
 void Device_register_init_control_vars(
         Device* device, Device_init_control_vars_func* init_func)
 {
-    assert(device != NULL);
-    assert(init_func != NULL);
+    rassert(device != NULL);
+    rassert(init_func != NULL);
 
     device->init_control_vars = init_func;
 
@@ -182,10 +182,10 @@ void Device_register_init_control_vars(
 void Device_set_port_existence(
         Device* device, Device_port_type type, int port, bool exists)
 {
-    assert(device != NULL);
-    assert(type < DEVICE_PORT_TYPES);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(device != NULL);
+    rassert(type < DEVICE_PORT_TYPES);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     device->existence[type][port] = exists;
 
@@ -195,10 +195,10 @@ void Device_set_port_existence(
 
 bool Device_get_port_existence(const Device* device, Device_port_type type, int port)
 {
-    assert(device != NULL);
-    assert(type < DEVICE_PORT_TYPES);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(device != NULL);
+    rassert(type < DEVICE_PORT_TYPES);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     return device->existence[type][port];
 }
@@ -206,7 +206,7 @@ bool Device_get_port_existence(const Device* device, Device_port_type type, int 
 
 bool Device_sync(Device* device)
 {
-    assert(device != NULL);
+    rassert(device != NULL);
 
     // Set existing keys on dimpl
     if (device->dimpl != NULL)
@@ -230,8 +230,8 @@ bool Device_sync(Device* device)
 
 bool Device_sync_states(const Device* device, Device_states* dstates)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
+    rassert(device != NULL);
+    rassert(dstates != NULL);
 
     if (device->dimpl != NULL)
     {
@@ -257,10 +257,10 @@ bool Device_sync_states(const Device* device, Device_states* dstates)
 
 bool Device_set_key(Device* device, const char* key, Streader* sr)
 {
-    assert(device != NULL);
-    assert(key != NULL);
-    assert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
-    assert(sr != NULL);
+    rassert(device != NULL);
+    rassert(key != NULL);
+    rassert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -284,10 +284,10 @@ bool Device_set_state_key(
         Device_states* dstates,
         const char* key)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(key != NULL);
-    assert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(key != NULL);
+    rassert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
 
     if (device->dimpl != NULL)
     {
@@ -309,13 +309,13 @@ void Device_set_control_var_generic(
         const char* var_name,
         const Value* value)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(random != NULL);
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
-    assert(var_name != NULL);
-    assert(value != NULL);
-    assert(Value_type_is_realtime(value->type));
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(random != NULL);
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
+    rassert(var_name != NULL);
+    rassert(value != NULL);
+    rassert(Value_type_is_realtime(value->type));
 
     if (device->set_control_var_generic != NULL)
         device->set_control_var_generic(
@@ -332,10 +332,10 @@ void Device_init_control_vars(
         Random* random,
         Channel* channel)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_MIXED, random != NULL));
-    assert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_MIXED, random != NULL));
+    rassert(implies(mode == DEVICE_CONTROL_VAR_MODE_VOICE, channel != NULL));
 
     if (device->init_control_vars != NULL)
         device->init_control_vars(device, dstates, mode, random, channel);
@@ -346,8 +346,8 @@ void Device_init_control_vars(
 
 void Device_print(const Device* device, FILE* out)
 {
-    assert(device != NULL);
-    assert(out != NULL);
+    rassert(device != NULL);
+    rassert(out != NULL);
 
     bool printed = false;
     for (int port = 0; port < KQT_DEVICE_PORTS_MAX; ++port)

--- a/src/lib/init/devices/Device_field.c
+++ b/src/lib/init/devices/Device_field.c
@@ -52,7 +52,7 @@ struct Device_field
 
 Device_field_type get_keyp_device_field_type(const char* keyp)
 {
-    assert(keyp != NULL);
+    rassert(keyp != NULL);
 
     // Find the last element
     const char* last_elem = keyp;
@@ -94,7 +94,7 @@ Device_field_type get_keyp_device_field_type(const char* keyp)
 
 Device_field* new_Device_field(const char* key, void* data)
 {
-    assert(key != NULL);
+    rassert(key != NULL);
 
     static const size_t sizes[DEVICE_FIELD_COUNT_] =
     {
@@ -114,10 +114,10 @@ Device_field* new_Device_field(const char* key, void* data)
     };
 
     const Device_field_type type = get_keyp_device_field_type(key);
-    assert(type != DEVICE_FIELD_NONE);
+    rassert(type != DEVICE_FIELD_NONE);
 
     const size_t data_size = sizes[type];
-    assert(data_size > 0);
+    rassert(data_size > 0);
 
     Device_field* field = memory_alloc_item(Device_field);
     if (field == NULL)
@@ -144,8 +144,8 @@ Device_field* new_Device_field(const char* key, void* data)
 
 Device_field* new_Device_field_from_data(const char* key, Streader* sr)
 {
-    assert(key != NULL);
-    assert(sr != NULL);
+    rassert(key != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -170,16 +170,16 @@ Device_field* new_Device_field_from_data(const char* key, Streader* sr)
 
 const char* Device_field_get_key(const Device_field* field)
 {
-    assert(field != NULL);
+    rassert(field != NULL);
     return field->key;
 }
 
 
 bool Device_field_change(Device_field* field, Streader* sr)
 {
-    assert(field != NULL);
-    assert(field->type != DEVICE_FIELD_NONE);
-    assert(sr != NULL);
+    rassert(field != NULL);
+    rassert(field->type != DEVICE_FIELD_NONE);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -235,7 +235,7 @@ bool Device_field_change(Device_field* field, Streader* sr)
                 }
             }
 
-            assert(!Streader_is_error_set(sr));
+            rassert(!Streader_is_error_set(sr));
             if (field->data.Envelope_type != NULL)
                 del_Envelope(field->data.Envelope_type);
 
@@ -259,7 +259,7 @@ bool Device_field_change(Device_field* field, Streader* sr)
                 }
             }
 
-            assert(!Streader_is_error_set(sr));
+            rassert(!Streader_is_error_set(sr));
             if (field->data.Sample_type != NULL)
                 del_Sample(field->data.Sample_type);
 
@@ -283,7 +283,7 @@ bool Device_field_change(Device_field* field, Streader* sr)
                 }
             }
 
-            assert(!Streader_is_error_set(sr));
+            rassert(!Streader_is_error_set(sr));
             if (field->data.Sample_type != NULL)
                 del_Sample(field->data.Sample_type);
 
@@ -343,7 +343,7 @@ bool Device_field_change(Device_field* field, Streader* sr)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     if (Streader_is_error_set(sr))
@@ -357,10 +357,10 @@ bool Device_field_change(Device_field* field, Streader* sr)
 
 int Device_field_cmp(const Device_field* field1, const Device_field* field2)
 {
-    assert(field1 != NULL);
-    assert(field1->key != NULL);
-    assert(field2 != NULL);
-    assert(field2->key != NULL);
+    rassert(field1 != NULL);
+    rassert(field1->key != NULL);
+    rassert(field2 != NULL);
+    rassert(field2->key != NULL);
 
     return strcmp(field1->key, field2->key);
 }
@@ -368,12 +368,12 @@ int Device_field_cmp(const Device_field* field1, const Device_field* field2)
 
 void Device_field_set_empty(Device_field* field, bool empty)
 {
-    assert(field != NULL);
-    assert(field->type != DEVICE_FIELD_ENVELOPE);
-    assert(field->type != DEVICE_FIELD_WAVPACK);
-    assert(field->type != DEVICE_FIELD_WAV);
-    assert(field->type != DEVICE_FIELD_NOTE_MAP);
-    assert(field->type != DEVICE_FIELD_HIT_MAP);
+    rassert(field != NULL);
+    rassert(field->type != DEVICE_FIELD_ENVELOPE);
+    rassert(field->type != DEVICE_FIELD_WAVPACK);
+    rassert(field->type != DEVICE_FIELD_WAV);
+    rassert(field->type != DEVICE_FIELD_NOTE_MAP);
+    rassert(field->type != DEVICE_FIELD_HIT_MAP);
 
     field->empty = empty;
 
@@ -383,7 +383,7 @@ void Device_field_set_empty(Device_field* field, bool empty)
 
 bool Device_field_get_empty(const Device_field* field)
 {
-    assert(field != NULL);
+    rassert(field != NULL);
     return field->empty;
 }
 
@@ -391,13 +391,13 @@ bool Device_field_get_empty(const Device_field* field)
 #if 0
 bool Device_field_modify(Device_field* field, void* data)
 {
-    assert(field != NULL);
-    assert(field->type != DEVICE_FIELD_ENVELOPE);
-    assert(field->type != DEVICE_FIELD_WAVPACK);
-    assert(field->type != DEVICE_FIELD_WAV);
-    assert(field->type != DEVICE_FIELD_NOTE_MAP);
-    assert(field->type != DEVICE_FIELD_HIT_MAP);
-    assert(data != NULL);
+    rassert(field != NULL);
+    rassert(field->type != DEVICE_FIELD_ENVELOPE);
+    rassert(field->type != DEVICE_FIELD_WAVPACK);
+    rassert(field->type != DEVICE_FIELD_WAV);
+    rassert(field->type != DEVICE_FIELD_NOTE_MAP);
+    rassert(field->type != DEVICE_FIELD_HIT_MAP);
+    rassert(data != NULL);
 
     switch (field->type)
     {
@@ -418,7 +418,7 @@ bool Device_field_modify(Device_field* field, void* data)
             break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     Device_field_set_empty(field, false);
@@ -430,8 +430,8 @@ bool Device_field_modify(Device_field* field, void* data)
 
 const bool* Device_field_get_bool(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_BOOL);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_BOOL);
 
     if (field->empty)
         return NULL;
@@ -442,8 +442,8 @@ const bool* Device_field_get_bool(const Device_field* field)
 
 const int64_t* Device_field_get_int(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_INT);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_INT);
 
     if (field->empty)
         return NULL;
@@ -454,8 +454,8 @@ const int64_t* Device_field_get_int(const Device_field* field)
 
 const double* Device_field_get_float(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_FLOAT);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_FLOAT);
 
     if (field->empty)
         return NULL;
@@ -466,8 +466,8 @@ const double* Device_field_get_float(const Device_field* field)
 
 const Tstamp* Device_field_get_tstamp(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_TSTAMP);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_TSTAMP);
 
     if (field->empty)
         return NULL;
@@ -478,8 +478,8 @@ const Tstamp* Device_field_get_tstamp(const Device_field* field)
 
 const Envelope* Device_field_get_envelope(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_ENVELOPE);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_ENVELOPE);
 
     if (field->empty)
         return NULL;
@@ -490,8 +490,8 @@ const Envelope* Device_field_get_envelope(const Device_field* field)
 
 const Sample* Device_field_get_sample(const Device_field* field)
 {
-    assert(field != NULL);
-    assert((field->type == DEVICE_FIELD_WAVPACK) || (field->type == DEVICE_FIELD_WAV));
+    rassert(field != NULL);
+    rassert((field->type == DEVICE_FIELD_WAVPACK) || (field->type == DEVICE_FIELD_WAV));
 
     if (field->empty)
         return NULL;
@@ -502,8 +502,8 @@ const Sample* Device_field_get_sample(const Device_field* field)
 
 const Sample_params* Device_field_get_sample_params(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_SAMPLE_PARAMS);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_SAMPLE_PARAMS);
 
     if (field->empty)
         return NULL;
@@ -514,8 +514,8 @@ const Sample_params* Device_field_get_sample_params(const Device_field* field)
 
 const Note_map* Device_field_get_note_map(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_NOTE_MAP);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_NOTE_MAP);
 
     if (field->empty)
         return NULL;
@@ -526,8 +526,8 @@ const Note_map* Device_field_get_note_map(const Device_field* field)
 
 const Hit_map* Device_field_get_hit_map(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_HIT_MAP);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_HIT_MAP);
 
     if (field->empty)
         return NULL;
@@ -538,8 +538,8 @@ const Hit_map* Device_field_get_hit_map(const Device_field* field)
 
 const Num_list* Device_field_get_num_list(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_NUM_LIST);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_NUM_LIST);
 
     if (field->empty)
         return NULL;
@@ -550,8 +550,8 @@ const Num_list* Device_field_get_num_list(const Device_field* field)
 
 const Padsynth_params* Device_field_get_padsynth_params(const Device_field* field)
 {
-    assert(field != NULL);
-    assert(field->type == DEVICE_FIELD_PADSYNTH_PARAMS);
+    rassert(field != NULL);
+    rassert(field->type == DEVICE_FIELD_PADSYNTH_PARAMS);
 
     if (field->empty)
         return NULL;

--- a/src/lib/init/devices/Device_impl.c
+++ b/src/lib/init/devices/Device_impl.c
@@ -474,7 +474,7 @@ bool Device_impl_set_key(Device_impl* dimpl, const char* key)
                 *dval : set_cb->cb.type_name ## _type.default_val;         \
             return set_cb->cb.type_name ## _type.set(dimpl, indices, val); \
         }                                                                  \
-        else (void)0
+        else ignore(0)
 
 #define SET_FIELDP(type_name, type)                                        \
         if (true)                                                          \
@@ -483,7 +483,7 @@ bool Device_impl_set_key(Device_impl* dimpl, const char* key)
                     dimpl->device->dparams, key);                          \
             return set_cb->cb.type_name ## _type.set(dimpl, indices, val); \
         }                                                                  \
-        else (void)0
+        else ignore(0)
 
         const Device_field_type dftype = get_keyp_device_field_type(
                 set_cb->key_pattern);
@@ -581,7 +581,7 @@ bool Device_impl_set_state_key(
             if (set_cb->cb.type_name ## _type.set_state != NULL)                      \
                 return set_cb->cb.type_name ## _type.set_state(dstate, indices, val); \
         }                                                                             \
-        else (void)0
+        else ignore(0)
 
 #define SET_FIELDP(type_name, type)                                                   \
         if (true)                                                                     \
@@ -591,7 +591,7 @@ bool Device_impl_set_state_key(
             if (set_cb->cb.type_name ## _type.set_state != NULL)                      \
                 return set_cb->cb.type_name ## _type.set_state(dstate, indices, val); \
         }                                                                             \
-        else (void)0
+        else ignore(0)
 
         const Device_field_type dftype = get_keyp_device_field_type(set_cb->key_pattern);
         rassert(dftype != DEVICE_FIELD_NONE);

--- a/src/lib/init/devices/Device_impl.c
+++ b/src/lib/init/devices/Device_impl.c
@@ -101,8 +101,8 @@ typedef struct Update_control_var_cb
 
 bool Device_impl_init(Device_impl* dimpl, Device_impl_destroy_func* destroy)
 {
-    assert(dimpl != NULL);
-    assert(destroy != NULL);
+    rassert(dimpl != NULL);
+    rassert(destroy != NULL);
 
     dimpl->create_pstate = NULL;
     dimpl->get_vstate_size = NULL;
@@ -128,8 +128,8 @@ bool Device_impl_init(Device_impl* dimpl, Device_impl_destroy_func* destroy)
 
 void Device_impl_set_device(Device_impl* dimpl, const Device* device)
 {
-    assert(dimpl != NULL);
-    assert(device != NULL);
+    rassert(dimpl != NULL);
+    rassert(device != NULL);
 
     dimpl->device = device;
 
@@ -139,7 +139,7 @@ void Device_impl_set_device(Device_impl* dimpl, const Device* device)
 
 int32_t Device_impl_get_vstate_size(const Device_impl* dimpl)
 {
-    assert(dimpl != NULL);
+    rassert(dimpl != NULL);
 
     if (dimpl->get_vstate_size != NULL)
         return dimpl->get_vstate_size();
@@ -156,10 +156,10 @@ int32_t Device_impl_get_vstate_size(const Device_impl* dimpl)
             Set_ ## type_name ## _func set_func,                  \
             Set_state_ ## type_name ## _func set_state_func)      \
     {                                                             \
-        assert(dimpl != NULL);                                    \
-        assert(keyp != NULL);                                     \
-        assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);                \
-        assert(set_func != NULL);                                 \
+        rassert(dimpl != NULL);                                   \
+        rassert(keyp != NULL);                                    \
+        rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);               \
+        rassert(set_func != NULL);                                \
                                                                   \
         Set_cb* set_cb = memory_alloc_item(Set_cb);               \
         if (set_cb == NULL)                                       \
@@ -192,11 +192,11 @@ bool Device_impl_register_set_tstamp(
         Set_tstamp_func set_func,
         Set_state_tstamp_func set_state_func)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
-    assert(default_val != NULL);
-    assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
-    assert(set_func != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
+    rassert(default_val != NULL);
+    rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
+    rassert(set_func != NULL);
 
     Set_cb* set_cb = memory_alloc_item(Set_cb);
     if (set_cb == NULL)
@@ -224,10 +224,10 @@ bool Device_impl_register_set_envelope(
         Set_envelope_func set_func,
         Set_state_envelope_func set_state_func)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
-    assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
-    assert(set_func != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
+    rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
+    rassert(set_func != NULL);
 
     Set_cb* set_cb = memory_alloc_item(Set_cb);
     if (set_cb == NULL)
@@ -255,10 +255,10 @@ bool Device_impl_register_set_sample(
         Set_sample_func set_func,
         Set_state_sample_func set_state_func)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
-    assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
-    assert(set_func != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
+    rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
+    rassert(set_func != NULL);
 
     Set_cb* set_cb = memory_alloc_item(Set_cb);
     if (set_cb == NULL)
@@ -286,10 +286,10 @@ bool Device_impl_register_set_num_list(
         Set_num_list_func set_func,
         Set_state_num_list_func set_state_func)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
-    assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
-    assert(set_func != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
+    rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
+    rassert(set_func != NULL);
 
     Set_cb* set_cb = memory_alloc_item(Set_cb);
     if (set_cb == NULL)
@@ -317,10 +317,10 @@ bool Device_impl_register_set_padsynth_params(
         Set_padsynth_params_func set_func,
         Set_state_padsynth_params_func set_state_func)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
-    assert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
-    assert(set_func != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
+    rassert(strlen(keyp) < KQT_KEY_LENGTH_MAX);
+    rassert(set_func != NULL);
 
     Set_cb* set_cb = memory_alloc_item(Set_cb);
     if (set_cb == NULL)
@@ -344,8 +344,8 @@ bool Device_impl_register_set_padsynth_params(
 static Update_control_var_cb* Device_impl_create_update_cv_cb(
         Device_impl* dimpl, const char* keyp, Value_type type)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
 
     Update_control_var_cb* update_cv_cb = memory_alloc_item(
             Update_control_var_cb);
@@ -371,8 +371,8 @@ bool Device_impl_create_cv_bool(
         Proc_state_set_cv_bool_func* pstate_set,
         Voice_state_set_cv_bool_func* vstate_set)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
 
     Update_control_var_cb* update_cv_cb =
         Device_impl_create_update_cv_cb(dimpl, keyp, VALUE_TYPE_BOOL);
@@ -392,8 +392,8 @@ bool Device_impl_create_cv_int(
         Proc_state_set_cv_int_func* pstate_set,
         Voice_state_set_cv_int_func* vstate_set)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
 
     Update_control_var_cb* update_cv_cb =
         Device_impl_create_update_cv_cb(dimpl, keyp, VALUE_TYPE_INT);
@@ -413,8 +413,8 @@ bool Device_impl_create_cv_float(
         Proc_state_set_cv_float_func* pstate_set,
         Voice_state_set_cv_float_func* vstate_set)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
 
     Update_control_var_cb* update_cv_cb =
         Device_impl_create_update_cv_cb(dimpl, keyp, VALUE_TYPE_FLOAT);
@@ -434,8 +434,8 @@ bool Device_impl_create_cv_tstamp(
         Proc_state_set_cv_tstamp_func* pstate_set,
         Voice_state_set_cv_tstamp_func* vstate_set)
 {
-    assert(dimpl != NULL);
-    assert(keyp != NULL);
+    rassert(dimpl != NULL);
+    rassert(keyp != NULL);
 
     Update_control_var_cb* update_cv_cb =
         Device_impl_create_update_cv_cb(dimpl, keyp, VALUE_TYPE_TSTAMP);
@@ -451,11 +451,11 @@ bool Device_impl_create_cv_tstamp(
 
 bool Device_impl_set_key(Device_impl* dimpl, const char* key)
 {
-    assert(dimpl != NULL);
-    assert(dimpl->device != NULL);
-    assert(key != NULL);
+    rassert(dimpl != NULL);
+    rassert(dimpl->device != NULL);
+    rassert(key != NULL);
 
-    assert(strlen(key) < KQT_KEY_LENGTH_MAX);
+    rassert(strlen(key) < KQT_KEY_LENGTH_MAX);
     char keyp[KQT_KEY_LENGTH_MAX] = "";
     Key_indices indices = { 0 };
     memset(indices, '\xff', KEY_INDICES_MAX * sizeof(int32_t));
@@ -487,7 +487,7 @@ bool Device_impl_set_key(Device_impl* dimpl, const char* key)
 
         const Device_field_type dftype = get_keyp_device_field_type(
                 set_cb->key_pattern);
-        assert(dftype != DEVICE_FIELD_NONE);
+        rassert(dftype != DEVICE_FIELD_NONE);
 
         switch (dftype)
         {
@@ -543,7 +543,7 @@ bool Device_impl_set_key(Device_impl* dimpl, const char* key)
                 break;
 
             default:
-                assert(false);
+                rassert(false);
         }
 
 #undef SET_FIELDP
@@ -557,11 +557,11 @@ bool Device_impl_set_key(Device_impl* dimpl, const char* key)
 bool Device_impl_set_state_key(
         const Device_impl* dimpl, Device_state* dstate, const char* key)
 {
-    assert(dimpl != NULL);
-    assert(key != NULL);
-    assert(dstate != NULL);
+    rassert(dimpl != NULL);
+    rassert(key != NULL);
+    rassert(dstate != NULL);
 
-    assert(strlen(key) < KQT_KEY_LENGTH_MAX);
+    rassert(strlen(key) < KQT_KEY_LENGTH_MAX);
     char keyp[KQT_KEY_LENGTH_MAX] = "";
     Key_indices indices = { 0 };
     memset(indices, '\xff', KEY_INDICES_MAX * sizeof(int32_t));
@@ -594,7 +594,7 @@ bool Device_impl_set_state_key(
         else (void)0
 
         const Device_field_type dftype = get_keyp_device_field_type(set_cb->key_pattern);
-        assert(dftype != DEVICE_FIELD_NONE);
+        rassert(dftype != DEVICE_FIELD_NONE);
 
         switch (dftype)
         {
@@ -650,7 +650,7 @@ bool Device_impl_set_state_key(
                 break;
 
             default:
-                assert(false);
+                rassert(false);
         }
 
 #undef SET_FIELDP
@@ -664,9 +664,9 @@ bool Device_impl_set_state_key(
 static const Update_control_var_cb* get_update_control_var_cb(
         const Device_impl* dimpl, const char* key, Key_indices indices)
 {
-    assert(dimpl != NULL);
-    assert(key != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(key != NULL);
+    rassert(indices != NULL);
 
     memset(indices, '\xff', KEY_INDICES_MAX * sizeof(int32_t));
 
@@ -683,9 +683,9 @@ void Device_impl_get_proc_cv_callback(
         Value_type type,
         Device_impl_proc_cv_callback* cb)
 {
-    assert(dimpl != NULL);
-    assert(key != NULL);
-    assert(cb != NULL);
+    rassert(dimpl != NULL);
+    rassert(key != NULL);
+    rassert(cb != NULL);
 
     const Update_control_var_cb* update_cv_cb =
         get_update_control_var_cb(dimpl, key, cb->indices);
@@ -717,7 +717,7 @@ void Device_impl_get_proc_cv_callback(
             break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return;
@@ -730,9 +730,9 @@ void Device_impl_get_voice_cv_callback(
         Value_type type,
         Device_impl_voice_cv_callback* cb)
 {
-    assert(dimpl != NULL);
-    assert(key != NULL);
-    assert(cb != NULL);
+    rassert(dimpl != NULL);
+    rassert(key != NULL);
+    rassert(cb != NULL);
 
     const Update_control_var_cb* update_cv_cb =
         get_update_control_var_cb(dimpl, key, cb->indices);
@@ -764,7 +764,7 @@ void Device_impl_get_voice_cv_callback(
             break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return;
@@ -773,7 +773,7 @@ void Device_impl_get_voice_cv_callback(
 
 void Device_impl_deinit(Device_impl* dimpl)
 {
-    assert(dimpl != NULL);
+    rassert(dimpl != NULL);
 
     del_AAtree(dimpl->update_cv_cbs);
     dimpl->update_cv_cbs = NULL;
@@ -791,7 +791,7 @@ void del_Device_impl(Device_impl* dimpl)
 
     Device_impl_deinit(dimpl);
 
-    assert(dimpl->destroy != NULL);
+    rassert(dimpl->destroy != NULL);
     dimpl->destroy(dimpl);
 
     return;

--- a/src/lib/init/devices/Device_params.c
+++ b/src/lib/init/devices/Device_params.c
@@ -241,7 +241,7 @@ bool Device_params_parse_value(Device_params* params, const char* key, Streader*
         if (field != NULL)                                                   \
             return Device_field_get_ ## ftype(field);                        \
     }                                                                        \
-    else (void)0
+    else ignore(0)
 
 const bool* Device_params_get_bool(const Device_params* params, const char* key)
 {

--- a/src/lib/init/devices/Device_params.c
+++ b/src/lib/init/devices/Device_params.c
@@ -36,8 +36,8 @@ struct Device_params
 Device_params_iter* Device_params_iter_init(
         Device_params_iter* iter, const Device_params* dparams)
 {
-    assert(iter != NULL);
-    assert(dparams != NULL);
+    rassert(iter != NULL);
+    rassert(dparams != NULL);
 
     // Init tree iterators
     AAiter_init(&iter->impl_iter, dparams->implement);
@@ -59,7 +59,7 @@ Device_params_iter* Device_params_iter_init(
 
 const char* Device_params_iter_get_next_key(Device_params_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     // Get the next key to be returned
     const char* ret_key = iter->next_impl_key;
@@ -68,12 +68,12 @@ const char* Device_params_iter_get_next_key(Device_params_iter* iter)
              strcmp(iter->next_config_key, ret_key) < 0))
         ret_key = iter->next_config_key;
 
-    assert(!(ret_key == NULL) ||
+    rassert(!(ret_key == NULL) ||
             (iter->next_impl_key == NULL && iter->next_config_key == NULL));
     if (ret_key == NULL)
         return NULL; // end reached
 
-    assert(iter->next_impl_key != NULL || iter->next_config_key != NULL);
+    rassert(iter->next_impl_key != NULL || iter->next_config_key != NULL);
 
     // Iterate the tree that is behind the other tree
     if (iter->next_config_key == NULL ||
@@ -96,8 +96,8 @@ const char* Device_params_iter_get_next_key(Device_params_iter* iter)
     }
 
     // Both tree iterators point to the same key, move both forwards
-    assert(iter->next_impl_key != NULL && iter->next_config_key != NULL);
-    assert(string_eq(iter->next_impl_key, iter->next_config_key));
+    rassert(iter->next_impl_key != NULL && iter->next_config_key != NULL);
+    rassert(string_eq(iter->next_impl_key, iter->next_config_key));
 
     const Device_field* impl_field = AAiter_get_next(&iter->impl_iter);
     iter->next_impl_key = (impl_field != NULL) ?
@@ -113,7 +113,7 @@ const char* Device_params_iter_get_next_key(Device_params_iter* iter)
 
 bool key_is_device_param(const char* key)
 {
-    assert(key != NULL);
+    rassert(key != NULL);
 
     if (key_is_text_device_param(key))
         return true;
@@ -127,7 +127,7 @@ bool key_is_device_param(const char* key)
 
 bool key_is_real_time_device_param(const char* key)
 {
-    assert(key != NULL);
+    rassert(key != NULL);
 
     const Device_field_type type = get_keyp_device_field_type(key);
     return type == DEVICE_FIELD_BOOL ||
@@ -139,7 +139,7 @@ bool key_is_real_time_device_param(const char* key)
 
 bool key_is_text_device_param(const char* key)
 {
-    assert(key != NULL);
+    rassert(key != NULL);
 
     if (key_is_real_time_device_param(key))
         return true;
@@ -179,11 +179,11 @@ Device_params* new_Device_params(void)
 
 bool Device_params_parse_value(Device_params* params, const char* key, Streader* sr)
 {
-    assert(params != NULL);
-    assert(key != NULL);
-    assert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
-    assert(key_is_device_param(key));
-    assert(sr != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
+    rassert(string_has_prefix(key, "i/") || string_has_prefix(key, "c/"));
+    rassert(key_is_device_param(key));
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -201,10 +201,10 @@ bool Device_params_parse_value(Device_params* params, const char* key, Streader*
     }
     else
     {
-        assert(false);
+        rassert(false);
     }
 
-    assert(tree != NULL);
+    rassert(tree != NULL);
     Device_field* field = AAtree_get_exact(tree, key);
     bool success = true;
     if (field != NULL)
@@ -245,8 +245,8 @@ bool Device_params_parse_value(Device_params* params, const char* key, Streader*
 
 const bool* Device_params_get_bool(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_BOOL)
         return NULL;
@@ -259,8 +259,8 @@ const bool* Device_params_get_bool(const Device_params* params, const char* key)
 
 const int64_t* Device_params_get_int(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_INT)
         return NULL;
@@ -273,8 +273,8 @@ const int64_t* Device_params_get_int(const Device_params* params, const char* ke
 
 const double* Device_params_get_float(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_FLOAT)
         return NULL;
@@ -287,8 +287,8 @@ const double* Device_params_get_float(const Device_params* params, const char* k
 
 const Tstamp* Device_params_get_tstamp(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_TSTAMP)
         return NULL;
@@ -301,8 +301,8 @@ const Tstamp* Device_params_get_tstamp(const Device_params* params, const char* 
 
 const Envelope* Device_params_get_envelope(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_ENVELOPE)
         return NULL;
@@ -315,8 +315,8 @@ const Envelope* Device_params_get_envelope(const Device_params* params, const ch
 
 const Sample* Device_params_get_sample(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     const Device_field_type type = get_keyp_device_field_type(key);
     if ((type != DEVICE_FIELD_WAVPACK) && (type != DEVICE_FIELD_WAV))
@@ -331,8 +331,8 @@ const Sample* Device_params_get_sample(const Device_params* params, const char* 
 const Sample_params* Device_params_get_sample_params(
         const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_SAMPLE_PARAMS)
         return NULL;
@@ -345,8 +345,8 @@ const Sample_params* Device_params_get_sample_params(
 
 const Note_map* Device_params_get_note_map(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_NOTE_MAP)
         return NULL;
@@ -359,8 +359,8 @@ const Note_map* Device_params_get_note_map(const Device_params* params, const ch
 
 const Hit_map* Device_params_get_hit_map(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_HIT_MAP)
         return NULL;
@@ -373,8 +373,8 @@ const Hit_map* Device_params_get_hit_map(const Device_params* params, const char
 
 const Num_list* Device_params_get_num_list(const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_NUM_LIST)
         return NULL;
@@ -388,8 +388,8 @@ const Num_list* Device_params_get_num_list(const Device_params* params, const ch
 const Padsynth_params* Device_params_get_padsynth_params(
         const Device_params* params, const char* key)
 {
-    assert(params != NULL);
-    assert(key != NULL);
+    rassert(params != NULL);
+    rassert(key != NULL);
 
     if (get_keyp_device_field_type(key) != DEVICE_FIELD_PADSYNTH_PARAMS)
         return NULL;

--- a/src/lib/init/devices/Param_proc_filter.c
+++ b/src/lib/init/devices/Param_proc_filter.c
@@ -40,9 +40,9 @@ struct Param_proc_filter
 
 static bool read_excluded(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Param_proc_filter* pf = userdata;
 
@@ -71,7 +71,7 @@ static bool read_excluded(Streader* sr, int32_t index, void* userdata)
 
 Param_proc_filter* new_Param_proc_filter(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -95,7 +95,7 @@ Param_proc_filter* new_Param_proc_filter(Streader* sr)
 
     if (!Streader_read_list(sr, read_excluded, pf))
     {
-        assert(Streader_is_error_set(sr));
+        rassert(Streader_is_error_set(sr));
         del_Param_proc_filter(pf);
         return NULL;
     }
@@ -106,9 +106,9 @@ Param_proc_filter* new_Param_proc_filter(Streader* sr)
 
 bool Param_proc_filter_is_proc_allowed(const Param_proc_filter* pf, int proc_index)
 {
-    assert(pf != NULL);
-    assert(proc_index >= 0);
-    assert(proc_index < KQT_PROCESSORS_MAX);
+    rassert(pf != NULL);
+    rassert(proc_index >= 0);
+    rassert(proc_index < KQT_PROCESSORS_MAX);
 
     const int64_t length = Vector_size(pf->excluded);
     for (int64_t i = 0; i < length; ++i)

--- a/src/lib/init/devices/Proc_table.c
+++ b/src/lib/init/devices/Proc_table.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -34,7 +34,7 @@ struct Proc_table
 
 Proc_table* new_Proc_table(int size)
 {
-    assert(size > 0);
+    rassert(size > 0);
 
     Proc_table* table = memory_alloc_item(Proc_table);
     if (table == NULL)
@@ -59,9 +59,9 @@ Proc_table* new_Proc_table(int size)
 
 void Proc_table_set_existent(Proc_table* table, int index, bool existent)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     Bit_array_set(table->existents, index, existent);
 
@@ -75,10 +75,10 @@ void Proc_table_set_existent(Proc_table* table, int index, bool existent)
 
 bool Proc_table_set_proc(Proc_table* table, int index, Processor* proc)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
-    assert(proc != NULL);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
+    rassert(proc != NULL);
 
     if (!Etable_set(table->procs, index, proc))
         return false;
@@ -91,9 +91,9 @@ bool Proc_table_set_proc(Proc_table* table, int index, Processor* proc)
 
 const Processor* Proc_table_get_proc(const Proc_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     return Etable_get(table->procs, index);
 }
@@ -101,9 +101,9 @@ const Processor* Proc_table_get_proc(const Proc_table* table, int index)
 
 Processor* Proc_table_get_proc_mut(Proc_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     return Etable_get(table->procs, index);
 }
@@ -111,9 +111,9 @@ Processor* Proc_table_get_proc_mut(Proc_table* table, int index)
 
 void Proc_table_remove_proc(Proc_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     Etable_remove(table->procs, index);
 
@@ -123,7 +123,7 @@ void Proc_table_remove_proc(Proc_table* table, int index)
 
 void Proc_table_clear(Proc_table* table)
 {
-    assert(table != NULL);
+    rassert(table != NULL);
 
     Etable_clear(table->procs);
 

--- a/src/lib/init/devices/Proc_type.c
+++ b/src/lib/init/devices/Proc_type.c
@@ -39,7 +39,7 @@ static const Proc_type proc_types[] =
 
 Proc_cons* Proc_type_find_cons(const char* type)
 {
-    assert(type != NULL);
+    rassert(type != NULL);
 
     for (int i = 0; proc_types[i].type != NULL; ++i)
     {

--- a/src/lib/init/devices/Processor.c
+++ b/src/lib/init/devices/Processor.c
@@ -29,9 +29,9 @@
 static Device_state* Processor_create_state_plain(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Proc_state* proc_state = memory_alloc_item(Proc_state);
     if (proc_state == NULL)
@@ -50,9 +50,9 @@ static Device_state* Processor_create_state_plain(
 static Device_state* Processor_create_dstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     const Device_impl* dimpl = Device_get_impl(device);
 
@@ -75,9 +75,9 @@ static void Processor_set_control_var_generic(
 
 Processor* new_Processor(int index, const Au_params* au_params)
 {
-    assert(index >= 0);
-    assert(index < KQT_PROCESSORS_MAX);
-    assert(au_params != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_PROCESSORS_MAX);
+    rassert(au_params != NULL);
 
     Processor* proc = memory_alloc_item(Processor);
     if (proc == NULL)
@@ -107,7 +107,7 @@ Processor* new_Processor(int index, const Au_params* au_params)
 
 void Processor_set_voice_signals(Processor* proc, bool enabled)
 {
-    assert(proc != NULL);
+    rassert(proc != NULL);
     proc->enable_voice_support = enabled;
     return;
 }
@@ -115,7 +115,7 @@ void Processor_set_voice_signals(Processor* proc, bool enabled)
 
 bool Processor_get_voice_signals(const Processor* proc)
 {
-    assert(proc != NULL);
+    rassert(proc != NULL);
     return proc->enable_voice_support;
 }
 
@@ -123,7 +123,7 @@ bool Processor_get_voice_signals(const Processor* proc)
 /*
 void Processor_set_signal_support(Processor* proc, bool enabled)
 {
-    assert(proc != NULL);
+    rassert(proc != NULL);
     proc->enable_signal_support = enabled;
     return;
 }
@@ -131,7 +131,7 @@ void Processor_set_signal_support(Processor* proc, bool enabled)
 
 bool Processor_get_signal_support(const Processor* proc)
 {
-    assert(proc != NULL);
+    rassert(proc != NULL);
     return proc->enable_signal_support;
 }
 // */
@@ -139,7 +139,7 @@ bool Processor_get_signal_support(const Processor* proc)
 
 const Au_params* Processor_get_au_params(const Processor* proc)
 {
-    assert(proc != NULL);
+    rassert(proc != NULL);
     return proc->au_params;
 }
 
@@ -153,11 +153,11 @@ static void Processor_set_control_var_generic(
         const char* key,
         const Value* value)
 {
-    assert(device != NULL);
-    assert(dstates != NULL);
-    assert(random != NULL);
-    assert(key != NULL);
-    assert(value != NULL);
+    rassert(device != NULL);
+    rassert(dstates != NULL);
+    rassert(random != NULL);
+    rassert(key != NULL);
+    rassert(value != NULL);
 
     Device_state* dstate = Device_states_get_state(dstates, Device_get_id(device));
 
@@ -167,7 +167,7 @@ static void Processor_set_control_var_generic(
     }
     else
     {
-        assert(channel != NULL);
+        rassert(channel != NULL);
         const Processor* proc = (const Processor*)device;
         Voice* voice = Channel_get_fg_voice(channel, proc->index);
         if (voice != NULL)

--- a/src/lib/init/devices/param_types/Envelope.c
+++ b/src/lib/init/devices/param_types/Envelope.c
@@ -52,13 +52,13 @@ Envelope* new_Envelope(int nodes_max,
         double min_x, double max_x, double step_x,
         double min_y, double max_y, double step_y)
 {
-    assert(nodes_max > 1);
-    assert(!isnan(min_x));
-    assert(!isnan(max_x));
-    assert(step_x >= 0);
-    assert(!isnan(min_y));
-    assert(!isnan(max_y));
-    assert(step_y >= 0);
+    rassert(nodes_max > 1);
+    rassert(!isnan(min_x));
+    rassert(!isnan(max_x));
+    rassert(step_x >= 0);
+    rassert(!isnan(min_y));
+    rassert(!isnan(max_y));
+    rassert(step_y >= 0);
 
     Envelope* env = memory_alloc_item(Envelope);
     if (env == NULL)
@@ -96,8 +96,8 @@ Envelope* new_Envelope(int nodes_max,
 
 static bool read_env_mark(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     if (index >= ENVELOPE_MARKS_MAX)
     {
@@ -133,9 +133,9 @@ static bool read_env_mark(Streader* sr, int32_t index, void* userdata)
 
 static bool read_env_item(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Envelope* env = userdata;
 
@@ -169,8 +169,8 @@ static bool read_env_item(Streader* sr, const char* key, void* userdata)
 
 bool Envelope_read(Envelope* env, Streader* sr)
 {
-    assert(env != NULL);
-    assert(sr != NULL);
+    rassert(env != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -189,8 +189,8 @@ typedef struct ndata
 
 static bool read_env_node(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     ndata* n = userdata;
     n->empty = false;
@@ -247,8 +247,8 @@ static bool read_env_node(Streader* sr, int32_t index, void* userdata)
 
 static bool Envelope_read_nodes(Envelope* env, Streader* sr)
 {
-    assert(env != NULL);
-    assert(sr != NULL);
+    rassert(env != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -277,16 +277,16 @@ static bool Envelope_read_nodes(Envelope* env, Streader* sr)
 
 int Envelope_node_count(const Envelope* env)
 {
-    assert(env != NULL);
+    rassert(env != NULL);
     return env->node_count;
 }
 
 
 void Envelope_set_interp(Envelope* env, Envelope_int interp)
 {
-    assert(env != NULL);
-//  assert(interp >= ENVELOPE_INT_NEAREST);
-    assert(interp < ENVELOPE_INT_LAST);
+    rassert(env != NULL);
+//  rassert(interp >= ENVELOPE_INT_NEAREST);
+    rassert(interp < ENVELOPE_INT_LAST);
     env->interp = interp;
     return;
 }
@@ -294,9 +294,9 @@ void Envelope_set_interp(Envelope* env, Envelope_int interp)
 
 void Envelope_set_mark(Envelope* env, int index, int value)
 {
-    assert(env != NULL);
-    assert(index >= 0);
-    assert(index < ENVELOPE_MARKS_MAX);
+    rassert(env != NULL);
+    rassert(index >= 0);
+    rassert(index < ENVELOPE_MARKS_MAX);
     env->marks[index] = value;
     return;
 }
@@ -304,9 +304,9 @@ void Envelope_set_mark(Envelope* env, int index, int value)
 
 int Envelope_get_mark(const Envelope* env, int index)
 {
-    assert(env != NULL);
-    assert(index >= 0);
-    assert(index < ENVELOPE_MARKS_MAX);
+    rassert(env != NULL);
+    rassert(index >= 0);
+    rassert(index < ENVELOPE_MARKS_MAX);
 
     return env->marks[index];
 }
@@ -314,20 +314,20 @@ int Envelope_get_mark(const Envelope* env, int index)
 
 Envelope_int Envelope_get_interp(const Envelope* env)
 {
-    assert(env != NULL);
+    rassert(env != NULL);
     return env->interp;
 }
 
 
 int Envelope_set_node(Envelope* env, double x, double y)
 {
-    assert(env != NULL);
-    assert(isfinite(x));
-    assert(isfinite(y));
+    rassert(env != NULL);
+    rassert(isfinite(x));
+    rassert(isfinite(y));
 
     if (env->node_count >= env->nodes_max)
     {
-        assert(env->node_count == env->nodes_max);
+        rassert(env->node_count == env->nodes_max);
         return -1;
     }
 
@@ -381,8 +381,8 @@ int Envelope_set_node(Envelope* env, double x, double y)
 
 bool Envelope_del_node(Envelope* env, int index)
 {
-    assert(env != NULL);
-    assert(index >= 0);
+    rassert(env != NULL);
+    rassert(index >= 0);
 
     if (index >= env->node_count)
         return false;
@@ -414,8 +414,8 @@ bool Envelope_del_node(Envelope* env, int index)
 
 double* Envelope_get_node(const Envelope* env, int index)
 {
-    assert(env != NULL);
-    assert(index >= 0);
+    rassert(env != NULL);
+    rassert(index >= 0);
 
     if (index >= env->node_count)
         return NULL;
@@ -426,10 +426,10 @@ double* Envelope_get_node(const Envelope* env, int index)
 
 double* Envelope_move_node(Envelope* env, int index, double x, double y)
 {
-    assert(env != NULL);
-    assert(index >= 0);
-    assert(isfinite(x));
-    assert(isfinite(y));
+    rassert(env != NULL);
+    rassert(index >= 0);
+    rassert(isfinite(x));
+    rassert(isfinite(y));
 
     if (index >= env->node_count)
         return NULL;
@@ -494,8 +494,8 @@ double* Envelope_move_node(Envelope* env, int index, double x, double y)
 
 double Envelope_get_value(const Envelope* env, double x)
 {
-    assert(env != NULL);
-    assert(isfinite(x));
+    rassert(env != NULL);
+    rassert(isfinite(x));
 
     if (env->node_count == 0
             || x < env->nodes[0]
@@ -517,9 +517,9 @@ double Envelope_get_value(const Envelope* env, double x)
     }
 
     // Interpolate
-    assert(start < env->node_count);
-    assert(end >= 0);
-    assert(start == end + 1);
+    rassert(start < env->node_count);
+    rassert(end >= 0);
+    rassert(start == end + 1);
 
     double prev_x = env->nodes[end * 2];
     double prev_y = env->nodes[end * 2 + 1];
@@ -545,18 +545,18 @@ double Envelope_get_value(const Envelope* env, double x)
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
-    assert(false);
+    rassert(false);
     return NAN;
 }
 
 
 void Envelope_set_first_lock(Envelope* env, bool lock_x, bool lock_y)
 {
-    assert(env != NULL);
-    assert(env->node_count > 0);
+    rassert(env != NULL);
+    rassert(env->node_count > 0);
 
     env->first_x_locked = lock_x;
     env->first_y_locked = lock_y;
@@ -567,8 +567,8 @@ void Envelope_set_first_lock(Envelope* env, bool lock_x, bool lock_y)
 
 void Envelope_set_last_lock(Envelope* env, bool lock_x, bool lock_y)
 {
-    assert(env != NULL);
-    assert(env->node_count > 0);
+    rassert(env != NULL);
+    rassert(env->node_count > 0);
 
     env->last_x_locked = lock_x;
     env->last_y_locked = lock_y;

--- a/src/lib/init/devices/param_types/Hit_map.c
+++ b/src/lib/init/devices/param_types/Hit_map.c
@@ -40,8 +40,8 @@ typedef struct Random_list
 
 static int Random_list_cmp(const Random_list* list1, const Random_list* list2)
 {
-    assert(list1 != NULL);
-    assert(list2 != NULL);
+    rassert(list1 != NULL);
+    rassert(list2 != NULL);
 
     if (list1->force < list2->force)
         return -1;
@@ -54,8 +54,8 @@ static int Random_list_cmp(const Random_list* list1, const Random_list* list2)
 
 static bool read_random_list_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     Random_list* list = userdata;
 
@@ -75,9 +75,9 @@ static bool read_random_list_entry(Streader* sr, int32_t index, void* userdata)
 
 static bool read_mapping(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Hit_map* map = userdata;
 
@@ -160,7 +160,7 @@ static bool read_mapping(Streader* sr, int32_t index, void* userdata)
 
 Hit_map* new_Hit_map_from_string(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -191,11 +191,11 @@ Hit_map* new_Hit_map_from_string(Streader* sr)
 const Sample_entry* Hit_map_get_entry(
         const Hit_map* map, int hit_index, double force, Random* random)
 {
-    assert(map != NULL);
-    assert(hit_index >= 0);
-    assert(hit_index < KQT_HITS_MAX);
-    assert(isfinite(force) || force == -INFINITY);
-    assert(random != NULL);
+    rassert(map != NULL);
+    rassert(hit_index >= 0);
+    rassert(hit_index < KQT_HITS_MAX);
+    rassert(isfinite(force) || force == -INFINITY);
+    rassert(random != NULL);
 
     AAtree* forces = map->hits[hit_index];
     if (forces == NULL)

--- a/src/lib/init/devices/param_types/Note_map.c
+++ b/src/lib/init/devices/param_types/Note_map.c
@@ -47,8 +47,8 @@ static double distance(const Random_list* list, const Random_list* key);
 
 static int Random_list_cmp(const Random_list* list1, const Random_list* list2)
 {
-    assert(list1 != NULL);
-    assert(list2 != NULL);
+    rassert(list1 != NULL);
+    rassert(list2 != NULL);
 
     if (list1->cents < list2->cents)
         return -1;
@@ -73,8 +73,8 @@ static void del_Random_list(Random_list* list)
 
 static bool read_random_list_entry(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     if (index >= NOTE_MAP_RANDOMS_MAX)
     {
@@ -94,9 +94,9 @@ static bool read_random_list_entry(Streader* sr, int32_t index, void* userdata)
 
 static bool read_mapping(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Note_map* map = userdata;
 
@@ -161,7 +161,7 @@ static bool read_mapping(Streader* sr, int32_t index, void* userdata)
 
 Note_map* new_Note_map_from_string(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -199,10 +199,10 @@ Note_map* new_Note_map_from_string(Streader* sr)
 
 bool Note_map_add_entry(Note_map* map, double cents, double force, Sample_entry* entry)
 {
-    assert(map != NULL);
-    assert(isfinite(cents));
-    assert(isfinite(force));
-    assert(entry != NULL);
+    rassert(map != NULL);
+    rassert(isfinite(cents));
+    rassert(isfinite(force));
+    rassert(entry != NULL);
 
     Random_list* key = &(Random_list){ .force = force, .cents = cents };
     Random_list* list = AAtree_get_exact(map->map, key);
@@ -222,7 +222,7 @@ bool Note_map_add_entry(Note_map* map, double cents, double force, Sample_entry*
 
     if (list->entry_count >= NOTE_MAP_RANDOMS_MAX)
     {
-        assert(list->entry_count == NOTE_MAP_RANDOMS_MAX);
+        rassert(list->entry_count == NOTE_MAP_RANDOMS_MAX);
         return false;
     }
 
@@ -238,8 +238,8 @@ bool Note_map_add_entry(Note_map* map, double cents, double force, Sample_entry*
 
 static double distance(const Random_list* list, const Random_list* key)
 {
-    assert(list != NULL);
-    assert(key != NULL);
+    rassert(list != NULL);
+    rassert(key != NULL);
     const double tone_d = (list->cents - key->cents) * 64;
     const double force_d = list->force - key->force;
     return hypot(tone_d, force_d);
@@ -249,10 +249,10 @@ static double distance(const Random_list* list, const Random_list* key)
 const Sample_entry* Note_map_get_entry(
         const Note_map* map, double cents, double force, Random* random)
 {
-    assert(map != NULL);
-    assert(isfinite(cents));
-    assert(isfinite(force) || (isinf(force) && force < 0));
-    assert(random != NULL);
+    rassert(map != NULL);
+    rassert(isfinite(cents));
+    rassert(isfinite(force) || (isinf(force) && force < 0));
+    rassert(random != NULL);
 
     const Random_list* key =
         &(Random_list){ .force = force, .freq = NAN, .cents = cents };
@@ -314,10 +314,10 @@ const Sample_entry* Note_map_get_entry(
     if (choice->entry_count == 0)
         return NULL;
 
-    assert(choice->entry_count <= NOTE_MAP_RANDOMS_MAX);
+    rassert(choice->entry_count <= NOTE_MAP_RANDOMS_MAX);
 //    state->middle_tone = choice->freq;
     const int index = Random_get_index(random, choice->entry_count);
-    assert(index >= 0);
+    rassert(index >= 0);
 //    fprintf(stderr, "%d\n", index);
 
     return &choice->entries[index];

--- a/src/lib/init/devices/param_types/Num_list.c
+++ b/src/lib/init/devices/param_types/Num_list.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -36,9 +36,9 @@ static bool Num_list_append(Num_list* nl, double num);
 
 static bool read_num(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Num_list* nl = userdata;
 
@@ -59,7 +59,7 @@ static bool read_num(Streader* sr, int32_t index, void* userdata)
 
 Num_list* new_Num_list_from_string(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -100,12 +100,12 @@ Num_list* new_Num_list_from_string(Streader* sr)
 
 static bool Num_list_append(Num_list* nl, double num)
 {
-    assert(nl != NULL);
-    assert(!isnan(num));
+    rassert(nl != NULL);
+    rassert(!isnan(num));
 
     if (nl->len >= nl->res)
     {
-        assert(nl->len == nl->res);
+        rassert(nl->len == nl->res);
 
         double* new_nums = memory_realloc_items(double, nl->res * 2, nl->nums);
         if (new_nums == NULL)
@@ -124,16 +124,16 @@ static bool Num_list_append(Num_list* nl, double num)
 
 int32_t Num_list_length(const Num_list* nl)
 {
-    assert(nl != NULL);
+    rassert(nl != NULL);
     return nl->len;
 }
 
 
 double Num_list_get_num(const Num_list* nl, int32_t index)
 {
-    assert(nl != NULL);
-    assert(index >= 0);
-    assert(index < nl->len);
+    rassert(nl != NULL);
+    rassert(index >= 0);
+    rassert(index < nl->len);
 
     return nl->nums[index];
 }

--- a/src/lib/init/devices/param_types/Padsynth_params.c
+++ b/src/lib/init/devices/param_types/Padsynth_params.c
@@ -25,9 +25,9 @@
 
 static bool read_harmonic(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Vector* harmonics = userdata;
 
@@ -62,9 +62,9 @@ static bool read_harmonic(Streader* sr, int32_t index, void* userdata)
 
 static bool read_param(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Padsynth_params* pp = userdata;
 
@@ -203,7 +203,7 @@ static bool read_param(Streader* sr, const char* key, void* userdata)
 
 Padsynth_params* new_Padsynth_params(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;

--- a/src/lib/init/devices/param_types/Sample.c
+++ b/src/lib/init/devices/param_types/Sample.c
@@ -46,10 +46,10 @@ Sample* new_Sample(void)
 
 Sample* new_Sample_from_buffers(float* buffers[], int count, int64_t length)
 {
-    assert(buffers != NULL);
-    assert(count >= 1);
-    assert(count <= 2);
-    assert(length > 0);
+    rassert(buffers != NULL);
+    rassert(count >= 1);
+    rassert(count <= 2);
+    rassert(length > 0);
 
     Sample* sample = new_Sample();
     if (sample == NULL)
@@ -61,7 +61,7 @@ Sample* new_Sample_from_buffers(float* buffers[], int count, int64_t length)
     sample->len = length;
     for (int i = 0; i < count; ++i)
     {
-        assert(buffers[i] != NULL);
+        rassert(buffers[i] != NULL);
         sample->data[i] = buffers[i];
     }
 
@@ -71,9 +71,9 @@ Sample* new_Sample_from_buffers(float* buffers[], int count, int64_t length)
 
 void* Sample_get_buffer(Sample* sample, int ch)
 {
-    assert(sample != NULL);
-    assert(ch >= 0);
-    assert(ch < sample->channels);
+    rassert(sample != NULL);
+    rassert(ch >= 0);
+    rassert(ch < sample->channels);
 
     return sample->data[ch];
 }
@@ -81,7 +81,7 @@ void* Sample_get_buffer(Sample* sample, int ch)
 
 int64_t Sample_get_len(const Sample* sample)
 {
-    assert(sample != NULL);
+    rassert(sample != NULL);
     return sample->len;
 }
 

--- a/src/lib/init/devices/param_types/Sample_entry.c
+++ b/src/lib/init/devices/param_types/Sample_entry.c
@@ -23,8 +23,8 @@
 
 bool Sample_entry_parse(Sample_entry* entry, Streader* sr)
 {
-    assert(entry != NULL);
-    assert(sr != NULL);
+    rassert(entry != NULL);
+    rassert(sr != NULL);
 
     int64_t sample = -1;
     double sample_cents = NAN;

--- a/src/lib/init/devices/param_types/Sample_params.c
+++ b/src/lib/init/devices/param_types/Sample_params.c
@@ -24,7 +24,7 @@
 
 Sample_params* Sample_params_init(Sample_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     params->format = SAMPLE_FORMAT_WAVPACK;
     params->mid_freq = 48000;
@@ -38,9 +38,9 @@ Sample_params* Sample_params_init(Sample_params* params)
 
 static bool read_field(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Sample_params* params = userdata;
 
@@ -140,8 +140,8 @@ static bool read_field(Streader* sr, const char* key, void* userdata)
 
 bool Sample_params_parse(Sample_params* params, Streader* sr)
 {
-    assert(params != NULL);
-    assert(sr != NULL);
+    rassert(params != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -162,8 +162,8 @@ bool Sample_params_parse(Sample_params* params, Streader* sr)
 
 Sample_params* Sample_params_copy(Sample_params* dest, const Sample_params* src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
+    rassert(dest != NULL);
+    rassert(src != NULL);
     memcpy(dest, src, sizeof(Sample_params));
     return dest;
 }

--- a/src/lib/init/devices/param_types/Wav.c
+++ b/src/lib/init/devices/param_types/Wav.c
@@ -30,8 +30,8 @@
 
 bool Sample_parse_wav(Sample* sample, Streader* sr)
 {
-    assert(sample != NULL);
-    assert(sr != NULL);
+    rassert(sample != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -57,7 +57,7 @@ typedef struct String_context
 
 static sf_count_t get_filelen_str(void* user_data)
 {
-    assert(user_data != NULL);
+    rassert(user_data != NULL);
     const String_context* context = user_data;
     return context->length;
 }
@@ -65,7 +65,7 @@ static sf_count_t get_filelen_str(void* user_data)
 
 static sf_count_t seek_str(sf_count_t offset, int whence, void* user_data)
 {
-    assert(user_data != NULL);
+    rassert(user_data != NULL);
     String_context* context = user_data;
 
     switch (whence)
@@ -75,8 +75,8 @@ static sf_count_t seek_str(sf_count_t offset, int whence, void* user_data)
         case SEEK_END: context->pos = context->length + offset; break;
     }
 
-    assert(context->pos >= 0);
-    assert(context->pos <= context->length);
+    rassert(context->pos >= 0);
+    rassert(context->pos <= context->length);
 
     return context->pos;
 }
@@ -84,7 +84,7 @@ static sf_count_t seek_str(sf_count_t offset, int whence, void* user_data)
 
 static sf_count_t read_str(void* ptr, sf_count_t count, void* user_data)
 {
-    assert(user_data != NULL);
+    rassert(user_data != NULL);
     String_context* context = user_data;
     const sf_count_t actual_count = min(count, context->length - context->pos);
     memcpy(ptr, &context->data[context->pos], (size_t)actual_count);
@@ -95,7 +95,7 @@ static sf_count_t read_str(void* ptr, sf_count_t count, void* user_data)
 
 static sf_count_t tell_str(void* user_data)
 {
-    assert(user_data != NULL);
+    rassert(user_data != NULL);
     const String_context* context = user_data;
     return context->pos;
 }
@@ -114,8 +114,8 @@ static void close_sndfile(SNDFILE* sf)
 
 bool Sample_parse_wav(Sample* sample, Streader* sr)
 {
-    assert(sample != NULL);
-    assert(sr != NULL);
+    rassert(sample != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;

--- a/src/lib/init/devices/param_types/Wavpack.c
+++ b/src/lib/init/devices/param_types/Wavpack.c
@@ -29,8 +29,8 @@
 
 bool Sample_parse_wavpack(Sample* sample, Streader* sr)
 {
-    assert(sample != NULL);
-    assert(sr != NULL);
+    rassert(sample != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -57,8 +57,8 @@ typedef struct String_context
 
 static int32_t read_bytes_str(void* id, void* data, int32_t bcount)
 {
-    assert(id != NULL);
-    assert(data != NULL);
+    rassert(id != NULL);
+    rassert(data != NULL);
 
     String_context* sc = id;
     if (sc->pos >= sc->length)
@@ -96,7 +96,7 @@ static int32_t read_bytes_str(void* id, void* data, int32_t bcount)
 
 static uint32_t get_pos_str(void* id)
 {
-    assert(id != NULL);
+    rassert(id != NULL);
     const String_context* sc = id;
     return (uint32_t)sc->pos;
 }
@@ -104,7 +104,7 @@ static uint32_t get_pos_str(void* id)
 
 static int set_pos_abs_str(void* id, uint32_t pos)
 {
-    assert(id != NULL);
+    rassert(id != NULL);
 
     String_context* sc = id;
     if (pos > sc->length)
@@ -120,7 +120,7 @@ static int set_pos_abs_str(void* id, uint32_t pos)
 
 static int set_pos_rel_str(void* id, int32_t delta, int mode)
 {
-    assert(id != NULL);
+    rassert(id != NULL);
 
     String_context* sc = id;
     int64_t ref = 0;
@@ -150,7 +150,7 @@ static int set_pos_rel_str(void* id, int32_t delta, int mode)
 static int push_back_byte_str(void* id, int c)
 {
 //    fprintf(stderr, "push back %c\n", (char)c);
-    assert(id != NULL);
+    rassert(id != NULL);
 
     String_context* sc = id;
     if (sc->push_back != EOF)
@@ -168,7 +168,7 @@ static int push_back_byte_str(void* id, int c)
 
 static uint32_t get_length_str(void* id)
 {
-    assert(id != NULL);
+    rassert(id != NULL);
     const String_context* sc = id;
     return (uint32_t)sc->length;
 }
@@ -176,7 +176,7 @@ static uint32_t get_length_str(void* id)
 
 static int can_seek_str(void* id)
 {
-    assert(id != NULL);
+    rassert(id != NULL);
     return 1;
 }
 
@@ -186,7 +186,7 @@ static int32_t write_bytes_str(void* id, void* data, int32_t bcount)
     ignore(id);
     ignore(data);
     ignore(bcount);
-    assert(false);
+    rassert(false);
     return 0;
 }
 
@@ -219,8 +219,8 @@ static WavpackStreamReader reader_str =
 
 bool Sample_parse_wavpack(Sample* sample, Streader* sr)
 {
-    assert(sample != NULL);
-    assert(sr != NULL);
+    rassert(sample != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;

--- a/src/lib/init/devices/processors/Proc_add.c
+++ b/src/lib/init/devices/processors/Proc_add.c
@@ -123,7 +123,7 @@ static float sine(double phase, double modifier)
 
 static void fill_buf(float* buf, const Sample* sample)
 {
-    assert(buf != NULL);
+    rassert(buf != NULL);
 
     if ((sample != NULL) && (sample->data[0] != NULL) && sample->is_float)
     {
@@ -151,8 +151,8 @@ static void fill_buf(float* buf, const Sample* sample)
 static bool Proc_add_set_base(
         Device_impl* dimpl, const Key_indices indices, const Sample* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_add* add = (Proc_add*)dimpl;
 
@@ -165,8 +165,8 @@ static bool Proc_add_set_base(
 static bool Proc_add_set_ramp_attack(
         Device_impl* dimpl, const Key_indices indices, bool enabled)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_add* add = (Proc_add*)dimpl;
     add->is_ramp_attack_enabled = enabled;
@@ -178,8 +178,8 @@ static bool Proc_add_set_ramp_attack(
 static bool Proc_add_set_tone_pitch(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     const int32_t ti = indices[0];
     if (ti < 0 || ti >= ADD_TONES_MAX)
@@ -199,8 +199,8 @@ static bool Proc_add_set_tone_pitch(
 static bool Proc_add_set_tone_volume(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     const int32_t ti = indices[0];
     if (ti < 0 || ti >= ADD_TONES_MAX)
@@ -220,8 +220,8 @@ static bool Proc_add_set_tone_volume(
 static bool Proc_add_set_tone_panning(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     const int32_t ti = indices[0];
     if (ti < 0 || ti >= ADD_TONES_MAX)

--- a/src/lib/init/devices/processors/Proc_debug.c
+++ b/src/lib/init/devices/processors/Proc_debug.c
@@ -59,8 +59,8 @@ Device_impl* new_Proc_debug(void)
 static bool Proc_debug_set_single_pulse(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_debug* debug = (Proc_debug*)dimpl;
     debug->single_pulse = value;

--- a/src/lib/init/devices/processors/Proc_delay.c
+++ b/src/lib/init/devices/processors/Proc_delay.c
@@ -79,7 +79,7 @@ Device_impl* new_Proc_delay(void)
 static bool Proc_delay_set_max_delay(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
+    rassert(dimpl != NULL);
     ignore(indices);
 
     Proc_delay* delay = (Proc_delay*)dimpl;
@@ -96,7 +96,7 @@ static bool Proc_delay_set_max_delay(
 static bool Proc_delay_set_init_delay(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
+    rassert(dimpl != NULL);
     ignore(indices);
 
     Proc_delay* delay = (Proc_delay*)dimpl;

--- a/src/lib/init/devices/processors/Proc_envgen.c
+++ b/src/lib/init/devices/processors/Proc_envgen.c
@@ -110,8 +110,8 @@ Device_impl* new_Proc_envgen(void)
 static bool Proc_envgen_set_time_env_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->is_time_env_enabled = value;
@@ -123,8 +123,8 @@ static bool Proc_envgen_set_time_env_enabled(
 static bool Proc_envgen_set_time_env(
         Device_impl* dimpl, const Key_indices indices, const Envelope* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
 
@@ -166,8 +166,8 @@ static bool Proc_envgen_set_time_env(
 static bool Proc_envgen_set_loop_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->is_loop_enabled = value;
@@ -179,8 +179,8 @@ static bool Proc_envgen_set_loop_enabled(
 static bool Proc_envgen_set_release_env(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->is_release_env = value;
@@ -192,8 +192,8 @@ static bool Proc_envgen_set_release_env(
 static bool Proc_envgen_set_env_scale_amount(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->env_scale_amount = isfinite(value) ? value : 0;
@@ -205,8 +205,8 @@ static bool Proc_envgen_set_env_scale_amount(
 static bool Proc_envgen_set_env_scale_center(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->env_scale_center = isfinite(value) ? value : 0;
@@ -218,8 +218,8 @@ static bool Proc_envgen_set_env_scale_center(
 static bool Proc_envgen_set_linear_force(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
 
@@ -232,8 +232,8 @@ static bool Proc_envgen_set_linear_force(
 static bool Proc_envgen_set_global_adjust(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->global_adjust = isfinite(value) ? value : 0;
@@ -245,8 +245,8 @@ static bool Proc_envgen_set_global_adjust(
 static bool Proc_envgen_set_force_env_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
     egen->is_force_env_enabled = value;
@@ -258,8 +258,8 @@ static bool Proc_envgen_set_force_env_enabled(
 static bool Proc_envgen_set_force_env(
         Device_impl* dimpl, const Key_indices indices, const Envelope* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
 
@@ -303,8 +303,8 @@ static bool Proc_envgen_set_force_env(
 static bool Proc_envgen_set_y_range(
         Device_impl* dimpl, const Key_indices indices, const Num_list* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_envgen* egen = (Proc_envgen*)dimpl;
 

--- a/src/lib/init/devices/processors/Proc_filter.c
+++ b/src/lib/init/devices/processors/Proc_filter.c
@@ -76,9 +76,9 @@ Device_impl* new_Proc_filter(void)
 static bool Proc_filter_set_cutoff(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Proc_filter* filter = (Proc_filter*)dimpl;
     filter->cutoff = value;
@@ -90,9 +90,9 @@ static bool Proc_filter_set_cutoff(
 static bool Proc_filter_set_resonance(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Proc_filter* filter = (Proc_filter*)dimpl;
     filter->resonance = value;

--- a/src/lib/init/devices/processors/Proc_force.c
+++ b/src/lib/init/devices/processors/Proc_force.c
@@ -96,7 +96,7 @@ Device_impl* new_Proc_force(void)
         if (!Envelope_read(force->def_force_release_env, sr))
         {
             // The default envelope should be valid
-            assert((sr->error.type == ERROR_MEMORY) ||
+            rassert((sr->error.type == ERROR_MEMORY) ||
                     (sr->error.type == ERROR_RESOURCE));
 
             del_Device_impl(&force->parent);
@@ -140,8 +140,8 @@ Device_impl* new_Proc_force(void)
 static bool Proc_force_set_global_force(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->global_force = isfinite(value) ? value : 0.0;
@@ -153,8 +153,8 @@ static bool Proc_force_set_global_force(
 static bool Proc_force_set_force_variation(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_var = (isfinite(value) && (value >= 0)) ? value : 0.0;
@@ -194,8 +194,8 @@ static bool is_valid_force_envelope(const Envelope* env)
 static bool Proc_force_set_env(
         Device_impl* dimpl, const Key_indices indices, const Envelope* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_env = is_valid_force_envelope(value) ? value : NULL;
@@ -207,8 +207,8 @@ static bool Proc_force_set_env(
 static bool Proc_force_set_env_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->is_force_env_enabled = value;
@@ -220,8 +220,8 @@ static bool Proc_force_set_env_enabled(
 static bool Proc_force_set_env_loop_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->is_force_env_loop_enabled = value;
@@ -233,8 +233,8 @@ static bool Proc_force_set_env_loop_enabled(
 static bool Proc_force_set_env_scale_amount(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_env_scale_amount = isfinite(value) ? value : 0;
@@ -246,8 +246,8 @@ static bool Proc_force_set_env_scale_amount(
 static bool Proc_force_set_env_scale_center(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_env_scale_center = isfinite(value) ? value : 0;
@@ -259,8 +259,8 @@ static bool Proc_force_set_env_scale_center(
 static bool Proc_force_set_env_rel(
         Device_impl* dimpl, const Key_indices indices, const Envelope* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
 
@@ -286,8 +286,8 @@ static bool Proc_force_set_env_rel(
 static bool Proc_force_set_env_rel_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->is_force_release_env_enabled = value;
@@ -299,8 +299,8 @@ static bool Proc_force_set_env_rel_enabled(
 static bool Proc_force_set_env_rel_scale_amount(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_release_env_scale_amount = isfinite(value) ? value : 0;
@@ -312,8 +312,8 @@ static bool Proc_force_set_env_rel_scale_amount(
 static bool Proc_force_set_env_rel_scale_center(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->force_release_env_scale_center = isfinite(value) ? value : 0;
@@ -325,8 +325,8 @@ static bool Proc_force_set_env_rel_scale_center(
 static bool Proc_force_set_release_ramp(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_force* force = (Proc_force*)dimpl;
     force->is_release_ramping_enabled = value;

--- a/src/lib/init/devices/processors/Proc_freeverb.c
+++ b/src/lib/init/devices/processors/Proc_freeverb.c
@@ -93,8 +93,8 @@ Device_impl* new_Proc_freeverb(void)
 static bool Proc_freeverb_set_initial_refl(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_freeverb* freeverb = (Proc_freeverb*)dimpl;
 
@@ -112,8 +112,8 @@ static bool Proc_freeverb_set_initial_refl(
 static bool Proc_freeverb_set_initial_damp(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_freeverb* freeverb = (Proc_freeverb*)dimpl;
 
@@ -130,7 +130,7 @@ static bool Proc_freeverb_set_initial_damp(
 
 static void Proc_freeverb_update_reflectivity(Proc_freeverb* freeverb, double reflect)
 {
-    assert(freeverb != NULL);
+    rassert(freeverb != NULL);
 
     freeverb->reflect_setting = reflect;
 
@@ -140,7 +140,7 @@ static void Proc_freeverb_update_reflectivity(Proc_freeverb* freeverb, double re
 
 static void Proc_freeverb_update_damp(Proc_freeverb* freeverb, double damp)
 {
-    assert(freeverb != NULL);
+    rassert(freeverb != NULL);
 
     freeverb->damp_setting = damp;
 
@@ -150,7 +150,7 @@ static void Proc_freeverb_update_damp(Proc_freeverb* freeverb, double damp)
 
 static void Proc_freeverb_update_gain(Proc_freeverb* freeverb, double gain)
 {
-    assert(freeverb != NULL);
+    rassert(freeverb != NULL);
 
     freeverb->gain = gain;
 
@@ -160,7 +160,7 @@ static void Proc_freeverb_update_gain(Proc_freeverb* freeverb, double gain)
 
 static void Proc_freeverb_update_wet(Proc_freeverb* freeverb, double wet)
 {
-    assert(freeverb != NULL);
+    rassert(freeverb != NULL);
 
     static const double scale_wet = 3;
     freeverb->wet = wet * scale_wet;

--- a/src/lib/init/devices/processors/Proc_gaincomp.c
+++ b/src/lib/init/devices/processors/Proc_gaincomp.c
@@ -70,8 +70,8 @@ Device_impl* new_Proc_gaincomp(void)
 static bool Proc_gc_set_map_enabled(
         Device_impl* dimpl, const Key_indices indices, bool value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_gaincomp* gc = (Proc_gaincomp*)dimpl;
     gc->is_map_enabled = value;
@@ -83,8 +83,8 @@ static bool Proc_gc_set_map_enabled(
 static bool Proc_gc_set_map(
         Device_impl* dimpl, const Key_indices indices, const Envelope* value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_gaincomp* gc = (Proc_gaincomp*)dimpl;
 

--- a/src/lib/init/devices/processors/Proc_padsynth.c
+++ b/src/lib/init/devices/processors/Proc_padsynth.c
@@ -61,8 +61,8 @@ struct Padsynth_sample_map
 static int Padsynth_sample_entry_cmp(
         const Padsynth_sample_entry* entry1, const Padsynth_sample_entry* entry2)
 {
-    assert(entry1 != NULL);
-    assert(entry2 != NULL);
+    rassert(entry1 != NULL);
+    rassert(entry2 != NULL);
 
     if (entry1->center_pitch < entry2->center_pitch)
         return -1;
@@ -94,15 +94,15 @@ static Padsynth_sample_map* new_Padsynth_sample_map(
         double max_pitch,
         double center_pitch)
 {
-    assert(sample_count > 0);
-    assert(sample_count <= 128);
-    assert(sample_length >= PADSYNTH_MIN_SAMPLE_LENGTH);
-    assert(sample_length <= PADSYNTH_MAX_SAMPLE_LENGTH);
-    assert(is_p2(sample_length));
-    assert(isfinite(min_pitch));
-    assert(isfinite(max_pitch));
-    assert(min_pitch <= max_pitch);
-    assert(isfinite(center_pitch));
+    rassert(sample_count > 0);
+    rassert(sample_count <= 128);
+    rassert(sample_length >= PADSYNTH_MIN_SAMPLE_LENGTH);
+    rassert(sample_length <= PADSYNTH_MAX_SAMPLE_LENGTH);
+    rassert(is_p2(sample_length));
+    rassert(isfinite(min_pitch));
+    rassert(isfinite(max_pitch));
+    rassert(min_pitch <= max_pitch);
+    rassert(isfinite(center_pitch));
 
     Padsynth_sample_map* sm = memory_alloc_item(Padsynth_sample_map);
     if (sm == NULL)
@@ -172,8 +172,8 @@ static Padsynth_sample_map* new_Padsynth_sample_map(
 static void Padsynth_sample_map_set_center_pitch(
         Padsynth_sample_map* sm, double center_pitch)
 {
-    assert(sm != NULL);
-    assert(isfinite(center_pitch));
+    rassert(sm != NULL);
+    rassert(isfinite(center_pitch));
 
     sm->center_pitch = center_pitch;
 
@@ -184,10 +184,10 @@ static void Padsynth_sample_map_set_center_pitch(
 static void Padsynth_sample_map_set_pitch_range(
         Padsynth_sample_map* sm, double min_pitch, double max_pitch)
 {
-    assert(sm != NULL);
-    assert(isfinite(min_pitch));
-    assert(isfinite(max_pitch));
-    assert(min_pitch <= max_pitch);
+    rassert(sm != NULL);
+    rassert(isfinite(min_pitch));
+    rassert(isfinite(max_pitch));
+    rassert(min_pitch <= max_pitch);
 
     if (sm->min_pitch == min_pitch && sm->max_pitch == max_pitch)
         return;
@@ -201,14 +201,14 @@ static void Padsynth_sample_map_set_pitch_range(
     Padsynth_sample_entry* entry = AAiter_get_at_least(iter, key);
     for (int i = 0; i < sm->sample_count; ++i)
     {
-        assert(entry != NULL);
+        rassert(entry != NULL);
         entry->center_pitch =
             lerp(min_pitch, max_pitch, i / (double)(sm->sample_count - 1));
 
         entry = AAiter_get_next(iter);
     }
 
-    assert(entry == NULL);
+    rassert(entry == NULL);
 
     return;
 }
@@ -217,8 +217,8 @@ static void Padsynth_sample_map_set_pitch_range(
 const Padsynth_sample_entry* Padsynth_sample_map_get_entry(
         const Padsynth_sample_map* sm, double pitch)
 {
-    assert(sm != NULL);
-    assert(isfinite(pitch));
+    rassert(sm != NULL);
+    rassert(isfinite(pitch));
 
     const Padsynth_sample_entry* key = PADSYNTH_SAMPLE_ENTRY_KEY(pitch);
     const Padsynth_sample_entry* prev = AAtree_get_at_most(sm->map, key);
@@ -237,7 +237,7 @@ const Padsynth_sample_entry* Padsynth_sample_map_get_entry(
 
 int32_t Padsynth_sample_map_get_sample_length(const Padsynth_sample_map* sm)
 {
-    assert(sm != NULL);
+    rassert(sm != NULL);
     return sm->sample_length;
 }
 
@@ -299,7 +299,7 @@ Device_impl* new_Proc_padsynth(void)
 static bool Proc_padsynth_set_params(
         Device_impl* dimpl, const Key_indices indices, const Padsynth_params* params)
 {
-    assert(dimpl != NULL);
+    rassert(dimpl != NULL);
     ignore(indices);
 
     Proc_padsynth* padsynth = (Proc_padsynth*)dimpl;
@@ -311,8 +311,8 @@ static bool Proc_padsynth_set_params(
 static bool Proc_padsynth_set_ramp_attack(
         Device_impl* dimpl, const Key_indices indices, bool enabled)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_padsynth* padsynth = (Proc_padsynth*)dimpl;
     padsynth->is_ramp_attack_enabled = enabled;
@@ -324,8 +324,8 @@ static bool Proc_padsynth_set_ramp_attack(
 static bool Proc_padsynth_set_stereo(
         Device_impl* dimpl, const Key_indices indices, bool enabled)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_padsynth* padsynth = (Proc_padsynth*)dimpl;
     padsynth->is_stereo_enabled = enabled;
@@ -346,8 +346,8 @@ static double profile(double freq_i, double bandwidth_i)
 
 static double get_profile_bound(double bandwidth_i)
 {
-    assert(isfinite(bandwidth_i));
-    assert(bandwidth_i > 0);
+    rassert(isfinite(bandwidth_i));
+    rassert(bandwidth_i > 0);
 
     return 5.2247 * bandwidth_i; // 5.2247 ~ sqrt(27.2972), see profile() above
 }
@@ -361,10 +361,10 @@ static void make_padsynth_sample(
         const float* Ws,
         const Padsynth_params* params)
 {
-    assert(entry != NULL);
-    assert(freq_amp != NULL);
-    assert(freq_phase != NULL);
-    assert(Ws != NULL);
+    rassert(entry != NULL);
+    rassert(freq_amp != NULL);
+    rassert(freq_phase != NULL);
+    rassert(Ws != NULL);
 
     int32_t sample_length = PADSYNTH_DEFAULT_SAMPLE_LENGTH;
     if (params != NULL)
@@ -412,8 +412,8 @@ static void make_padsynth_sample(
             if (buf_start >= buf_length || buf_stop <= 0)
                 continue;
 
-            //assert(profile((buf_start - 1) / (double)sample_length - freq_i, bandwidth_i) == 0.0);
-            //assert(profile((buf_stop + 1) / (double)sample_length - freq_i, bandwidth_i) == 0.0);
+            //rassert(profile((buf_start - 1) / (double)sample_length - freq_i, bandwidth_i) == 0.0);
+            //rassert(profile((buf_stop + 1) / (double)sample_length - freq_i, bandwidth_i) == 0.0);
 
             buf_start = max(0, buf_start);
             buf_stop = min(buf_stop, buf_length);
@@ -483,7 +483,7 @@ static void make_padsynth_sample(
 
 static bool apply_padsynth(Proc_padsynth* padsynth, const Padsynth_params* params)
 {
-    assert(padsynth != NULL);
+    rassert(padsynth != NULL);
 
     int32_t sample_length = PADSYNTH_DEFAULT_SAMPLE_LENGTH;
     int sample_count = 1;
@@ -567,7 +567,7 @@ static bool apply_padsynth(Proc_padsynth* padsynth, const Padsynth_params* param
         const Padsynth_sample_entry* key = PADSYNTH_SAMPLE_ENTRY_KEY(-INFINITY);
         Padsynth_sample_entry* entry =
             AAtree_get_at_least(padsynth->sample_map->map, key);
-        assert(entry != NULL);
+        rassert(entry != NULL);
 
         make_padsynth_sample(entry, &padsynth->random, freq_amp, freq_phase, Ws, NULL);
     }

--- a/src/lib/init/devices/processors/Proc_panning.c
+++ b/src/lib/init/devices/processors/Proc_panning.c
@@ -66,9 +66,9 @@ Device_impl* new_Proc_panning(void)
 static bool Proc_panning_set_panning(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Proc_panning* panning = (Proc_panning*)dimpl;
     panning->panning = value;

--- a/src/lib/init/devices/processors/Proc_stream.c
+++ b/src/lib/init/devices/processors/Proc_stream.c
@@ -76,8 +76,8 @@ Device_impl* new_Proc_stream(void)
 static bool Proc_stream_set_init_value(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_stream* stream = (Proc_stream*)dimpl;
     stream->init_value = isfinite(value) ? value : 0.0;
@@ -89,8 +89,8 @@ static bool Proc_stream_set_init_value(
 static bool Proc_stream_set_init_osc_speed(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_stream* stream = (Proc_stream*)dimpl;
     stream->init_osc_speed = (isfinite(value) && (value >= 0)) ? value : 0.0;
@@ -102,8 +102,8 @@ static bool Proc_stream_set_init_osc_speed(
 static bool Proc_stream_set_init_osc_depth(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_stream* stream = (Proc_stream*)dimpl;
     stream->init_osc_depth = (isfinite(value) && (value >= 0)) ? value : 0.0;

--- a/src/lib/init/devices/processors/Proc_volume.c
+++ b/src/lib/init/devices/processors/Proc_volume.c
@@ -69,8 +69,8 @@ Device_impl* new_Proc_volume(void)
 static bool Proc_volume_set_volume(
         Device_impl* dimpl, const Key_indices indices, double value)
 {
-    assert(dimpl != NULL);
-    assert(indices != NULL);
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
 
     Proc_volume* volume = (Proc_volume*)dimpl;
     volume->volume = isfinite(value) ? value : 0.0;

--- a/src/lib/init/manifest.c
+++ b/src/lib/init/manifest.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2016
  *
  * This file is part of Kunquat.
  *
@@ -22,7 +22,7 @@
 
 static bool read_manifest_entry(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(key);
     ignore(userdata);
 
@@ -31,7 +31,7 @@ static bool read_manifest_entry(Streader* sr, const char* key, void* userdata)
 
 bool read_default_manifest(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;

--- a/src/lib/init/sheet/Channel_defaults.c
+++ b/src/lib/init/sheet/Channel_defaults.c
@@ -28,7 +28,7 @@
 
 Channel_defaults* Channel_defaults_init(Channel_defaults* chd)
 {
-    assert(chd != NULL);
+    rassert(chd != NULL);
 
     chd->control_num = 0;
     memset(chd->init_expr, '\0', KQT_VAR_NAME_MAX);
@@ -39,9 +39,9 @@ Channel_defaults* Channel_defaults_init(Channel_defaults* chd)
 
 static bool read_ch_defaults_item(Streader* sr, const char* key, void* userdata)
 {
-    assert(sr != NULL);
-    assert(key != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(key != NULL);
+    rassert(userdata != NULL);
 
     Channel_defaults* chd = userdata;
 
@@ -85,8 +85,8 @@ static bool read_ch_defaults_item(Streader* sr, const char* key, void* userdata)
 
 bool Channel_defaults_read(Channel_defaults* chd, Streader* sr)
 {
-    assert(chd != NULL);
-    assert(sr != NULL);
+    rassert(chd != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;

--- a/src/lib/init/sheet/Channel_defaults_list.c
+++ b/src/lib/init/sheet/Channel_defaults_list.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2016
  *
  * This file is part of Kunquat.
  *
@@ -25,8 +25,8 @@
 
 static bool read_ch_defaults_item(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     Channel_defaults_list* cdl = userdata;
 
@@ -42,7 +42,7 @@ static bool read_ch_defaults_item(Streader* sr, int32_t index, void* userdata)
 
 Channel_defaults_list* new_Channel_defaults_list(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -73,9 +73,9 @@ Channel_defaults_list* new_Channel_defaults_list(Streader* sr)
 const Channel_defaults* Channel_defaults_list_get(
         const Channel_defaults_list* cdl, int32_t ch_index)
 {
-    assert(cdl != NULL);
-    assert(ch_index >= 0);
-    assert(ch_index < KQT_CHANNELS_MAX);
+    rassert(cdl != NULL);
+    rassert(ch_index >= 0);
+    rassert(ch_index < KQT_CHANNELS_MAX);
 
     return &cdl->ch_defaults[ch_index];
 }

--- a/src/lib/init/sheet/Column.c
+++ b/src/lib/init/sheet/Column.c
@@ -47,8 +47,8 @@ static void del_Trigger_list(Trigger_list* trlist);
 
 static Trigger_list* new_Trigger_list(Trigger_list* nil, Trigger* trigger)
 {
-    assert(!(nil == NULL) || (trigger == NULL));
-    assert(!(trigger == NULL) || (nil == NULL));
+    rassert(!(nil == NULL) || (trigger == NULL));
+    rassert(!(trigger == NULL) || (nil == NULL));
 
     Trigger_list* trlist = memory_alloc_item(Trigger_list);
     if (trlist == NULL)
@@ -56,13 +56,13 @@ static Trigger_list* new_Trigger_list(Trigger_list* nil, Trigger* trigger)
 
     if (nil == NULL)
     {
-        assert(trigger == NULL);
+        rassert(trigger == NULL);
         trlist->trigger = NULL;
         trlist->prev = trlist->next = trlist;
     }
     else
     {
-        assert(trigger != NULL);
+        rassert(trigger != NULL);
         trlist->trigger = trigger;
         trlist->prev = trlist->next = nil;
     }
@@ -73,7 +73,7 @@ static Trigger_list* new_Trigger_list(Trigger_list* nil, Trigger* trigger)
 
 static Trigger_list* Trigger_list_init(Trigger_list* trlist)
 {
-    assert(trlist != NULL);
+    rassert(trlist != NULL);
     trlist->prev = trlist->next = trlist;
     return trlist;
 }
@@ -81,13 +81,13 @@ static Trigger_list* Trigger_list_init(Trigger_list* trlist)
 
 static int Trigger_list_cmp(const Trigger_list* list1, const Trigger_list* list2)
 {
-    assert(list1 != NULL);
-    assert(list2 != NULL);
+    rassert(list1 != NULL);
+    rassert(list2 != NULL);
 
     Trigger* ev1 = list1->next->trigger;
     Trigger* ev2 = list2->next->trigger;
-    assert(ev1 != NULL);
-    assert(ev2 != NULL);
+    rassert(ev1 != NULL);
+    rassert(ev2 != NULL);
 
     return Tstamp_cmp(Trigger_get_pos(ev1), Trigger_get_pos(ev2));
 }
@@ -114,7 +114,7 @@ Column_iter* new_Column_iter(Column* col)
 
 void Column_iter_init(Column_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     iter->version = 0;
     iter->col = NULL;
@@ -127,8 +127,8 @@ void Column_iter_init(Column_iter* iter)
 
 void Column_iter_change_col(Column_iter* iter, Column* col)
 {
-    assert(iter != NULL);
-    assert(col != NULL);
+    rassert(iter != NULL);
+    rassert(col != NULL);
 
     iter->col = col;
     iter->version = col->version;
@@ -141,17 +141,17 @@ void Column_iter_change_col(Column_iter* iter, Column* col)
 
 Trigger* Column_iter_get(Column_iter* iter, const Tstamp* pos)
 {
-    assert(iter != NULL);
-    assert(pos != NULL);
+    rassert(iter != NULL);
+    rassert(pos != NULL);
 
     iter->trlist = Column_iter_get_row(iter, pos);
     if (iter->trlist == NULL)
         return NULL;
 
-    assert(iter->trlist->trigger == NULL);
-    assert(iter->trlist->next != iter->trlist);
+    rassert(iter->trlist->trigger == NULL);
+    rassert(iter->trlist->next != iter->trlist);
     iter->trlist = iter->trlist->next;
-    assert(iter->trlist->trigger != NULL);
+    rassert(iter->trlist->trigger != NULL);
 
     return iter->trlist->trigger;
 }
@@ -159,8 +159,8 @@ Trigger* Column_iter_get(Column_iter* iter, const Tstamp* pos)
 
 Trigger_list* Column_iter_get_row(Column_iter* iter, const Tstamp* pos)
 {
-    assert(iter != NULL);
-    assert(pos != NULL);
+    rassert(iter != NULL);
+    rassert(pos != NULL);
 
     if (iter->col == NULL)
         return NULL;
@@ -177,7 +177,7 @@ Trigger_list* Column_iter_get_row(Column_iter* iter, const Tstamp* pos)
 
 Trigger* Column_iter_get_next(Column_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     if (iter->trlist == NULL || iter->col == NULL)
         return NULL;
@@ -189,8 +189,8 @@ Trigger* Column_iter_get_next(Column_iter* iter)
         return NULL;
     }
 
-    assert(iter->trlist->trigger != NULL);
-    assert(iter->trlist != iter->trlist->next);
+    rassert(iter->trlist->trigger != NULL);
+    rassert(iter->trlist != iter->trlist->next);
 
     iter->trlist = iter->trlist->next;
     if (iter->trlist->trigger != NULL)
@@ -200,10 +200,10 @@ Trigger* Column_iter_get_next(Column_iter* iter)
     if (iter->trlist == NULL)
         return NULL;
 
-    assert(iter->trlist->trigger == NULL);
-    assert(iter->trlist->next != iter->trlist);
+    rassert(iter->trlist->trigger == NULL);
+    rassert(iter->trlist->next != iter->trlist);
     iter->trlist = iter->trlist->next;
-    assert(iter->trlist->trigger != NULL);
+    rassert(iter->trlist->trigger != NULL);
 
     return iter->trlist->trigger;
 }
@@ -211,7 +211,7 @@ Trigger* Column_iter_get_next(Column_iter* iter)
 
 Trigger_list* Column_iter_get_next_row(Column_iter* iter)
 {
-    assert(iter != NULL);
+    rassert(iter != NULL);
 
     if (iter->trlist == NULL || iter->col == NULL)
         return NULL;
@@ -277,8 +277,8 @@ Column* new_Column(const Tstamp* len)
 Column* new_Column_from_string(
         Streader* sr, const Tstamp* len, const Event_names* event_names)
 {
-    assert(sr != NULL);
-    assert(event_names != NULL);
+    rassert(sr != NULL);
+    rassert(event_names != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -305,9 +305,9 @@ typedef struct Read_trigger_data
 
 static bool read_trigger(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     ignore(index);
-    assert(userdata != NULL);
+    rassert(userdata != NULL);
 
     Read_trigger_data* rtdata = userdata;
 
@@ -323,9 +323,9 @@ static bool read_trigger(Streader* sr, int32_t index, void* userdata)
 
 static bool Column_parse(Column* col, Streader* sr, const Event_names* event_names)
 {
-    assert(col != NULL);
-    assert(sr != NULL);
-    assert(event_names != NULL);
+    rassert(col != NULL);
+    rassert(sr != NULL);
+    rassert(event_names != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -343,8 +343,8 @@ static bool Column_parse(Column* col, Streader* sr, const Event_names* event_nam
 
 bool Column_ins(Column* col, Trigger* trigger)
 {
-    assert(col != NULL);
-    assert(trigger != NULL);
+    rassert(col != NULL);
+    rassert(trigger != NULL);
 
     ++col->version;
     Trigger_list* key = Trigger_list_init(&(Trigger_list){ .trigger = trigger });
@@ -376,9 +376,9 @@ bool Column_ins(Column* col, Trigger* trigger)
         return true;
     }
 
-    assert(ret->next != ret);
-    assert(ret->prev != ret);
-    assert(ret->trigger == NULL);
+    rassert(ret->next != ret);
+    rassert(ret->prev != ret);
+    rassert(ret->trigger == NULL);
 
     Trigger_list* node = new_Trigger_list(ret, trigger);
     if (node == NULL)
@@ -411,20 +411,20 @@ static void del_Trigger_list(Trigger_list* trlist)
     if (trlist == NULL)
         return;
 
-    assert(trlist->trigger == NULL);
+    rassert(trlist->trigger == NULL);
     Trigger_list* cur = trlist->next;
-    assert(cur->trigger != NULL);
+    rassert(cur->trigger != NULL);
 
     while (cur->trigger != NULL)
     {
         Trigger_list* next = cur->next;
-        assert(cur->trigger != NULL);
+        rassert(cur->trigger != NULL);
         del_Trigger(cur->trigger);
         memory_free(cur);
         cur = next;
     }
 
-    assert(cur == trlist);
+    rassert(cur == trlist);
     memory_free(cur);
 
     return;

--- a/src/lib/init/sheet/Order_list.c
+++ b/src/lib/init/sheet/Order_list.c
@@ -36,7 +36,7 @@ typedef struct Index_mapping
 
 static Index_mapping* new_Index_mapping(Index_mapping* im)
 {
-    assert(im != NULL);
+    rassert(im != NULL);
 
     Index_mapping* new_im = memory_alloc_item(Index_mapping);
     if (new_im == NULL)
@@ -56,8 +56,8 @@ struct Order_list
 
 static bool read_piref(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     Order_list* ol = userdata;
 
@@ -102,7 +102,7 @@ static bool read_piref(Streader* sr, int32_t index, void* userdata)
 
 Order_list* new_Order_list(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -157,7 +157,7 @@ Order_list* new_Order_list(Streader* sr)
 
 int Order_list_get_len(const Order_list* ol)
 {
-    assert(ol != NULL);
+    rassert(ol != NULL);
 
     return (int)Vector_size(ol->pat_insts);
 }
@@ -165,8 +165,8 @@ int Order_list_get_len(const Order_list* ol)
 
 Pat_inst_ref* Order_list_get_pat_inst_ref(const Order_list* ol, int index)
 {
-    assert(ol != NULL);
-    assert(index < Order_list_get_len(ol));
+    rassert(ol != NULL);
+    rassert(index < Order_list_get_len(ol));
 
     return Vector_get_ref(ol->pat_insts, index);
 }
@@ -174,8 +174,8 @@ Pat_inst_ref* Order_list_get_pat_inst_ref(const Order_list* ol, int index)
 
 bool Order_list_contains_pat_inst_ref(const Order_list* ol, const Pat_inst_ref* piref)
 {
-    assert(ol != NULL);
-    assert(piref != NULL);
+    rassert(ol != NULL);
+    rassert(piref != NULL);
 
     for (int64_t i = 0; i < Vector_size(ol->pat_insts); ++i)
     {

--- a/src/lib/init/sheet/Pat_table.c
+++ b/src/lib/init/sheet/Pat_table.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -34,7 +34,7 @@ struct Pat_table
 
 Pat_table* new_Pat_table(int size)
 {
-    assert(size > 0);
+    rassert(size > 0);
 
     Pat_table* table = memory_alloc_item(Pat_table);
     if (table == NULL)
@@ -59,10 +59,10 @@ Pat_table* new_Pat_table(int size)
 
 bool Pat_table_set(Pat_table* table, int index, Pattern* pat)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
-    assert(pat != NULL);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
+    rassert(pat != NULL);
 
     return Etable_set(table->pats, index, pat);
 }
@@ -70,9 +70,9 @@ bool Pat_table_set(Pat_table* table, int index, Pattern* pat)
 
 void Pat_table_set_existent(Pat_table* table, int index, bool existent)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     Bit_array_set(table->existents, index, existent);
 
@@ -82,9 +82,9 @@ void Pat_table_set_existent(Pat_table* table, int index, bool existent)
 
 bool Pat_table_get_existent(const Pat_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     return Bit_array_get(table->existents, index);
 }
@@ -92,9 +92,9 @@ bool Pat_table_get_existent(const Pat_table* table, int index)
 
 Pattern* Pat_table_get(Pat_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     return Etable_get(table->pats, index);
 }
@@ -102,9 +102,9 @@ Pattern* Pat_table_get(Pat_table* table, int index)
 
 void Pat_table_remove(Pat_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index >= 0);
-    assert(index < table->size);
+    rassert(table != NULL);
+    rassert(index >= 0);
+    rassert(index < table->size);
 
     Etable_remove(table->pats, index);
 
@@ -114,7 +114,7 @@ void Pat_table_remove(Pat_table* table, int index)
 
 void Pat_table_clear(Pat_table* table)
 {
-    assert(table != NULL);
+    rassert(table != NULL);
     Etable_clear(table->pats);
     return;
 }

--- a/src/lib/init/sheet/Pattern.c
+++ b/src/lib/init/sheet/Pattern.c
@@ -70,8 +70,8 @@ Pattern* new_Pattern(void)
 
 bool Pattern_read_length(Pattern* pat, Streader* sr)
 {
-    assert(pat != NULL);
-    assert(sr != NULL);
+    rassert(pat != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -95,9 +95,9 @@ bool Pattern_read_length(Pattern* pat, Streader* sr)
 
 void Pattern_set_inst_existent(Pattern* pat, int index, bool existent)
 {
-    assert(pat != NULL);
-    assert(index >= 0);
-    assert(index < KQT_PAT_INSTANCES_MAX);
+    rassert(pat != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_PAT_INSTANCES_MAX);
 
     Bit_array_set(pat->existents, index, existent);
 
@@ -107,9 +107,9 @@ void Pattern_set_inst_existent(Pattern* pat, int index, bool existent)
 
 bool Pattern_get_inst_existent(const Pattern* pat, int index)
 {
-    assert(pat != NULL);
-    assert(index >= 0);
-    assert(index < KQT_PAT_INSTANCES_MAX);
+    rassert(pat != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_PAT_INSTANCES_MAX);
 
     return Bit_array_get(pat->existents, index);
 }
@@ -117,10 +117,10 @@ bool Pattern_get_inst_existent(const Pattern* pat, int index)
 
 bool Pattern_set_column(Pattern* pat, int index, Column* col)
 {
-    assert(pat != NULL);
-    assert(index >= 0);
-    assert(index < KQT_COLUMNS_MAX);
-    assert(col != NULL);
+    rassert(pat != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_COLUMNS_MAX);
+    rassert(col != NULL);
 
     Column* old_col = pat->cols[index];
     pat->cols[index] = col;
@@ -132,9 +132,9 @@ bool Pattern_set_column(Pattern* pat, int index, Column* col)
 
 Column* Pattern_get_column(const Pattern* pat, int index)
 {
-    assert(pat != NULL);
-    assert(index >= 0);
-    assert(index < KQT_COLUMNS_MAX);
+    rassert(pat != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_COLUMNS_MAX);
 
     return pat->cols[index];
 }
@@ -142,7 +142,7 @@ Column* Pattern_get_column(const Pattern* pat, int index)
 
 const Tstamp* Pattern_get_length(const Pattern* pat)
 {
-    assert(pat != NULL);
+    rassert(pat != NULL);
     return &pat->length;
 }
 

--- a/src/lib/init/sheet/Song.c
+++ b/src/lib/init/sheet/Song.c
@@ -46,8 +46,8 @@ Song* new_Song(void)
 
 bool Song_read_tempo(Song* song, Streader* sr)
 {
-    assert(song != NULL);
-    assert(sr != NULL);
+    rassert(song != NULL);
+    rassert(sr != NULL);
 
     double tempo = NAN;
 
@@ -69,15 +69,15 @@ bool Song_read_tempo(Song* song, Streader* sr)
 
 double Song_get_tempo(const Song* song)
 {
-    assert(song != NULL);
+    rassert(song != NULL);
     return song->tempo;
 }
 
 
 bool Song_read_global_vol(Song* song, Streader* sr)
 {
-    assert(song != NULL);
-    assert(sr != NULL);
+    rassert(song != NULL);
+    rassert(sr != NULL);
 
     double vol = NAN;
 
@@ -94,7 +94,7 @@ bool Song_read_global_vol(Song* song, Streader* sr)
 
 double Song_get_global_vol(const Song* song)
 {
-    assert(song != NULL);
+    rassert(song != NULL);
     return song->global_vol;
 }
 

--- a/src/lib/init/sheet/Song_table.c
+++ b/src/lib/init/sheet/Song_table.c
@@ -57,9 +57,9 @@ Song_table* new_Song_table(void)
 
 bool Song_table_set(Song_table* table, int index, Song* song)
 {
-    assert(table != NULL);
-    assert(index < KQT_SONGS_MAX);
-    assert(song != NULL);
+    rassert(table != NULL);
+    rassert(index < KQT_SONGS_MAX);
+    rassert(song != NULL);
 
     if (!Etable_set(table->songs, index, song))
         return false;
@@ -80,8 +80,8 @@ bool Song_table_set(Song_table* table, int index, Song* song)
 
 Song* Song_table_get(Song_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index < KQT_SONGS_MAX);
+    rassert(table != NULL);
+    rassert(index < KQT_SONGS_MAX);
 
     if (index >= table->effective_size)
         return NULL;
@@ -92,8 +92,8 @@ Song* Song_table_get(Song_table* table, int index)
 
 void Song_table_set_existent(Song_table* table, int index, bool existent)
 {
-    assert(table != NULL);
-    assert(index < KQT_SONGS_MAX);
+    rassert(table != NULL);
+    rassert(index < KQT_SONGS_MAX);
 
     Bit_array_set(table->existents, index, existent);
 
@@ -103,8 +103,8 @@ void Song_table_set_existent(Song_table* table, int index, bool existent)
 
 bool Song_table_get_existent(Song_table* table, int index)
 {
-    assert(table != NULL);
-    assert(index < KQT_SONGS_MAX);
+    rassert(table != NULL);
+    rassert(index < KQT_SONGS_MAX);
 
     return Bit_array_get(table->existents, index);
 }

--- a/src/lib/init/sheet/Track_list.c
+++ b/src/lib/init/sheet/Track_list.c
@@ -38,8 +38,8 @@ typedef struct read_data
 
 static bool read_song(Streader* sr, int32_t index, void* userdata)
 {
-    assert(sr != NULL);
-    assert(userdata != NULL);
+    rassert(sr != NULL);
+    rassert(userdata != NULL);
 
     if (index >= KQT_TRACKS_MAX)
     {
@@ -80,7 +80,7 @@ static bool read_song(Streader* sr, int32_t index, void* userdata)
 
 Track_list* new_Track_list(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -124,28 +124,28 @@ Track_list* new_Track_list(Streader* sr)
 
 int Track_list_get_len(const Track_list* tl)
 {
-    assert(tl != NULL);
+    rassert(tl != NULL);
     return (int)Vector_size(tl->songs);
 }
 
 
 int Track_list_get_song_index(const Track_list* tl, int index)
 {
-    assert(tl != NULL);
-    assert(index < Track_list_get_len(tl));
+    rassert(tl != NULL);
+    rassert(index < Track_list_get_len(tl));
 
     int16_t song_index = -1;
     Vector_get(tl->songs, index, &song_index);
 
-    assert(song_index >= 0);
+    rassert(song_index >= 0);
     return song_index;
 }
 
 
 int Track_list_get_track_by_song(const Track_list* tl, int song_index)
 {
-    assert(tl != NULL);
-    assert(song_index >= 0);
+    rassert(tl != NULL);
+    rassert(song_index >= 0);
 
     for (int64_t i = 0; i < Vector_size(tl->songs); ++i)
     {

--- a/src/lib/init/sheet/Trigger.c
+++ b/src/lib/init/sheet/Trigger.c
@@ -24,8 +24,8 @@
 
 Trigger* new_Trigger(Event_type type, Tstamp* pos)
 {
-    assert(Event_is_valid(type));
-    assert(pos != NULL);
+    rassert(Event_is_valid(type));
+    rassert(pos != NULL);
 
     Trigger* trigger = memory_alloc_item(Trigger);
     if (trigger == NULL)
@@ -41,8 +41,8 @@ Trigger* new_Trigger(Event_type type, Tstamp* pos)
 
 Trigger* new_Trigger_from_string(Streader* sr, const Event_names* names)
 {
-    assert(sr != NULL);
-    assert(names != NULL);
+    rassert(sr != NULL);
+    rassert(names != NULL);
 
     if (Streader_is_error_set(sr))
         return NULL;
@@ -119,21 +119,21 @@ Trigger* new_Trigger_from_string(Streader* sr, const Event_names* names)
 
 const Tstamp* Trigger_get_pos(const Trigger* trigger)
 {
-    assert(trigger != NULL);
+    rassert(trigger != NULL);
     return &trigger->pos;
 }
 
 
 Event_type Trigger_get_type(const Trigger* trigger)
 {
-    assert(trigger != NULL);
+    rassert(trigger != NULL);
     return trigger->type;
 }
 
 
 const char* Trigger_get_desc(const Trigger* trigger)
 {
-    assert(trigger != NULL);
+    rassert(trigger != NULL);
     return trigger->desc;
 }
 
@@ -143,7 +143,7 @@ void del_Trigger(Trigger* trigger)
     if (trigger == NULL)
         return;
 
-    assert(Event_is_valid(trigger->type));
+    rassert(Event_is_valid(trigger->type));
     memory_free(trigger->desc);
     memory_free(trigger);
 

--- a/src/lib/mathnum/Random.c
+++ b/src/lib/mathnum/Random.c
@@ -29,9 +29,9 @@
 
 Random* Random_init(Random* random, const char* context)
 {
-    assert(random != NULL);
-    assert(context != NULL);
-    assert(strlen(context) <= CONTEXT_LEN_MAX);
+    rassert(random != NULL);
+    rassert(context != NULL);
+    rassert(strlen(context) <= CONTEXT_LEN_MAX);
 
     strcpy(random->context, context);
 
@@ -43,7 +43,7 @@ Random* Random_init(Random* random, const char* context)
 
 void Random_set_seed(Random* random, uint64_t seed)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
 
     uint64_t cseed = 0;
     uint64_t dummy = 0;
@@ -57,7 +57,7 @@ void Random_set_seed(Random* random, uint64_t seed)
 
 void Random_reset(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
     random->state = random->seed;
     return;
 }
@@ -65,7 +65,7 @@ void Random_reset(Random* random)
 
 uint64_t Random_get_uint64(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
 
     // multiplier and increment from Knuth
     random->state = 6364136223846793005ULL * random->state +
@@ -77,14 +77,14 @@ uint64_t Random_get_uint64(Random* random)
 
 uint32_t Random_get_uint32(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
     return (uint32_t)(Random_get_uint64(random) >> 32);
 }
 
 
 double Random_get_float_lb(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
     return
         (double)(Random_get_uint64(random) >> EXCESS_DOUBLE_BITS) / (double)DOUBLE_LIMIT;
 }
@@ -92,8 +92,8 @@ double Random_get_float_lb(Random* random)
 
 int32_t Random_get_index(Random* random, int32_t size)
 {
-    assert(random != NULL);
-    assert(size > 0);
+    rassert(random != NULL);
+    rassert(size > 0);
 
     return (int32_t)(Random_get_uint64(random) >> 33) % size;
 }
@@ -101,7 +101,7 @@ int32_t Random_get_index(Random* random, int32_t size)
 
 double Random_get_float_scale(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
     return
         (double)(Random_get_uint64(random) >> EXCESS_DOUBLE_BITS) /
         (double)(DOUBLE_LIMIT - 1);
@@ -110,7 +110,7 @@ double Random_get_float_scale(Random* random)
 
 double Random_get_float_signal(Random* random)
 {
-    assert(random != NULL);
+    rassert(random != NULL);
 
     static const int64_t max_val_abs = (DOUBLE_LIMIT >> 1) - 1;
 

--- a/src/lib/mathnum/Tstamp.c
+++ b/src/lib/mathnum/Tstamp.c
@@ -29,7 +29,7 @@
         rassert((ts) != NULL);                \
         rassert((ts)->rem >= 0);              \
         rassert((ts)->rem < KQT_TSTAMP_BEAT); \
-    } else (void)0
+    } else ignore(0)
 #else
     #define Tstamp_validate(ts) (ignore(ts))
 #endif

--- a/src/lib/mathnum/Tstamp.c
+++ b/src/lib/mathnum/Tstamp.c
@@ -23,12 +23,12 @@
 
 
 #ifndef NDEBUG
-    #define Tstamp_validate(ts)              \
-    if (true)                                \
-    {                                        \
-        assert((ts) != NULL);                \
-        assert((ts)->rem >= 0);              \
-        assert((ts)->rem < KQT_TSTAMP_BEAT); \
+    #define Tstamp_validate(ts)               \
+    if (true)                                 \
+    {                                         \
+        rassert((ts) != NULL);                \
+        rassert((ts)->rem >= 0);              \
+        rassert((ts)->rem < KQT_TSTAMP_BEAT); \
     } else (void)0
 #else
     #define Tstamp_validate(ts) (ignore(ts))
@@ -37,7 +37,7 @@
 
 Tstamp* Tstamp_init(Tstamp* ts)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
 
     ts->beats = 0;
     ts->rem = 0;
@@ -65,9 +65,9 @@ int Tstamp_cmp(const Tstamp* ts1, const Tstamp* ts2)
 
 Tstamp* Tstamp_set(Tstamp* ts, int64_t beats, int32_t rem)
 {
-    assert(ts != NULL);
-    assert(rem >= 0);
-    assert(rem < KQT_TSTAMP_BEAT);
+    rassert(ts != NULL);
+    rassert(rem >= 0);
+    rassert(rem < KQT_TSTAMP_BEAT);
 
     ts->beats = beats;
     ts->rem = rem;
@@ -78,21 +78,21 @@ Tstamp* Tstamp_set(Tstamp* ts, int64_t beats, int32_t rem)
 
 int64_t Tstamp_get_beats(const Tstamp* ts)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
     return ts->beats;
 }
 
 
 int32_t Tstamp_get_rem(const Tstamp* ts)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
     return ts->rem;
 }
 
 
 Tstamp* Tstamp_add(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 {
-    assert(result != NULL);
+    rassert(result != NULL);
     Tstamp_validate(ts1);
     Tstamp_validate(ts2);
 
@@ -108,8 +108,8 @@ Tstamp* Tstamp_add(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
         --result->beats;
         result->rem += (int32_t)KQT_TSTAMP_BEAT;
     }
-    assert(result->rem >= 0);
-    assert(result->rem < KQT_TSTAMP_BEAT);
+    rassert(result->rem >= 0);
+    rassert(result->rem < KQT_TSTAMP_BEAT);
 
     return result;
 }
@@ -117,7 +117,7 @@ Tstamp* Tstamp_add(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 
 Tstamp* Tstamp_sub(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 {
-    assert(result != NULL);
+    rassert(result != NULL);
     Tstamp_validate(ts1);
     Tstamp_validate(ts2);
 
@@ -133,8 +133,8 @@ Tstamp* Tstamp_sub(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
         ++result->beats;
         result->rem -= (int32_t)KQT_TSTAMP_BEAT;
     }
-    assert(result->rem >= 0);
-    assert(result->rem < KQT_TSTAMP_BEAT);
+    rassert(result->rem >= 0);
+    rassert(result->rem < KQT_TSTAMP_BEAT);
 
     return result;
 }
@@ -142,7 +142,7 @@ Tstamp* Tstamp_sub(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 
 Tstamp* Tstamp_copy(Tstamp* dest, const Tstamp* src)
 {
-    assert(dest != NULL);
+    rassert(dest != NULL);
     Tstamp_validate(src);
 
     dest->beats = src->beats;
@@ -154,7 +154,7 @@ Tstamp* Tstamp_copy(Tstamp* dest, const Tstamp* src)
 
 Tstamp* Tstamp_min(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 {
-    assert(result != NULL);
+    rassert(result != NULL);
     Tstamp_validate(ts1);
     Tstamp_validate(ts2);
 
@@ -170,9 +170,9 @@ Tstamp* Tstamp_min(Tstamp* result, const Tstamp* ts1, const Tstamp* ts2)
 double Tstamp_toframes(const Tstamp* ts, double tempo, int32_t rate)
 {
     Tstamp_validate(ts);
-    assert(ts->beats >= 0);
-    assert(tempo > 0);
-    assert(rate > 0);
+    rassert(ts->beats >= 0);
+    rassert(tempo > 0);
+    rassert(rate > 0);
 
     return ((double)ts->beats + ((double)ts->rem / KQT_TSTAMP_BEAT)) *
             60 * rate / tempo;
@@ -181,10 +181,10 @@ double Tstamp_toframes(const Tstamp* ts, double tempo, int32_t rate)
 
 Tstamp* Tstamp_fromframes(Tstamp* ts, int32_t frames, double tempo, int32_t rate)
 {
-    assert(ts != NULL);
-    assert(frames >= 0);
-    assert(tempo > 0);
-    assert(rate > 0);
+    rassert(ts != NULL);
+    rassert(frames >= 0);
+    rassert(tempo > 0);
+    rassert(rate > 0);
 
     double val = (double)frames * tempo / rate / 60;
     ts->beats = (int64_t)val;

--- a/src/lib/mathnum/common.c
+++ b/src/lib/mathnum/common.c
@@ -22,14 +22,14 @@
 
 bool is_p2(int64_t x)
 {
-    assert(x > 0);
+    rassert(x > 0);
     return (x & (x - 1)) == 0;
 }
 
 
 int64_t next_p2(int64_t x)
 {
-    assert(x > 0);
+    rassert(x > 0);
 
     x |= x >> 1;
     x |= x >> 2;
@@ -44,7 +44,7 @@ int64_t next_p2(int64_t x)
 
 int64_t ceil_p2(int64_t x)
 {
-    assert(x > 0);
+    rassert(x > 0);
 
     if (is_p2(x))
         return x;
@@ -55,7 +55,7 @@ int64_t ceil_p2(int64_t x)
 
 int64_t ipowi(int64_t base, int64_t exp)
 {
-    assert(exp >= 0);
+    rassert(exp >= 0);
 
     if (exp == 0)
         return 1;
@@ -68,7 +68,7 @@ int64_t ipowi(int64_t base, int64_t exp)
 
 double powi(double base, int exp)
 {
-    assert(exp >= 0);
+    rassert(exp >= 0);
 
     double ret = 1.0;
     while (exp > 0)
@@ -86,9 +86,9 @@ double powi(double base, int exp)
 
 double get_range_norm(double value, double start_value, double end_value)
 {
-    assert(isfinite(value));
-    assert(isfinite(start_value));
-    assert(isfinite(end_value));
+    rassert(isfinite(value));
+    rassert(isfinite(start_value));
+    rassert(isfinite(end_value));
 
     if (start_value == end_value)
         return 0;

--- a/src/lib/mathnum/common.h
+++ b/src/lib/mathnum/common.h
@@ -109,7 +109,7 @@ double powi(double base, int exp);
  * \param t    The lerp parameter -- must be >= \c 0 and <= \c 1.
  */
 #define lerp(v1, v2, t) \
-    (assert((t) >= 0), assert((t) <= 1), (v1) + ((v2) - (v1)) * (t))
+    (rassert((t) >= 0), rassert((t) <= 1), (v1) + ((v2) - (v1)) * (t))
 
 
 /**

--- a/src/lib/mathnum/conversions.c
+++ b/src/lib/mathnum/conversions.c
@@ -21,21 +21,21 @@
 
 double dB_to_scale(double dB)
 {
-    assert(isfinite(dB) || (dB == -INFINITY));
+    rassert(isfinite(dB) || (dB == -INFINITY));
     return exp2(dB / 6.0);
 }
 
 
 double scale_to_dB(double scale)
 {
-    assert(scale >= 0);
+    rassert(scale >= 0);
     return log2(scale) * 6;
 }
 
 
 double cents_to_Hz(double cents)
 {
-    assert(isfinite(cents));
+    rassert(isfinite(cents));
     return exp2(cents / 1200.0) * 440;
 }
 

--- a/src/lib/mathnum/conversions.h
+++ b/src/lib/mathnum/conversions.h
@@ -42,7 +42,7 @@ double dB_to_scale(double dB);
  */
 static inline double fast_dB_to_scale(double dB)
 {
-    rassert(isfinite(dB) || (dB == -INFINITY));
+    dassert(isfinite(dB) || (dB == -INFINITY));
 
     if (dB == -INFINITY)
         return 0.0;
@@ -70,7 +70,7 @@ double scale_to_dB(double scale);
  */
 static inline double fast_scale_to_dB(double scale)
 {
-    rassert(scale >= 0);
+    dassert(scale >= 0);
     if (scale == 0)
         return -INFINITY;
 

--- a/src/lib/mathnum/conversions.h
+++ b/src/lib/mathnum/conversions.h
@@ -42,7 +42,7 @@ double dB_to_scale(double dB);
  */
 static inline double fast_dB_to_scale(double dB)
 {
-    assert(isfinite(dB) || (dB == -INFINITY));
+    rassert(isfinite(dB) || (dB == -INFINITY));
 
     if (dB == -INFINITY)
         return 0.0;
@@ -70,7 +70,7 @@ double scale_to_dB(double scale);
  */
 static inline double fast_scale_to_dB(double scale)
 {
-    assert(scale >= 0);
+    rassert(scale >= 0);
     if (scale == 0)
         return -INFINITY;
 

--- a/src/lib/mathnum/fast_exp2.h
+++ b/src/lib/mathnum/fast_exp2.h
@@ -33,7 +33,7 @@
  */
 static inline double fast_exp2(double x)
 {
-    assert(isfinite(x));
+    rassert(isfinite(x));
 
 #define K 3
 #define N (1 << K)
@@ -54,8 +54,8 @@ static inline double fast_exp2(double x)
 
     x *= N;
     const double i = floor(x + L);
-    assert(i >= INT_MIN);
-    assert(i <= INT_MAX);
+    rassert(i >= INT_MIN);
+    rassert(i <= INT_MAX);
     const int j = (int)i;
     const int k = j & (N - 1);
     return ldexp(b[k] * (x - i + A), j >> K);

--- a/src/lib/mathnum/fast_exp2.h
+++ b/src/lib/mathnum/fast_exp2.h
@@ -33,7 +33,7 @@
  */
 static inline double fast_exp2(double x)
 {
-    rassert(isfinite(x));
+    dassert(isfinite(x));
 
 #define K 3
 #define N (1 << K)
@@ -54,8 +54,8 @@ static inline double fast_exp2(double x)
 
     x *= N;
     const double i = floor(x + L);
-    rassert(i >= INT_MIN);
-    rassert(i <= INT_MAX);
+    dassert(i >= INT_MIN);
+    dassert(i <= INT_MAX);
     const int j = (int)i;
     const int k = j & (N - 1);
     return ldexp(b[k] * (x - i + A), j >> K);

--- a/src/lib/mathnum/fast_log2.h
+++ b/src/lib/mathnum/fast_log2.h
@@ -30,8 +30,8 @@
  */
 static inline double fast_log2(double x)
 {
-    rassert(isfinite(x));
-    rassert(x > 0);
+    dassert(isfinite(x));
+    dassert(x > 0);
 
     // Shift x to range [1, 2)
     int exp = 0;

--- a/src/lib/mathnum/fast_log2.h
+++ b/src/lib/mathnum/fast_log2.h
@@ -30,8 +30,8 @@
  */
 static inline double fast_log2(double x)
 {
-    assert(isfinite(x));
-    assert(x > 0);
+    rassert(isfinite(x));
+    rassert(x > 0);
 
     // Shift x to range [1, 2)
     int exp = 0;

--- a/src/lib/mathnum/fast_sin.h
+++ b/src/lib/mathnum/fast_sin.h
@@ -30,8 +30,8 @@
  */
 static inline double fast_sin(double x)
 {
-    assert(x >= 0);
-    assert(x <= 2.0 * PI);
+    rassert(x >= 0);
+    rassert(x <= 2.0 * PI);
 
     // Use a parabolic approximation based on:
     // http://forum.devmaster.net/t/fast-and-accurate-sine-cosine/9648

--- a/src/lib/mathnum/fast_sin.h
+++ b/src/lib/mathnum/fast_sin.h
@@ -30,8 +30,8 @@
  */
 static inline double fast_sin(double x)
 {
-    rassert(x >= 0);
-    rassert(x <= 2.0 * PI);
+    dassert(x >= 0);
+    dassert(x <= 2.0 * PI);
 
     // Use a parabolic approximation based on:
     // http://forum.devmaster.net/t/fast-and-accurate-sine-cosine/9648

--- a/src/lib/mathnum/hmac.c
+++ b/src/lib/mathnum/hmac.c
@@ -24,9 +24,9 @@
 
 void hmac_md5(uint64_t key, const char* msg, uint64_t* lower, uint64_t* upper)
 {
-    assert(msg != NULL);
-    assert(lower != NULL);
-    assert(upper != NULL);
+    rassert(msg != NULL);
+    rassert(lower != NULL);
+    rassert(upper != NULL);
 
     unsigned char key_str[64] = { 0 };
     for (int i = 0; i < 8; ++i)

--- a/src/lib/mathnum/irfft.c
+++ b/src/lib/mathnum/irfft.c
@@ -24,8 +24,8 @@
 
 static uint32_t reverse_bits(uint32_t n, int bit_count)
 {
-    assert(bit_count > 0);
-    assert(bit_count <= 31);
+    rassert(bit_count > 0);
+    rassert(bit_count <= 31);
 
     n = (uint32_t)(((n & 0xaaaaaaaaUL) >> 1) | ((n & 0x55555555UL) << 1));
     n = (uint32_t)(((n & 0xccccccccUL) >> 2) | ((n & 0x33333333UL) << 2));
@@ -39,8 +39,8 @@ static uint32_t reverse_bits(uint32_t n, int bit_count)
 
 static int get_bit_count(int32_t n)
 {
-    assert(n > 0);
-    assert(is_p2(n));
+    rassert(n > 0);
+    rassert(is_p2(n));
 
     int count = 0;
     n >>= 1;
@@ -56,7 +56,7 @@ static int get_bit_count(int32_t n)
 
 static void bit_reversal_permute(float* data, int32_t length)
 {
-    assert(is_p2(length));
+    rassert(is_p2(length));
 
     const int bit_count = get_bit_count(length);
 
@@ -77,9 +77,9 @@ static void bit_reversal_permute(float* data, int32_t length)
 
 void fill_Ws(float* Ws, int32_t tlength)
 {
-    assert(Ws != NULL);
-    assert(tlength >= 4);
-    assert(is_p2(tlength));
+    rassert(Ws != NULL);
+    rassert(tlength >= 4);
+    rassert(is_p2(tlength));
 
     const int32_t Wlength = tlength / 4;
 
@@ -96,14 +96,14 @@ void fill_Ws(float* Ws, int32_t tlength)
 
 void irfft(float* data, const float* Ws, int32_t length)
 {
-    assert(data != NULL);
-    assert(Ws != NULL);
-    assert(length > 0);
-    assert(is_p2(length));
+    rassert(data != NULL);
+    rassert(Ws != NULL);
+    rassert(length > 0);
+    rassert(is_p2(length));
 
     const int bit_count = get_bit_count(length);
-    assert(bit_count > 0);
-    assert(bit_count < 31);
+    rassert(bit_count > 0);
+    rassert(bit_count < 31);
 
     // Algorithmically mostly based on the description in the LaTeX documentation
     // of GNU Scientific Library, http://www.gnu.org/software/gsl/

--- a/src/lib/mathnum/md5.c
+++ b/src/lib/mathnum/md5.c
@@ -67,9 +67,9 @@ static const uint32_t T[] =
 
 void md5_str(const char* str, uint64_t* lower, uint64_t* upper)
 {
-    assert(str != NULL);
-    assert(lower != NULL);
-    assert(upper != NULL);
+    rassert(str != NULL);
+    rassert(lower != NULL);
+    rassert(upper != NULL);
 
     md5(str, (int)strlen(str), lower, upper, true);
 
@@ -79,10 +79,10 @@ void md5_str(const char* str, uint64_t* lower, uint64_t* upper)
 
 void md5(const char* seq, int len, uint64_t* lower, uint64_t* upper, bool complete)
 {
-    assert(seq != NULL);
-    assert(len >= 0);
-    assert(lower != NULL);
-    assert(upper != NULL);
+    rassert(seq != NULL);
+    rassert(len >= 0);
+    rassert(lower != NULL);
+    rassert(upper != NULL);
 
     const uint64_t a = 0x67452301ULL;
     const uint64_t b = 0xefcdab89ULL;
@@ -105,12 +105,12 @@ void md5_with_state(
         bool last,
         int prev_len)
 {
-    assert(seq != NULL);
-    assert(len >= 0);
-    assert(lower != NULL);
-    assert(upper != NULL);
-    assert(last || len % 64 == 0);
-    assert(prev_len >= 0);
+    rassert(seq != NULL);
+    rassert(len >= 0);
+    rassert(lower != NULL);
+    rassert(upper != NULL);
+    rassert(last || len % 64 == 0);
+    rassert(prev_len >= 0);
 
     int cur_len = len;
     len += prev_len;
@@ -158,8 +158,8 @@ void md5_with_state(
 
 static void prepare_X(uint32_t* X, const unsigned char* p)
 {
-    assert(X != NULL);
-    assert(p != NULL);
+    rassert(X != NULL);
+    rassert(p != NULL);
 
     for (int i = 0; i < 16; ++i)
     {
@@ -176,11 +176,11 @@ static void prepare_X(uint32_t* X, const unsigned char* p)
 static void md5_rounds(
         uint32_t* X, uint32_t* aa, uint32_t* bb, uint32_t* cc, uint32_t* dd)
 {
-    assert(X != NULL);
-    assert(aa != NULL);
-    assert(bb != NULL);
-    assert(cc != NULL);
-    assert(dd != NULL);
+    rassert(X != NULL);
+    rassert(aa != NULL);
+    rassert(bb != NULL);
+    rassert(cc != NULL);
+    rassert(dd != NULL);
 
     uint32_t a = *aa;
     uint32_t b = *bb;
@@ -236,7 +236,7 @@ static void md5_rounds(
 
 static void add_length(unsigned char* p, uint64_t len)
 {
-    assert(p != NULL);
+    rassert(p != NULL);
 
     len *= 8;
     for (int i = 0; i < 8; ++i)
@@ -275,8 +275,8 @@ static uint32_t I(uint32_t x, uint32_t y, uint32_t z)
 
 static uint32_t left_rotate(uint32_t value, int steps)
 {
-    assert(steps > 0);
-    assert(steps < 32);
+    rassert(steps > 0);
+    rassert(steps < 32);
 
     return (value << steps) | (value >> (32 - steps));
 }

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -33,7 +33,7 @@ static int32_t out_of_memory_error_steps = -1;
         {                                       \
             --out_of_memory_error_steps;        \
         }                                       \
-    } else (void)0
+    } else ignore(0)
 
 
 static int32_t total_alloc_count = 0;

--- a/src/lib/memory.c
+++ b/src/lib/memory.c
@@ -41,7 +41,7 @@ static int32_t total_alloc_count = 0;
 
 void* memory_alloc(int64_t size)
 {
-    assert(size >= 0);
+    rassert(size >= 0);
 
     if (size == 0)
         return NULL;
@@ -58,8 +58,8 @@ void* memory_alloc(int64_t size)
 
 void* memory_calloc(int64_t item_count, int64_t item_size)
 {
-    assert(item_count >= 0);
-    assert(item_size >= 0);
+    rassert(item_count >= 0);
+    rassert(item_size >= 0);
 
     if (item_count == 0 || item_size == 0)
         return NULL;
@@ -76,7 +76,7 @@ void* memory_calloc(int64_t item_count, int64_t item_size)
 
 void* memory_realloc(void* ptr, int64_t size)
 {
-    assert(size >= 0);
+    rassert(size >= 0);
 
     if (ptr == NULL)
         return memory_alloc(size);

--- a/src/lib/player/Active_jumps.c
+++ b/src/lib/player/Active_jumps.c
@@ -51,8 +51,8 @@ Active_jumps* new_Active_jumps(void)
 
 void Active_jumps_add_context(Active_jumps* jumps, AAnode* handle)
 {
-    assert(jumps != NULL);
-    assert(handle != NULL);
+    rassert(jumps != NULL);
+    rassert(handle != NULL);
 
     AAtree_attach(jumps->jumps, handle);
 
@@ -69,14 +69,14 @@ Jump_context* Active_jumps_get_next_context(
         int ch_num,
         int64_t order)
 {
-    assert(jumps != NULL);
-    assert(piref != NULL);
-    assert(piref->pat >= 0);
-    assert(piref->inst >= 0);
-    assert(row != NULL);
-    assert(ch_num >= 0);
-    assert(ch_num < KQT_CHANNELS_MAX);
-    assert(order >= 0);
+    rassert(jumps != NULL);
+    rassert(piref != NULL);
+    rassert(piref->pat >= 0);
+    rassert(piref->inst >= 0);
+    rassert(row != NULL);
+    rassert(ch_num >= 0);
+    rassert(ch_num < KQT_CHANNELS_MAX);
+    rassert(order >= 0);
 
     Jump_context* key = JUMP_CONTEXT_AUTO;
     key->piref = *piref;
@@ -96,11 +96,11 @@ Jump_context* Active_jumps_get_next_context(
 
 AAnode* Active_jumps_remove_context(Active_jumps* jumps, const Jump_context* jc)
 {
-    assert(jumps != NULL);
-    assert(jc != NULL);
-    assert(AAtree_contains(jumps->jumps, jc));
+    rassert(jumps != NULL);
+    rassert(jc != NULL);
+    rassert(AAtree_contains(jumps->jumps, jc));
 
-    assert(jumps->use_count > 0);
+    rassert(jumps->use_count > 0);
     --jumps->use_count;
 
     return AAtree_detach(jumps->jumps, jc);
@@ -109,8 +109,8 @@ AAnode* Active_jumps_remove_context(Active_jumps* jumps, const Jump_context* jc)
 
 void Active_jumps_reset(Active_jumps* jumps, Jump_cache* jcache)
 {
-    assert(jumps != NULL);
-    assert(jcache != NULL);
+    rassert(jumps != NULL);
+    rassert(jcache != NULL);
 
     Jump_context* key = JUMP_CONTEXT_AUTO;
     key->piref.pat = -1;
@@ -121,10 +121,10 @@ void Active_jumps_reset(Active_jumps* jumps, Jump_cache* jcache)
     while (cur != NULL)
     {
         AAnode* handle = AAtree_detach(jumps->jumps, cur);
-        assert(handle != NULL);
+        rassert(handle != NULL);
         Jump_cache_release_context(jcache, handle);
 
-        assert(jumps->use_count > 0);
+        rassert(jumps->use_count > 0);
         --jumps->use_count;
 
         cur = AAtree_get_at_least(jumps->jumps, key);
@@ -139,7 +139,7 @@ void del_Active_jumps(Active_jumps* jumps)
     if (jumps == NULL)
         return;
 
-    assert(jumps->use_count == 0);
+    rassert(jumps->use_count == 0);
 
     del_AAtree(jumps->jumps);
     memory_free(jumps);

--- a/src/lib/player/Active_names.c
+++ b/src/lib/player/Active_names.c
@@ -42,9 +42,9 @@ Active_names* new_Active_names(void)
 
 bool Active_names_set(Active_names* names, Active_cat cat, const char* name)
 {
-    assert(names != NULL);
-    assert(cat < ACTIVE_CAT_COUNT);
-    assert(name != NULL);
+    rassert(names != NULL);
+    rassert(cat < ACTIVE_CAT_COUNT);
+    rassert(name != NULL);
 
     const size_t length_limit =
         (cat == ACTIVE_CAT_CONTROL_VAR) ? KQT_KEY_LENGTH_MAX : KQT_VAR_NAME_MAX;
@@ -59,8 +59,8 @@ bool Active_names_set(Active_names* names, Active_cat cat, const char* name)
 
 const char* Active_names_get(const Active_names* names, Active_cat cat)
 {
-    assert(names != NULL);
-    assert(cat < ACTIVE_CAT_COUNT);
+    rassert(names != NULL);
+    rassert(cat < ACTIVE_CAT_COUNT);
 
     return names->names[cat];
 }
@@ -68,7 +68,7 @@ const char* Active_names_get(const Active_names* names, Active_cat cat)
 
 void Active_names_reset(Active_names* names)
 {
-    assert(names != NULL);
+    rassert(names != NULL);
     memset(names->names, '\0', sizeof(names->names));
     return;
 }

--- a/src/lib/player/Cgiter.c
+++ b/src/lib/player/Cgiter.c
@@ -23,10 +23,10 @@
 
 void Cgiter_init(Cgiter* cgiter, const Module* module, int col_index)
 {
-    assert(cgiter != NULL);
-    assert(module != NULL);
-    assert(col_index >= 0);
-    assert(col_index < KQT_COLUMNS_MAX);
+    rassert(cgiter != NULL);
+    rassert(module != NULL);
+    rassert(col_index >= 0);
+    rassert(col_index < KQT_COLUMNS_MAX);
 
     cgiter->module = module;
     cgiter->col_index = col_index;
@@ -47,11 +47,11 @@ void Cgiter_init(Cgiter* cgiter, const Module* module, int col_index)
 static const Pat_inst_ref* find_pat_inst_ref(
         const Module* module, int track, int system)
 {
-    assert(module != NULL);
-    assert(track >= 0);
-    assert(track < KQT_TRACKS_MAX);
-    assert(system >= 0);
-    assert(system < KQT_SYSTEMS_MAX);
+    rassert(module != NULL);
+    rassert(track >= 0);
+    rassert(track < KQT_TRACKS_MAX);
+    rassert(system >= 0);
+    rassert(system < KQT_SYSTEMS_MAX);
 
     const Track_list* tl = Module_get_track_list(module);
     if (tl != NULL && track < Track_list_get_len(tl))
@@ -61,7 +61,7 @@ static const Pat_inst_ref* find_pat_inst_ref(
         if (ol != NULL && system < Order_list_get_len(ol))
         {
             Pat_inst_ref* piref = Order_list_get_pat_inst_ref(ol, system);
-            assert(piref != NULL);
+            rassert(piref != NULL);
             return piref;
         }
     }
@@ -71,7 +71,7 @@ static const Pat_inst_ref* find_pat_inst_ref(
 
 void Cgiter_reset(Cgiter* cgiter, const Position* start_pos)
 {
-    assert(cgiter != NULL);
+    rassert(cgiter != NULL);
 
     if (Position_is_valid(start_pos))
     {
@@ -91,7 +91,7 @@ void Cgiter_reset(Cgiter* cgiter, const Position* start_pos)
     else
     {
         // Pattern playback mode
-        assert(Position_has_valid_pattern_pos(start_pos));
+        rassert(Position_has_valid_pattern_pos(start_pos));
         cgiter->pos = *start_pos;
 
         cgiter->is_pattern_playback_state = true;
@@ -119,7 +119,7 @@ void Cgiter_reset(Cgiter* cgiter, const Position* start_pos)
 
 const Trigger_row* Cgiter_get_trigger_row(Cgiter* cgiter)
 {
-    assert(cgiter != NULL);
+    rassert(cgiter != NULL);
 
     if (Cgiter_has_finished(cgiter))
         return NULL;
@@ -154,8 +154,8 @@ const Trigger_row* Cgiter_get_trigger_row(Cgiter* cgiter)
     cgiter->cur_tr.head = Column_iter_get_row(&cgiter->citer, &cgiter->pos.pat_pos);
     if (cgiter->cur_tr.head == NULL)
         return NULL;
-    assert(cgiter->cur_tr.head->next != NULL);
-    assert(cgiter->cur_tr.head->next->trigger != NULL);
+    rassert(cgiter->cur_tr.head->next != NULL);
+    rassert(cgiter->cur_tr.head->next->trigger != NULL);
     if (Tstamp_cmp(&cgiter->cur_tr.head->next->trigger->pos, &cgiter->pos.pat_pos) > 0)
         return NULL;
 
@@ -165,8 +165,8 @@ const Trigger_row* Cgiter_get_trigger_row(Cgiter* cgiter)
 
 void Cgiter_clear_returned_status(Cgiter* cgiter)
 {
-    assert(cgiter != NULL);
-    assert(cgiter->row_returned);
+    rassert(cgiter != NULL);
+    rassert(cgiter->row_returned);
 
     cgiter->row_returned = false;
 
@@ -176,9 +176,9 @@ void Cgiter_clear_returned_status(Cgiter* cgiter)
 
 bool Cgiter_peek(Cgiter* cgiter, Tstamp* dist)
 {
-    assert(cgiter != NULL);
-    assert(dist != NULL);
-    assert(Tstamp_cmp(dist, TSTAMP_AUTO) >= 0);
+    rassert(cgiter != NULL);
+    rassert(dist != NULL);
+    rassert(Tstamp_cmp(dist, TSTAMP_AUTO) >= 0);
 
     if (Cgiter_has_finished(cgiter))
         return false;
@@ -211,7 +211,7 @@ bool Cgiter_peek(Cgiter* cgiter, Tstamp* dist)
 
     // Check next trigger row
     Column* column = Pattern_get_column(pattern, cgiter->col_index);
-    assert(column != NULL);
+    rassert(column != NULL);
     Column_iter_change_col(&cgiter->citer, column);
 
     const Tstamp* epsilon = Tstamp_set(TSTAMP_AUTO, 0, 1);
@@ -220,8 +220,8 @@ bool Cgiter_peek(Cgiter* cgiter, Tstamp* dist)
 
     if (row != NULL)
     {
-        assert(row->next != NULL);
-        assert(row->next->trigger != NULL);
+        rassert(row->next != NULL);
+        rassert(row->next->trigger != NULL);
         if (Tstamp_cmp(&row->next->trigger->pos, pat_length) <= 0)
         {
             // Trigger row found inside this pattern
@@ -242,8 +242,8 @@ bool Cgiter_peek(Cgiter* cgiter, Tstamp* dist)
 
 static void Cgiter_go_to_next_system(Cgiter* cgiter)
 {
-    assert(cgiter != NULL);
-    assert(!cgiter->is_pattern_playback_state);
+    rassert(cgiter != NULL);
+    rassert(!cgiter->is_pattern_playback_state);
 
     Tstamp_set(&cgiter->pos.pat_pos, 0, 0);
 
@@ -262,9 +262,9 @@ static void Cgiter_go_to_next_system(Cgiter* cgiter)
 
 void Cgiter_move(Cgiter* cgiter, const Tstamp* dist)
 {
-    assert(cgiter != NULL);
-    assert(dist != NULL);
-    assert(Tstamp_cmp(dist, TSTAMP_AUTO) >= 0);
+    rassert(cgiter != NULL);
+    rassert(dist != NULL);
+    rassert(Tstamp_cmp(dist, TSTAMP_AUTO) >= 0);
 
     if (cgiter->pos.piref.pat < 0)
         return;
@@ -310,7 +310,7 @@ void Cgiter_move(Cgiter* cgiter, const Tstamp* dist)
 
 bool Cgiter_has_finished(const Cgiter* cgiter)
 {
-    assert(cgiter != NULL);
+    rassert(cgiter != NULL);
     return cgiter->has_finished;
 }
 

--- a/src/lib/player/Channel.c
+++ b/src/lib/player/Channel.c
@@ -30,11 +30,11 @@
 
 static bool Channel_init(Channel* ch, int num, Env_state* estate, const Module* module)
 {
-    assert(ch != NULL);
-    assert(num >= 0);
-    assert(num < KQT_COLUMNS_MAX);
-    assert(estate != NULL);
-    assert(module != NULL);
+    rassert(ch != NULL);
+    rassert(num >= 0);
+    rassert(num < KQT_COLUMNS_MAX);
+    rassert(estate != NULL);
+    rassert(module != NULL);
 
     General_state_preinit(&ch->parent);
 
@@ -70,13 +70,13 @@ Channel* new_Channel(
         double* tempo,
         int32_t* audio_rate)
 {
-    assert(num >= 0);
-    assert(num < KQT_CHANNELS_MAX);
-    assert(au_table != NULL);
-    assert(estate != NULL);
-    assert(voices != NULL);
-    assert(tempo != NULL);
-    assert(audio_rate != NULL);
+    rassert(num >= 0);
+    rassert(num < KQT_CHANNELS_MAX);
+    rassert(au_table != NULL);
+    rassert(estate != NULL);
+    rassert(voices != NULL);
+    rassert(tempo != NULL);
+    rassert(audio_rate != NULL);
 
     Channel* ch = memory_alloc_item(Channel);
     if (ch == NULL)
@@ -99,8 +99,8 @@ Channel* new_Channel(
 
 void Channel_set_audio_rate(Channel* ch, int32_t audio_rate)
 {
-    assert(ch != NULL);
-    assert(audio_rate > 0);
+    rassert(ch != NULL);
+    rassert(audio_rate > 0);
 
     Force_controls_set_audio_rate(&ch->force_controls, audio_rate);
     Pitch_controls_set_audio_rate(&ch->pitch_controls, audio_rate);
@@ -112,8 +112,8 @@ void Channel_set_audio_rate(Channel* ch, int32_t audio_rate)
 
 void Channel_set_tempo(Channel* ch, double tempo)
 {
-    assert(ch != NULL);
-    assert(tempo > 0);
+    rassert(ch != NULL);
+    rassert(tempo > 0);
 
     Force_controls_set_tempo(&ch->force_controls, tempo);
     Pitch_controls_set_tempo(&ch->pitch_controls, tempo);
@@ -125,7 +125,7 @@ void Channel_set_tempo(Channel* ch, double tempo)
 
 void Channel_set_random_seed(Channel* ch, uint64_t seed)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
 
     Random_set_seed(&ch->rand, seed);
 
@@ -135,8 +135,8 @@ void Channel_set_random_seed(Channel* ch, uint64_t seed)
 
 void Channel_set_event_cache(Channel* ch, Event_cache* cache)
 {
-    assert(ch != NULL);
-    assert(cache != NULL);
+    rassert(ch != NULL);
+    rassert(cache != NULL);
 
     del_Event_cache(ch->event_cache);
     ch->event_cache = cache;
@@ -147,7 +147,7 @@ void Channel_set_event_cache(Channel* ch, Event_cache* cache)
 
 void Channel_reset(Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
 
     General_state_reset(&ch->parent);
 
@@ -199,13 +199,13 @@ void Channel_reset(Channel* ch)
 
 void Channel_apply_defaults(Channel* ch, const Channel_defaults* ch_defaults)
 {
-    assert(ch != NULL);
-    assert(ch_defaults != NULL);
+    rassert(ch != NULL);
+    rassert(ch_defaults != NULL);
 
     ch->au_input = ch_defaults->control_num;
     bool success = Active_names_set(
             ch->parent.active_names, ACTIVE_CAT_INIT_EXPRESSION, ch_defaults->init_expr);
-    assert(success);
+    rassert(success);
 
     return;
 }
@@ -213,16 +213,16 @@ void Channel_apply_defaults(Channel* ch, const Channel_defaults* ch_defaults)
 
 Random* Channel_get_random_source(Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
     return &ch->rand;
 }
 
 
 Voice* Channel_get_fg_voice(Channel* ch, int proc_index)
 {
-    assert(ch != NULL);
-    assert(proc_index >= 0);
-    assert(proc_index < KQT_PROCESSORS_MAX);
+    rassert(ch != NULL);
+    rassert(proc_index >= 0);
+    rassert(proc_index < KQT_PROCESSORS_MAX);
 
     return ch->fg[proc_index];
 }
@@ -230,7 +230,7 @@ Voice* Channel_get_fg_voice(Channel* ch, int proc_index)
 
 double Channel_get_fg_force(const Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
 
     bool has_fg_voice = false;
     for (int i = 0; i < KQT_PROCESSORS_MAX; ++i)
@@ -250,28 +250,28 @@ double Channel_get_fg_force(const Channel* ch)
 
 const Channel_cv_state* Channel_get_cv_state(const Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
     return ch->cvstate;
 }
 
 
 Channel_cv_state* Channel_get_cv_state_mut(Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
     return ch->cvstate;
 }
 
 
 const Channel_stream_state* Channel_get_stream_state(const Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
     return ch->csstate;
 }
 
 
 Channel_stream_state* Channel_get_stream_state_mut(Channel* ch)
 {
-    assert(ch != NULL);
+    rassert(ch != NULL);
     return ch->csstate;
 }
 

--- a/src/lib/player/Channel_cv_state.c
+++ b/src/lib/player/Channel_cv_state.c
@@ -42,9 +42,9 @@ typedef struct Entry
 
 static Entry* Entry_init(Entry* entry, const char* var_name)
 {
-    assert(entry != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(entry != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
 
     strcpy(entry->var_name, var_name);
 
@@ -85,9 +85,9 @@ Channel_cv_state* new_Channel_cv_state(void)
 
 bool Channel_cv_state_add_entry(Channel_cv_state* state, const char* var_name)
 {
-    assert(state != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(state != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
 
     const Entry* entry = Entry_init(ENTRY_AUTO, var_name);
 
@@ -113,11 +113,11 @@ bool Channel_cv_state_add_entry(Channel_cv_state* state, const char* var_name)
 bool Channel_cv_state_set_value(
         Channel_cv_state* state, const char* var_name, const Value* value)
 {
-    assert(state != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
-    assert(value != NULL);
-    assert(Value_type_is_realtime(value->type));
+    rassert(state != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(value != NULL);
+    rassert(Value_type_is_realtime(value->type));
 
     const Entry* key = Entry_init(ENTRY_AUTO, var_name);
 
@@ -135,9 +135,9 @@ bool Channel_cv_state_set_value(
 const Value* Channel_cv_state_get_value(
         const Channel_cv_state* state, const char* var_name)
 {
-    assert(state != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(state != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
 
     const Entry* key = Entry_init(ENTRY_AUTO, var_name);
 
@@ -152,9 +152,9 @@ const Value* Channel_cv_state_get_value(
 bool Channel_cv_state_set_carrying_enabled(
         Channel_cv_state* state, const char* var_name, bool enabled)
 {
-    assert(state != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(state != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
 
     const Entry* key = Entry_init(ENTRY_AUTO, var_name);
 
@@ -171,9 +171,9 @@ bool Channel_cv_state_set_carrying_enabled(
 bool Channel_cv_state_is_carrying_enabled(
         const Channel_cv_state* state, const char* var_name)
 {
-    assert(state != NULL);
-    assert(var_name != NULL);
-    assert(strlen(var_name) < KQT_VAR_NAME_MAX);
+    rassert(state != NULL);
+    rassert(var_name != NULL);
+    rassert(strlen(var_name) < KQT_VAR_NAME_MAX);
 
     const Entry* key = Entry_init(ENTRY_AUTO, var_name);
 
@@ -187,7 +187,7 @@ bool Channel_cv_state_is_carrying_enabled(
 
 void Channel_cv_state_reset(Channel_cv_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     const Entry* key = Entry_init(ENTRY_AUTO, "");
 

--- a/src/lib/player/Channel_stream_state.c
+++ b/src/lib/player/Channel_stream_state.c
@@ -67,8 +67,8 @@ Channel_stream_state* new_Channel_stream_state(void)
 void Channel_stream_state_set_audio_rate(
         Channel_stream_state* state, int32_t audio_rate)
 {
-    assert(state != NULL);
-    assert(audio_rate > 0);
+    rassert(state != NULL);
+    rassert(audio_rate > 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, state->tree);
 
@@ -85,9 +85,9 @@ void Channel_stream_state_set_audio_rate(
 
 void Channel_stream_state_set_tempo(Channel_stream_state* state, double tempo)
 {
-    assert(state != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(state != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, state->tree);
 
@@ -105,9 +105,9 @@ void Channel_stream_state_set_tempo(Channel_stream_state* state, double tempo)
 bool Channel_stream_state_add_entry(
         Channel_stream_state* state, const char* stream_name)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     if (!AAtree_contains(state->tree, stream_name))
     {
@@ -134,10 +134,10 @@ bool Channel_stream_state_add_entry(
 bool Channel_stream_state_set_value(
         Channel_stream_state* state, const char* stream_name, double value)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(isfinite(value));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(isfinite(value));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -153,10 +153,10 @@ bool Channel_stream_state_set_value(
 bool Channel_stream_state_slide_target(
         Channel_stream_state* state, const char* stream_name, double value)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(isfinite(value));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(isfinite(value));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -171,10 +171,10 @@ bool Channel_stream_state_slide_target(
 bool Channel_stream_state_slide_length(
         Channel_stream_state* state, const char* stream_name, const Tstamp* length)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(length != NULL);
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(length != NULL);
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -189,10 +189,10 @@ bool Channel_stream_state_slide_length(
 bool Channel_stream_state_set_osc_speed(
         Channel_stream_state* state, const char* stream_name, double speed)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(isfinite(speed));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(isfinite(speed));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -207,10 +207,10 @@ bool Channel_stream_state_set_osc_speed(
 bool Channel_stream_state_set_osc_depth(
         Channel_stream_state* state, const char* stream_name, double depth)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(isfinite(depth));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(isfinite(depth));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -225,10 +225,10 @@ bool Channel_stream_state_set_osc_depth(
 bool Channel_stream_state_set_osc_speed_slide(
         Channel_stream_state* state, const char* stream_name, const Tstamp* length)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(length != NULL);
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(length != NULL);
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -243,10 +243,10 @@ bool Channel_stream_state_set_osc_speed_slide(
 bool Channel_stream_state_set_osc_depth_slide(
         Channel_stream_state* state, const char* stream_name, const Tstamp* length)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(length != NULL);
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(length != NULL);
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -263,10 +263,10 @@ bool Channel_stream_state_set_controls(
         const char* stream_name,
         const Linear_controls* controls)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
-    assert(controls != NULL);
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
+    rassert(controls != NULL);
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -282,9 +282,9 @@ bool Channel_stream_state_set_controls(
 const Linear_controls* Channel_stream_state_get_controls(
         const Channel_stream_state* state, const char* stream_name)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     const Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -297,9 +297,9 @@ const Linear_controls* Channel_stream_state_get_controls(
 bool Channel_stream_state_set_carrying_enabled(
         Channel_stream_state* state, const char* stream_name, bool enabled)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -314,9 +314,9 @@ bool Channel_stream_state_set_carrying_enabled(
 bool Channel_stream_state_is_carrying_enabled(
         const Channel_stream_state* state, const char* stream_name)
 {
-    assert(state != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(state != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     Entry* entry = AAtree_get_exact(state->tree, stream_name);
     if (entry == NULL)
@@ -328,8 +328,8 @@ bool Channel_stream_state_is_carrying_enabled(
 
 void Channel_stream_state_update(Channel_stream_state* state, int64_t step_count)
 {
-    assert(state != NULL);
-    assert(step_count >= 0);
+    rassert(state != NULL);
+    rassert(step_count >= 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, state->tree);
 
@@ -348,7 +348,7 @@ void Channel_stream_state_update(Channel_stream_state* state, int64_t step_count
 
 void Channel_stream_state_reset(Channel_stream_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, state->tree);
 

--- a/src/lib/player/Device_states.c
+++ b/src/lib/player/Device_states.c
@@ -53,9 +53,9 @@ Device_states* new_Device_states(void)
 
 bool Device_states_add_state(Device_states* states, Device_state* state)
 {
-    assert(states != NULL);
-    assert(state != NULL);
-    assert(!AAtree_contains(states->states, state));
+    rassert(states != NULL);
+    rassert(state != NULL);
+    rassert(!AAtree_contains(states->states, state));
 
     if (!AAtree_ins(states->states, state))
         return false;
@@ -68,11 +68,11 @@ bool Device_states_add_state(Device_states* states, Device_state* state)
 
 Device_state* Device_states_get_state(const Device_states* states, uint32_t id)
 {
-    assert(states != NULL);
-    assert(id > 0);
+    rassert(states != NULL);
+    rassert(id > 0);
 
     const Device_state* key = DEVICE_STATE_KEY(id);
-    assert(AAtree_contains(states->states, key));
+    rassert(AAtree_contains(states->states, key));
 
     return AAtree_get_exact(states->states, key);
 }
@@ -80,8 +80,8 @@ Device_state* Device_states_get_state(const Device_states* states, uint32_t id)
 
 void Device_states_remove_state(Device_states* states, uint32_t id)
 {
-    assert(states != NULL);
-    assert(id > 0);
+    rassert(states != NULL);
+    rassert(id > 0);
 
     const Device_state* key = DEVICE_STATE_KEY(id);
     del_Device_state(AAtree_remove(states->states, key));
@@ -92,8 +92,8 @@ void Device_states_remove_state(Device_states* states, uint32_t id)
 
 bool Device_states_set_audio_rate(Device_states* states, int32_t rate)
 {
-    assert(states != NULL);
-    assert(rate > 0);
+    rassert(states != NULL);
+    rassert(rate > 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -113,8 +113,8 @@ bool Device_states_set_audio_rate(Device_states* states, int32_t rate)
 
 bool Device_states_set_audio_buffer_size(Device_states* states, int32_t size)
 {
-    assert(states != NULL);
-    assert(size >= 0);
+    rassert(states != NULL);
+    rassert(size >= 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -135,8 +135,8 @@ bool Device_states_set_audio_buffer_size(Device_states* states, int32_t size)
 /*
 bool Device_states_allocate_space(Device_states* states, char* key)
 {
-    assert(states != NULL);
-    assert(key != NULL);
+    rassert(states != NULL);
+    rassert(key != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -158,7 +158,7 @@ bool Device_states_allocate_space(Device_states* states, char* key)
 void Device_states_clear_audio_buffers(
         Device_states* states, int32_t start, int32_t stop)
 {
-    assert(states != NULL);
+    rassert(states != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -177,9 +177,9 @@ void Device_states_clear_audio_buffers(
 
 void Device_states_set_tempo(Device_states* states, double tempo)
 {
-    assert(states != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(states != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -197,7 +197,7 @@ void Device_states_set_tempo(Device_states* states, double tempo)
 
 void Device_states_reset(Device_states* states)
 {
-    assert(states != NULL);
+    rassert(states != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 
@@ -215,7 +215,7 @@ void Device_states_reset(Device_states* states)
 
 void Device_states_reset_node_states(Device_states* states)
 {
-    assert(states != NULL);
+    rassert(states != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, states->states);
 

--- a/src/lib/player/Env_state.c
+++ b/src/lib/player/Env_state.c
@@ -33,7 +33,7 @@ struct Env_state
 
 Env_state* new_Env_state(const Environment* env)
 {
-    assert(env != NULL);
+    rassert(env != NULL);
 
     Env_state* estate = memory_alloc_item(Env_state);
     if (estate == NULL)
@@ -48,7 +48,7 @@ Env_state* new_Env_state(const Environment* env)
 
 bool Env_state_refresh_space(Env_state* estate)
 {
-    assert(estate != NULL);
+    rassert(estate != NULL);
 
     AAtree* vars = new_AAtree(
             (AAtree_item_cmp*)strcmp, (AAtree_item_destroy*)del_Env_var);
@@ -85,8 +85,8 @@ bool Env_state_refresh_space(Env_state* estate)
 
 Env_var* Env_state_get_var(const Env_state* estate, const char* name)
 {
-    assert(estate != NULL);
-    assert(name != NULL);
+    rassert(estate != NULL);
+    rassert(name != NULL);
 
     if (estate->vars == NULL)
         return NULL;
@@ -97,7 +97,7 @@ Env_var* Env_state_get_var(const Env_state* estate, const char* name)
 
 void Env_state_reset(Env_state* estate)
 {
-    assert(estate != NULL);
+    rassert(estate != NULL);
 
     Environment_iter* iter = Environment_iter_init(ENVIRONMENT_ITER_AUTO, estate->env);
 
@@ -106,8 +106,8 @@ void Env_state_reset(Env_state* estate)
     {
         const Env_var* init_var = Environment_get(estate->env, name);
         Env_var* state_var = Env_state_get_var(estate, name);
-        assert(init_var != NULL);
-        assert(state_var != NULL);
+        rassert(init_var != NULL);
+        rassert(state_var != NULL);
 
         Env_var_set_value(state_var, Env_var_get_value(init_var));
 

--- a/src/lib/player/Event_buffer.c
+++ b/src/lib/player/Event_buffer.c
@@ -42,8 +42,8 @@ static const char EMPTY_BUFFER[] = "[]";
 
 Event_buffer* new_Event_buffer(int32_t size)
 {
-    assert(size >= 0);
-    assert(size <= EVENT_BUF_SIZE_MAX);
+    rassert(size >= 0);
+    rassert(size <= EVENT_BUF_SIZE_MAX);
 
     Event_buffer* ebuf = memory_alloc_item(Event_buffer);
     if (ebuf == NULL)
@@ -73,14 +73,14 @@ Event_buffer* new_Event_buffer(int32_t size)
 
 bool Event_buffer_is_empty(const Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
+    rassert(ebuf != NULL);
     return string_eq(ebuf->buf, EMPTY_BUFFER);
 }
 
 
 bool Event_buffer_is_full(const Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
+    rassert(ebuf != NULL);
     return (ebuf->size < EVENT_LEN_MAX) ||
         (ebuf->write_pos >= ebuf->size - EVENT_LEN_MAX);
 }
@@ -88,8 +88,8 @@ bool Event_buffer_is_full(const Event_buffer* ebuf)
 
 void Event_buffer_reset_add_counter(Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
-    assert(!ebuf->is_skipping);
+    rassert(ebuf != NULL);
+    rassert(!ebuf->is_skipping);
 
     ebuf->events_added = 0;
 
@@ -99,10 +99,10 @@ void Event_buffer_reset_add_counter(Event_buffer* ebuf)
 
 void Event_buffer_start_skipping(Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
-    assert(!ebuf->is_skipping);
-    assert(Event_buffer_is_full(ebuf));
-    assert(ebuf->events_added > 0);
+    rassert(ebuf != NULL);
+    rassert(!ebuf->is_skipping);
+    rassert(Event_buffer_is_full(ebuf));
+    rassert(ebuf->events_added > 0);
 
     ebuf->is_skipping = true;
     ebuf->events_skipped = 0;
@@ -113,37 +113,37 @@ void Event_buffer_start_skipping(Event_buffer* ebuf)
 
 bool Event_buffer_is_skipping(const Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
+    rassert(ebuf != NULL);
     return ebuf->is_skipping;
 }
 
 
 const char* Event_buffer_get_events(const Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
+    rassert(ebuf != NULL);
     return ebuf->buf;
 }
 
 
 void Event_buffer_add(Event_buffer* ebuf, int ch, const char* name, const Value* arg)
 {
-    assert(ebuf != NULL);
-    assert(!Event_buffer_is_full(ebuf));
-    assert(ch >= 0);
-    assert(ch < KQT_CHANNELS_MAX);
-    assert(name != NULL);
-    assert(arg != NULL);
+    rassert(ebuf != NULL);
+    rassert(!Event_buffer_is_full(ebuf));
+    rassert(ch >= 0);
+    rassert(ch < KQT_CHANNELS_MAX);
+    rassert(name != NULL);
+    rassert(arg != NULL);
 
     // Skipping mode
     if (ebuf->is_skipping)
     {
         // This event has already been processed
-        assert(ebuf->events_skipped < ebuf->events_added);
+        rassert(ebuf->events_skipped < ebuf->events_added);
 
         ++ebuf->events_skipped;
         if (ebuf->events_skipped >= ebuf->events_added)
         {
-            assert(ebuf->events_skipped == ebuf->events_added);
+            rassert(ebuf->events_skipped == ebuf->events_added);
             ebuf->is_skipping = false;
         }
 
@@ -161,7 +161,7 @@ void Event_buffer_add(Event_buffer* ebuf, int ch, const char* name, const Value*
 
     // Name
     const size_t len = strlen(name);
-    assert(len > 0);
+    rassert(len > 0);
     if (name[len - 1] == '"')
     {
         // Print with properly escaped trailing double quote
@@ -192,7 +192,7 @@ void Event_buffer_add(Event_buffer* ebuf, int ch, const char* name, const Value*
 
     // Update the write position
     ebuf->write_pos += advance;
-    assert(ebuf->write_pos < ebuf->size);
+    rassert(ebuf->write_pos < ebuf->size);
 
     // Close the list
     strcpy(ebuf->buf + ebuf->write_pos, "]");
@@ -205,7 +205,7 @@ void Event_buffer_add(Event_buffer* ebuf, int ch, const char* name, const Value*
 
 void Event_buffer_clear(Event_buffer* ebuf)
 {
-    assert(ebuf != NULL);
+    rassert(ebuf != NULL);
 
     strcpy(ebuf->buf, EMPTY_BUFFER);
     ebuf->write_pos = 1;

--- a/src/lib/player/Event_cache.c
+++ b/src/lib/player/Event_cache.c
@@ -68,8 +68,8 @@ Event_cache* new_Event_cache(void)
 
 bool Event_cache_add_event(Event_cache* cache, char* event_name)
 {
-    assert(cache != NULL);
-    assert(event_name != NULL);
+    rassert(cache != NULL);
+    rassert(event_name != NULL);
 
     if (AAtree_get_exact(cache->cache, event_name) != NULL)
         return true;
@@ -87,9 +87,9 @@ bool Event_cache_add_event(Event_cache* cache, char* event_name)
 
 void Event_cache_update(Event_cache* cache, const char* event_name, const Value* value)
 {
-    assert(cache != NULL);
-    assert(event_name != NULL);
-    assert(value != NULL);
+    rassert(cache != NULL);
+    rassert(event_name != NULL);
+    rassert(value != NULL);
 
     Event_state* state = AAtree_get_exact(cache->cache, event_name);
     if (state == NULL)
@@ -102,11 +102,11 @@ void Event_cache_update(Event_cache* cache, const char* event_name, const Value*
 
 const Value* Event_cache_get_value(const Event_cache* cache, const char* event_name)
 {
-    assert(cache != NULL);
-    assert(event_name != NULL);
+    rassert(cache != NULL);
+    rassert(event_name != NULL);
 
     Event_state* state = AAtree_get_exact(cache->cache, event_name);
-    assert(state != NULL);
+    rassert(state != NULL);
 
     return &state->value;
 }
@@ -114,7 +114,7 @@ const Value* Event_cache_get_value(const Event_cache* cache, const char* event_n
 
 void Event_cache_reset(Event_cache* cache)
 {
-    assert(cache != NULL);
+    rassert(cache != NULL);
 
     AAiter* iter = AAiter_init(AAITER_AUTO, cache->cache);
     Event_state* es = AAiter_get_at_least(iter, "");
@@ -141,8 +141,8 @@ void del_Event_cache(Event_cache* cache)
 
 static Event_state* new_Event_state(const char* event_name)
 {
-    assert(event_name != NULL);
-    assert(strlen(event_name) <= EVENT_NAME_MAX);
+    rassert(event_name != NULL);
+    rassert(strlen(event_name) <= EVENT_NAME_MAX);
 
     Event_state* es = memory_alloc_item(Event_state);
     if (es == NULL)
@@ -156,7 +156,7 @@ static Event_state* new_Event_state(const char* event_name)
 
 static void Event_state_reset(Event_state* es)
 {
-    assert(es != NULL);
+    rassert(es != NULL);
     es->value.type = VALUE_TYPE_NONE;
     return;
 }

--- a/src/lib/player/Event_handler.c
+++ b/src/lib/player/Event_handler.c
@@ -72,10 +72,10 @@ Event_handler* new_Event_handler(
         Device_states* device_states,
         Au_table* au_table)
 {
-    assert(master_params != NULL);
-    assert(channels != NULL);
-    assert(device_states != NULL);
-    assert(au_table != NULL);
+    rassert(master_params != NULL);
+    rassert(channels != NULL);
+    rassert(device_states != NULL);
+    rassert(au_table != NULL);
 
     Event_handler* eh = memory_alloc_item(Event_handler);
     if (eh == NULL)
@@ -125,7 +125,7 @@ Event_handler* new_Event_handler(
 
 const Event_names* Event_handler_get_names(const Event_handler* eh)
 {
-    assert(eh != NULL);
+    rassert(eh != NULL);
     return eh->event_names;
 }
 
@@ -136,9 +136,9 @@ bool Event_handler_set_ch_process(
         bool (*ch_process)(
             Channel*, Device_states*, const Master_params*, const Value*))
 {
-    assert(eh != NULL);
-    assert(Event_is_channel(type));
-    assert(ch_process != NULL);
+    rassert(eh != NULL);
+    rassert(Event_is_channel(type));
+    rassert(ch_process != NULL);
 
     eh->ch_process[type] = ch_process;
 
@@ -151,9 +151,9 @@ bool Event_handler_set_general_process(
         Event_type type,
         bool (*general_process)(General_state*, const Value*))
 {
-    assert(eh != NULL);
-    assert(Event_is_general(type));
-    assert(general_process != NULL);
+    rassert(eh != NULL);
+    rassert(Event_is_general(type));
+    rassert(general_process != NULL);
 
     eh->general_process[type] = general_process;
 
@@ -166,9 +166,9 @@ bool Event_handler_set_control_process(
         Event_type type,
         bool (*control_process)(General_state*, Channel*, const Value*))
 {
-    assert(eh != NULL);
-    assert(Event_is_control(type));
-    assert(control_process != NULL);
+    rassert(eh != NULL);
+    rassert(Event_is_control(type));
+    rassert(control_process != NULL);
 
     eh->control_process[type] = control_process;
 
@@ -181,9 +181,9 @@ bool Event_handler_set_master_process(
         Event_type type,
         bool (*global_process)(Master_params*, const Value*))
 {
-    assert(eh != NULL);
-    assert(Event_is_master(type));
-    assert(global_process != NULL);
+    rassert(eh != NULL);
+    rassert(Event_is_master(type));
+    rassert(global_process != NULL);
 
     eh->master_process[type] = global_process;
 
@@ -203,9 +203,9 @@ bool Event_handler_set_au_process(
             Device_states*,
             const Value*))
 {
-    assert(eh != NULL);
-    assert(Event_is_au(type));
-    assert(au_process != NULL);
+    rassert(eh != NULL);
+    rassert(Event_is_au(type));
+    rassert(au_process != NULL);
 
     eh->au_process[type] = au_process;
 
@@ -219,14 +219,14 @@ static bool Event_handler_handle(
         Event_type type,
         const Value* value)
 {
-    assert(eh != NULL);
-    assert(index >= 0);
-    assert(index < KQT_COLUMNS_MAX);
-    assert(Event_is_valid(type));
-    assert(eh->channels[index]->freq != NULL);
-    assert(*eh->channels[index]->freq > 0);
-    assert(eh->channels[index]->tempo != NULL);
-    assert(*eh->channels[index]->tempo > 0);
+    rassert(eh != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_COLUMNS_MAX);
+    rassert(Event_is_valid(type));
+    rassert(eh->channels[index]->freq != NULL);
+    rassert(*eh->channels[index]->freq > 0);
+    rassert(eh->channels[index]->tempo != NULL);
+    rassert(*eh->channels[index]->tempo > 0);
 
     if (Event_is_channel(type))
     {
@@ -249,7 +249,7 @@ static bool Event_handler_handle(
             return false;
 
         const Au_params* au_params = Audio_unit_get_params(au);
-        assert(au_params != NULL);
+        rassert(au_params != NULL);
         Au_state* au_state = (Au_state*)Device_states_get_state(
                 eh->device_states,
                 Device_get_id((Device*)au));
@@ -288,21 +288,21 @@ static bool Event_handler_handle(
 bool Event_handler_trigger(
         Event_handler* eh, int ch_num, const char* name, const Value* arg)
 {
-    assert(eh != NULL);
-    assert(ch_num >= 0);
-    assert(ch_num < KQT_CHANNELS_MAX);
-    assert(name != NULL);
-    assert(arg != NULL);
+    rassert(eh != NULL);
+    rassert(ch_num >= 0);
+    rassert(ch_num < KQT_CHANNELS_MAX);
+    rassert(name != NULL);
+    rassert(arg != NULL);
 
     Event_type type = Event_names_get(eh->event_names, name);
-    assert(type != Event_NONE);
-    assert(!Event_is_query(type));
-    assert(!Event_is_auto(type));
+    rassert(type != Event_NONE);
+    rassert(!Event_is_query(type));
+    rassert(!Event_is_auto(type));
 
-    assert(eh->channels[ch_num]->freq != NULL);
-    assert(*eh->channels[ch_num]->freq > 0);
-    assert(eh->channels[ch_num]->tempo != NULL);
-    assert(*eh->channels[ch_num]->tempo > 0);
+    rassert(eh->channels[ch_num]->freq != NULL);
+    rassert(*eh->channels[ch_num]->freq > 0);
+    rassert(eh->channels[ch_num]->tempo != NULL);
+    rassert(*eh->channels[ch_num]->tempo > 0);
 
     return Event_handler_handle(eh, ch_num, type, arg);
 }
@@ -317,15 +317,15 @@ bool Event_handler_process_type(
         Event_type* event_type,
         Read_state* state)
 {
-    assert(eh != NULL);
-    assert(index >= 0);
-    assert(index < KQT_COLUMNS_MAX);
-    assert(desc != NULL);
-    assert(*desc != NULL);
-    assert(event_name != NULL);
-    assert(event_type != NULL);
-    assert(state != NULL);
-    assert(!state->error);
+    rassert(eh != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_COLUMNS_MAX);
+    rassert(desc != NULL);
+    rassert(*desc != NULL);
+    rassert(event_name != NULL);
+    rassert(event_type != NULL);
+    rassert(state != NULL);
+    rassert(!state->error);
 
     *desc = read_const_char(*desc, '[', state);
     *desc = read_string(*desc, event_name, EVENT_NAME_MAX + 2, state);
@@ -343,7 +343,7 @@ bool Event_handler_process_type(
         return false;
     }
 
-    assert(Event_is_valid(*event_type));
+    rassert(Event_is_valid(*event_type));
     if (!General_state_events_enabled((General_state*)eh->channels[index]) &&
             *event_type != Event_general_if &&
             *event_type != Event_general_else &&

--- a/src/lib/player/Event_names.c
+++ b/src/lib/player/Event_names.c
@@ -82,9 +82,9 @@ Event_names* new_Event_names(void)
 
     for (int i = 0; event_specs[i].name[0] != '\0'; ++i)
     {
-        assert(strlen(event_specs[i].name) > 0);
-        assert(strlen(event_specs[i].name) < EVENT_NAME_MAX);
-        assert(!AAtree_contains(names->names, event_specs[i].name));
+        rassert(strlen(event_specs[i].name) > 0);
+        rassert(strlen(event_specs[i].name) < EVENT_NAME_MAX);
+        rassert(!AAtree_contains(names->names, event_specs[i].name));
 
         if (!AAtree_ins(names->names, &event_specs[i]))
         {
@@ -99,8 +99,8 @@ Event_names* new_Event_names(void)
 
 static int event_name_cmp(const char* e1, const char* e2)
 {
-    assert(e1 != NULL);
-    assert(e2 != NULL);
+    rassert(e1 != NULL);
+    rassert(e2 != NULL);
 
     int i = 0;
     for (i = 0; e1[i] != '\0' && e1[i] != '"' &&
@@ -123,15 +123,15 @@ static int event_name_cmp(const char* e1, const char* e2)
 
 bool Event_names_error(Event_names* names)
 {
-    assert(names != NULL);
+    rassert(names != NULL);
     return names->error;
 }
 
 
 Event_type Event_names_get(const Event_names* names, const char* name)
 {
-    assert(names != NULL);
-    assert(name != NULL);
+    rassert(names != NULL);
+    rassert(name != NULL);
 
     Name_info* info = AAtree_get_exact(names->names, name);
     if (info == NULL)
@@ -143,11 +143,11 @@ Event_type Event_names_get(const Event_names* names, const char* name)
 
 Value_type Event_names_get_param_type(const Event_names* names, const char* name)
 {
-    assert(names != NULL);
-    assert(name != NULL);
+    rassert(names != NULL);
+    rassert(name != NULL);
 
     Name_info* info = AAtree_get_exact(names->names, name);
-    assert(info != NULL);
+    rassert(info != NULL);
 
     return info->param_type;
 }

--- a/src/lib/player/Force_controls.c
+++ b/src/lib/player/Force_controls.c
@@ -25,7 +25,7 @@
 
 void Force_controls_init(Force_controls* fc, int32_t audio_rate, double tempo)
 {
-    assert(fc != NULL);
+    rassert(fc != NULL);
 
     fc->force = NAN;
     Slider_init(&fc->slider, SLIDE_MODE_LINEAR);
@@ -40,8 +40,8 @@ void Force_controls_init(Force_controls* fc, int32_t audio_rate, double tempo)
 
 void Force_controls_set_audio_rate(Force_controls* fc, int32_t audio_rate)
 {
-    assert(fc != NULL);
-    assert(audio_rate > 0);
+    rassert(fc != NULL);
+    rassert(audio_rate > 0);
 
     Slider_set_audio_rate(&fc->slider, audio_rate);
     LFO_set_audio_rate(&fc->tremolo, audio_rate);
@@ -52,8 +52,8 @@ void Force_controls_set_audio_rate(Force_controls* fc, int32_t audio_rate)
 
 void Force_controls_set_tempo(Force_controls* fc, double tempo)
 {
-    assert(fc != NULL);
-    assert(tempo > 0);
+    rassert(fc != NULL);
+    rassert(tempo > 0);
 
     Slider_set_tempo(&fc->slider, tempo);
     LFO_set_tempo(&fc->tremolo, tempo);
@@ -64,7 +64,7 @@ void Force_controls_set_tempo(Force_controls* fc, double tempo)
 
 void Force_controls_reset(Force_controls* fc)
 {
-    assert(fc != NULL);
+    rassert(fc != NULL);
 
     fc->force = NAN;
     Slider_init(&fc->slider, SLIDE_MODE_LINEAR);
@@ -77,9 +77,9 @@ void Force_controls_reset(Force_controls* fc)
 void Force_controls_copy(
         Force_controls* restrict dest, const Force_controls* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(src != dest);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(src != dest);
 
     dest->force = src->force;
     Slider_copy(&dest->slider, &src->slider);

--- a/src/lib/player/General_state.c
+++ b/src/lib/player/General_state.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -22,7 +22,7 @@
 
 General_state* General_state_preinit(General_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     state->estate = NULL;
     state->active_names = NULL;
@@ -35,10 +35,10 @@ General_state* General_state_preinit(General_state* state)
 General_state* General_state_init(
         General_state* state, bool global, Env_state* estate, const Module* module)
 {
-    assert(state != NULL);
-    assert(state->active_names == NULL);
-    assert(estate != NULL);
-    assert(module != NULL);
+    rassert(state != NULL);
+    rassert(state->active_names == NULL);
+    rassert(estate != NULL);
+    rassert(module != NULL);
 
     state->global = global;
     state->estate = estate;
@@ -56,7 +56,7 @@ General_state* General_state_init(
 
 bool General_state_events_enabled(General_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 #if 0
     if (state->global)
         fprintf(stderr, "enabled: %d, exec: %d, evaluated: %d\n",
@@ -74,7 +74,7 @@ bool General_state_events_enabled(General_state* state)
 
 void General_state_reset(General_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     state->pause = false;
     state->cond_level_index = -1;
@@ -108,7 +108,7 @@ void General_state_reset(General_state* state)
 
 void General_state_deinit(General_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     del_Active_names(state->active_names);
     state->active_names = NULL;

--- a/src/lib/player/Jump_cache.c
+++ b/src/lib/player/Jump_cache.c
@@ -34,7 +34,7 @@ struct Jump_cache
 
 Jump_cache* new_Jump_cache(int num_contexts)
 {
-    assert(num_contexts > 0);
+    rassert(num_contexts > 0);
 
     Jump_cache* jcache = memory_alloc_item(Jump_cache);
     if (jcache == NULL)
@@ -82,7 +82,7 @@ Jump_cache* new_Jump_cache(int num_contexts)
 
 AAnode* Jump_cache_acquire_context(Jump_cache* jcache)
 {
-    assert(jcache != NULL);
+    rassert(jcache != NULL);
 
     Jump_context* key = JUMP_CONTEXT_AUTO;
     key->piref.pat = -1;
@@ -92,11 +92,11 @@ AAnode* Jump_cache_acquire_context(Jump_cache* jcache)
     const Jump_context* elem = AAtree_get_at_least(jcache->contexts, key);
     if (elem == NULL)
     {
-        assert(jcache->use_count == jcache->num_contexts);
+        rassert(jcache->use_count == jcache->num_contexts);
         return NULL;
     }
 
-    assert(jcache->use_count < jcache->num_contexts);
+    rassert(jcache->use_count < jcache->num_contexts);
     ++jcache->use_count;
 
     return AAtree_detach(jcache->contexts, elem);
@@ -105,8 +105,8 @@ AAnode* Jump_cache_acquire_context(Jump_cache* jcache)
 
 void Jump_cache_release_context(Jump_cache* jcache, AAnode* handle)
 {
-    assert(jcache != NULL);
-    assert(handle != NULL);
+    rassert(jcache != NULL);
+    rassert(handle != NULL);
 
     Jump_context* jc = AAnode_get_data(handle);
     jc->piref.pat = -1;
@@ -119,7 +119,7 @@ void Jump_cache_release_context(Jump_cache* jcache, AAnode* handle)
 
     AAtree_attach(jcache->contexts, handle);
 
-    assert(jcache->use_count > 0);
+    rassert(jcache->use_count > 0);
     --jcache->use_count;
 
     return;
@@ -131,7 +131,7 @@ void del_Jump_cache(Jump_cache* jcache)
     if (jcache == NULL)
         return;
 
-    assert(jcache->use_count == 0);
+    rassert(jcache->use_count == 0);
 
     del_AAtree(jcache->contexts);
     memory_free(jcache);

--- a/src/lib/player/Jump_context.c
+++ b/src/lib/player/Jump_context.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2016
  *
  * This file is part of Kunquat.
  *
@@ -44,8 +44,8 @@ Jump_context* new_Jump_context(void)
 
 int Jump_context_cmp(const Jump_context* jc1, const Jump_context* jc2)
 {
-    assert(jc1 != NULL);
-    assert(jc2 != NULL);
+    rassert(jc1 != NULL);
+    rassert(jc2 != NULL);
 
     int diff = Pat_inst_ref_cmp(&jc1->piref, &jc2->piref);
     if (diff != 0)

--- a/src/lib/player/LFO.c
+++ b/src/lib/player/LFO.c
@@ -32,8 +32,8 @@ static void LFO_update_time(LFO* lfo, int32_t audio_rate, double tempo);
 
 LFO* LFO_init(LFO* lfo, LFO_mode mode)
 {
-    assert(lfo != NULL);
-    assert(mode == LFO_MODE_LINEAR || mode == LFO_MODE_EXP);
+    rassert(lfo != NULL);
+    rassert(mode == LFO_MODE_LINEAR || mode == LFO_MODE_EXP);
 
     lfo->mode = mode;
     lfo->audio_rate = DEFAULT_AUDIO_RATE;
@@ -58,9 +58,9 @@ LFO* LFO_init(LFO* lfo, LFO_mode mode)
 
 LFO* LFO_copy(LFO* restrict dest, const LFO* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(src != dest);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(src != dest);
 
     memcpy(dest, src, sizeof(LFO));
 //    Slider_copy(&dest->speed_slider, &src->speed_slider);
@@ -72,8 +72,8 @@ LFO* LFO_copy(LFO* restrict dest, const LFO* restrict src)
 
 void LFO_set_audio_rate(LFO* lfo, int32_t audio_rate)
 {
-    assert(lfo != NULL);
-    assert(audio_rate > 0);
+    rassert(lfo != NULL);
+    rassert(audio_rate > 0);
 
     if (lfo->audio_rate == audio_rate)
         return;
@@ -94,9 +94,9 @@ void LFO_set_audio_rate(LFO* lfo, int32_t audio_rate)
 
 void LFO_set_tempo(LFO* lfo, double tempo)
 {
-    assert(lfo != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(lfo != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     if (lfo->tempo == tempo)
         return;
@@ -117,9 +117,9 @@ void LFO_set_tempo(LFO* lfo, double tempo)
 
 void LFO_set_speed(LFO* lfo, double speed)
 {
-    assert(lfo != NULL);
-    assert(isfinite(speed));
-    assert(speed >= 0);
+    rassert(lfo != NULL);
+    rassert(isfinite(speed));
+    rassert(speed >= 0);
 
     if (Slider_in_progress(&lfo->speed_slider))
     {
@@ -140,9 +140,9 @@ void LFO_set_speed(LFO* lfo, double speed)
 
 void LFO_set_speed_slide(LFO* lfo, const Tstamp* length)
 {
-    assert(lfo != NULL);
-    assert(length != NULL);
-    assert(Tstamp_cmp(length, Tstamp_init(TSTAMP_AUTO)) >= 0);
+    rassert(lfo != NULL);
+    rassert(length != NULL);
+    rassert(Tstamp_cmp(length, Tstamp_init(TSTAMP_AUTO)) >= 0);
 
     Slider_set_length(&lfo->speed_slider, length);
 
@@ -152,8 +152,8 @@ void LFO_set_speed_slide(LFO* lfo, const Tstamp* length)
 
 void LFO_set_depth(LFO* lfo, double depth)
 {
-    assert(lfo != NULL);
-    assert(isfinite(depth));
+    rassert(lfo != NULL);
+    rassert(isfinite(depth));
 
     if (Slider_in_progress(&lfo->depth_slider))
     {
@@ -174,9 +174,9 @@ void LFO_set_depth(LFO* lfo, double depth)
 
 void LFO_set_depth_slide(LFO* lfo, const Tstamp* length)
 {
-    assert(lfo != NULL);
-    assert(length != NULL);
-    assert(Tstamp_cmp(length, Tstamp_init(TSTAMP_AUTO)) >= 0);
+    rassert(lfo != NULL);
+    rassert(length != NULL);
+    rassert(Tstamp_cmp(length, Tstamp_init(TSTAMP_AUTO)) >= 0);
 
     Slider_set_length(&lfo->depth_slider, length);
 
@@ -186,10 +186,10 @@ void LFO_set_depth_slide(LFO* lfo, const Tstamp* length)
 
 void LFO_set_offset(LFO* lfo, double offset)
 {
-    assert(lfo != NULL);
-    assert(isfinite(offset));
-    assert(offset >= -1);
-    assert(offset <= 1);
+    rassert(lfo != NULL);
+    rassert(isfinite(offset));
+    rassert(offset >= -1);
+    rassert(offset <= 1);
 
     lfo->offset = offset;
 
@@ -199,9 +199,9 @@ void LFO_set_offset(LFO* lfo, double offset)
 
 void LFO_turn_on(LFO* lfo)
 {
-    assert(lfo != NULL);
-    assert(lfo->audio_rate > 0);
-    assert(lfo->tempo > 0);
+    rassert(lfo != NULL);
+    rassert(lfo->audio_rate > 0);
+    rassert(lfo->tempo > 0);
 
     if (!lfo->on)
     {
@@ -209,8 +209,8 @@ void LFO_turn_on(LFO* lfo)
         if (lfo->phase < 0)
             lfo->phase += 2 * PI;
 
-        assert(lfo->phase >= 0);
-        assert(lfo->phase < 2 * PI);
+        rassert(lfo->phase >= 0);
+        rassert(lfo->phase < 2 * PI);
     }
 
     lfo->on = true;
@@ -220,9 +220,9 @@ void LFO_turn_on(LFO* lfo)
 
 void LFO_turn_off(LFO* lfo)
 {
-    assert(lfo != NULL);
-    assert(lfo->audio_rate > 0);
-    assert(lfo->tempo > 0);
+    rassert(lfo != NULL);
+    rassert(lfo->audio_rate > 0);
+    rassert(lfo->tempo > 0);
 
     lfo->on = false;
 
@@ -232,17 +232,17 @@ void LFO_turn_off(LFO* lfo)
 
 double LFO_step(LFO* lfo)
 {
-    assert(lfo != NULL);
-    assert(lfo->audio_rate > 0);
-    assert(isfinite(lfo->tempo));
-    assert(lfo->tempo > 0);
+    rassert(lfo != NULL);
+    rassert(lfo->audio_rate > 0);
+    rassert(isfinite(lfo->tempo));
+    rassert(lfo->tempo > 0);
 
     if (!LFO_active(lfo))
     {
         if (lfo->mode == LFO_MODE_EXP)
             return 1;
 
-        assert(lfo->mode == LFO_MODE_LINEAR);
+        rassert(lfo->mode == LFO_MODE_LINEAR);
         return 0;
     }
 
@@ -293,22 +293,22 @@ double LFO_step(LFO* lfo)
     if (lfo->mode == LFO_MODE_EXP)
         return exp2(value);
 
-    assert(lfo->mode == LFO_MODE_LINEAR);
+    rassert(lfo->mode == LFO_MODE_LINEAR);
     return value;
 }
 
 
 double LFO_skip(LFO* lfo, int64_t steps)
 {
-    assert(lfo != NULL);
-    assert(steps >= 0);
+    rassert(lfo != NULL);
+    rassert(steps >= 0);
 
     if (steps == 0)
     {
         if (lfo->mode == LFO_MODE_EXP)
             return 1;
 
-        assert(lfo->mode == LFO_MODE_LINEAR);
+        rassert(lfo->mode == LFO_MODE_LINEAR);
         return 0;
     }
     else if (steps == 1)
@@ -328,16 +328,16 @@ double LFO_skip(LFO* lfo, int64_t steps)
     if (lfo->mode == LFO_MODE_EXP)
         return exp2(value);
 
-    assert(lfo->mode == LFO_MODE_LINEAR);
+    rassert(lfo->mode == LFO_MODE_LINEAR);
     return value;
 }
 
 
 static void LFO_update_time(LFO* lfo, int32_t audio_rate, double tempo)
 {
-    assert(lfo != NULL);
-    assert(audio_rate > 0);
-    assert(tempo > 0);
+    rassert(lfo != NULL);
+    rassert(audio_rate > 0);
+    rassert(tempo > 0);
 
 //    lfo->speed *= (double)audio_rate / lfo->audio_rate;
 //    lfo->speed *= lfo->tempo / tempo;
@@ -357,7 +357,7 @@ static void LFO_update_time(LFO* lfo, int32_t audio_rate, double tempo)
 
 bool LFO_active(const LFO* lfo)
 {
-    assert(lfo != NULL);
+    rassert(lfo != NULL);
 
     return lfo->update > 0 ||
            Slider_in_progress(&lfo->speed_slider) ||
@@ -367,7 +367,7 @@ bool LFO_active(const LFO* lfo)
 
 int32_t LFO_estimate_active_steps_left(const LFO* lfo)
 {
-    assert(lfo != NULL);
+    rassert(lfo != NULL);
 
     if (Slider_in_progress(&lfo->depth_slider) && lfo->target_depth == 0)
         return Slider_estimate_active_steps_left(&lfo->depth_slider);
@@ -378,23 +378,23 @@ int32_t LFO_estimate_active_steps_left(const LFO* lfo)
 
 double LFO_get_target_speed(const LFO* lfo)
 {
-    assert(lfo != NULL);
+    rassert(lfo != NULL);
     return lfo->target_speed;
 }
 
 
 double LFO_get_target_depth(const LFO* lfo)
 {
-    assert(lfo != NULL);
+    rassert(lfo != NULL);
     return lfo->target_depth;
 }
 
 
 void LFO_change_depth_range(LFO* lfo, double from_depth, double to_depth)
 {
-    assert(lfo != NULL);
-    assert(isfinite(from_depth));
-    assert(isfinite(to_depth));
+    rassert(lfo != NULL);
+    rassert(isfinite(from_depth));
+    rassert(isfinite(to_depth));
 
     if (from_depth == 0)
     {

--- a/src/lib/player/Linear_controls.c
+++ b/src/lib/player/Linear_controls.c
@@ -27,7 +27,7 @@
 
 void Linear_controls_init(Linear_controls* lc)
 {
-    assert(lc != NULL);
+    rassert(lc != NULL);
 
     lc->value = NAN;
     lc->min_value = -INFINITY;
@@ -41,8 +41,8 @@ void Linear_controls_init(Linear_controls* lc)
 
 void Linear_controls_set_audio_rate(Linear_controls* lc, int32_t audio_rate)
 {
-    assert(lc != NULL);
-    assert(audio_rate > 0);
+    rassert(lc != NULL);
+    rassert(audio_rate > 0);
 
     Slider_set_audio_rate(&lc->slider, audio_rate);
     LFO_set_audio_rate(&lc->lfo, audio_rate);
@@ -53,8 +53,8 @@ void Linear_controls_set_audio_rate(Linear_controls* lc, int32_t audio_rate)
 
 void Linear_controls_set_tempo(Linear_controls* lc, double tempo)
 {
-    assert(lc != NULL);
-    assert(tempo > 0);
+    rassert(lc != NULL);
+    rassert(tempo > 0);
 
     Slider_set_tempo(&lc->slider, tempo);
     LFO_set_tempo(&lc->lfo, tempo);
@@ -65,9 +65,9 @@ void Linear_controls_set_tempo(Linear_controls* lc, double tempo)
 
 void Linear_controls_set_range(Linear_controls* lc, double min_value, double max_value)
 {
-    assert(lc != NULL);
-    assert(!isnan(min_value));
-    assert(max_value >= min_value);
+    rassert(lc != NULL);
+    rassert(!isnan(min_value));
+    rassert(max_value >= min_value);
 
     lc->min_value = min_value;
     lc->max_value = max_value;
@@ -78,8 +78,8 @@ void Linear_controls_set_range(Linear_controls* lc, double min_value, double max
 
 void Linear_controls_set_value(Linear_controls* lc, double value)
 {
-    assert(lc != NULL);
-    assert(isfinite(value));
+    rassert(lc != NULL);
+    rassert(isfinite(value));
 
     lc->value = value;
     Slider_break(&lc->slider);
@@ -90,15 +90,15 @@ void Linear_controls_set_value(Linear_controls* lc, double value)
 
 double Linear_controls_get_value(const Linear_controls* lc)
 {
-    assert(lc != NULL);
+    rassert(lc != NULL);
     return clamp(lc->value, lc->min_value, lc->max_value);
 }
 
 
 void Linear_controls_slide_value_target(Linear_controls* lc, double value)
 {
-    assert(lc != NULL);
-    assert(isfinite(value));
+    rassert(lc != NULL);
+    rassert(isfinite(value));
 
     if (Slider_in_progress(&lc->slider))
         Slider_change_target(&lc->slider, value);
@@ -111,8 +111,8 @@ void Linear_controls_slide_value_target(Linear_controls* lc, double value)
 
 void Linear_controls_slide_value_length(Linear_controls* lc, const Tstamp* length)
 {
-    assert(lc != NULL);
-    assert(length != NULL);
+    rassert(lc != NULL);
+    rassert(length != NULL);
 
     Slider_set_length(&lc->slider, length);
 
@@ -122,8 +122,8 @@ void Linear_controls_slide_value_length(Linear_controls* lc, const Tstamp* lengt
 
 void Linear_controls_osc_speed_value(Linear_controls* lc, double speed)
 {
-    assert(lc != NULL);
-    assert(speed >= 0);
+    rassert(lc != NULL);
+    rassert(speed >= 0);
 
     LFO_set_speed(&lc->lfo, speed);
 
@@ -138,8 +138,8 @@ void Linear_controls_osc_speed_value(Linear_controls* lc, double speed)
 
 void Linear_controls_osc_depth_value(Linear_controls* lc, double depth)
 {
-    assert(lc != NULL);
-    assert(isfinite(depth));
+    rassert(lc != NULL);
+    rassert(isfinite(depth));
 
     //if (lc->osc_speed > 0)
     //    LFO_set_speed(&lc->lfo, lc->osc_speed);
@@ -153,8 +153,8 @@ void Linear_controls_osc_depth_value(Linear_controls* lc, double depth)
 
 void Linear_controls_osc_speed_slide_value(Linear_controls* lc, const Tstamp* length)
 {
-    assert(lc != NULL);
-    assert(length != NULL);
+    rassert(lc != NULL);
+    rassert(length != NULL);
 
     LFO_set_speed_slide(&lc->lfo, length);
 
@@ -164,8 +164,8 @@ void Linear_controls_osc_speed_slide_value(Linear_controls* lc, const Tstamp* le
 
 void Linear_controls_osc_depth_slide_value(Linear_controls* lc, const Tstamp* length)
 {
-    assert(lc != NULL);
-    assert(length != NULL);
+    rassert(lc != NULL);
+    rassert(length != NULL);
 
     LFO_set_depth_slide(&lc->lfo, length);
 
@@ -179,9 +179,9 @@ void Linear_controls_fill_work_buffer(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(lc != NULL);
-    assert(wb != NULL);
-    assert(buf_start < buf_stop);
+    rassert(lc != NULL);
+    rassert(wb != NULL);
+    rassert(buf_start < buf_stop);
 
     float* values = Work_buffer_get_contents_mut(wb);
 
@@ -275,8 +275,8 @@ void Linear_controls_fill_work_buffer(
 
 void Linear_controls_skip(Linear_controls* lc, int64_t step_count)
 {
-    assert(lc != NULL);
-    assert(step_count >= 0);
+    rassert(lc != NULL);
+    rassert(step_count >= 0);
 
     if (Slider_in_progress(&lc->slider))
         lc->value = Slider_skip(&lc->slider, step_count);
@@ -290,9 +290,9 @@ void Linear_controls_skip(Linear_controls* lc, int64_t step_count)
 void Linear_controls_copy(
         Linear_controls* restrict dest, const Linear_controls* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(src != dest);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(src != dest);
 
     dest->value = src->value;
     Slider_copy(&dest->slider, &src->slider);
@@ -310,13 +310,13 @@ void Linear_controls_convert(
         double range_min,
         double range_max)
 {
-    assert(dest != NULL);
-    assert(isfinite(map_min_to));
-    assert(isfinite(map_max_to));
-    assert(src != NULL);
-    assert(src != dest);
-    assert(isfinite(range_min));
-    assert(isfinite(range_max));
+    rassert(dest != NULL);
+    rassert(isfinite(map_min_to));
+    rassert(isfinite(map_max_to));
+    rassert(src != NULL);
+    rassert(src != dest);
+    rassert(isfinite(range_min));
+    rassert(isfinite(range_max));
 
     Linear_controls_copy(dest, src);
 
@@ -374,7 +374,7 @@ void Linear_controls_convert(
             new_max = -new_max;
         }
 
-        assert(new_min <= new_max);
+        rassert(new_min <= new_max);
 
         dest->min_value = new_min;
         dest->max_value = new_max;

--- a/src/lib/player/Master_params.c
+++ b/src/lib/player/Master_params.c
@@ -29,7 +29,7 @@
 
 static void Master_params_clear(Master_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     Position_init(&params->start_pos);
 
@@ -85,7 +85,7 @@ static void Master_params_clear(Master_params* params)
 
 Master_params* Master_params_preinit(Master_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     General_state_preinit(&params->parent);
 
@@ -104,9 +104,9 @@ Master_params* Master_params_preinit(Master_params* params)
 Master_params* Master_params_init(
         Master_params* params, const Module* module, Env_state* estate)
 {
-    assert(params != NULL);
-    assert(module != NULL);
-    assert(estate != NULL);
+    rassert(params != NULL);
+    rassert(module != NULL);
+    rassert(estate != NULL);
 
     // Sanitise fields
     params->playback_id = 1;
@@ -134,7 +134,7 @@ Master_params* Master_params_init(
 
 void Master_params_set_starting_tempo(Master_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     const Track_list* tl = Module_get_track_list(params->parent.module);
     if (tl != NULL)
@@ -178,7 +178,7 @@ void Master_params_set_starting_tempo(Master_params* params)
 
 void Master_params_reset(Master_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     ++params->playback_id;
 
@@ -197,7 +197,7 @@ void Master_params_reset(Master_params* params)
 
 void Master_params_deinit(Master_params* params)
 {
-    assert(params != NULL);
+    rassert(params != NULL);
 
     if (params->active_jumps != NULL && params->jump_cache != NULL)
         Active_jumps_reset(params->active_jumps, params->jump_cache);

--- a/src/lib/player/Param_validator.c
+++ b/src/lib/player/Param_validator.c
@@ -34,7 +34,7 @@
 
 bool v_any_bool(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_bool(sr, NULL);
 }
@@ -42,7 +42,7 @@ bool v_any_bool(const char* param)
 
 bool v_any_int(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_int(sr, NULL);
 }
@@ -50,7 +50,7 @@ bool v_any_int(const char* param)
 
 bool v_any_float(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_float(sr, NULL);
 }
@@ -58,7 +58,7 @@ bool v_any_float(const char* param)
 
 bool v_any_str(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_string(sr, 0, NULL);
 }
@@ -66,7 +66,7 @@ bool v_any_str(const char* param)
 
 bool v_any_ts(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_tstamp(sr, NULL);
 }
@@ -74,7 +74,7 @@ bool v_any_ts(const char* param)
 
 bool v_arp_index(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t index = -1;
     Streader* sr = init_c_streader(param);
@@ -87,7 +87,7 @@ bool v_arp_index(const char* param)
 
 bool v_arp_speed(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double speed = NAN;
     Streader* sr = init_c_streader(param);
@@ -98,7 +98,7 @@ bool v_arp_speed(const char* param)
 
 bool v_au(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t au = -1;
     Streader* sr = init_c_streader(param);
@@ -111,7 +111,7 @@ bool v_au(const char* param)
 
 bool v_cond(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_string(sr, 0, NULL);
 }
@@ -119,7 +119,7 @@ bool v_cond(const char* param)
 
 bool v_counter(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t counter = -1;
     Streader* sr = init_c_streader(param);
@@ -132,7 +132,7 @@ bool v_counter(const char* param)
 
 bool v_finite_float(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double value = NAN;
     Streader* sr = init_c_streader(param);
@@ -143,7 +143,7 @@ bool v_finite_float(const char* param)
 
 bool v_finite_rt(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_finite_rt(sr, NULL);
 }
@@ -151,7 +151,7 @@ bool v_finite_rt(const char* param)
 
 bool v_force(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double force = NAN;
     Streader* sr = init_c_streader(param);
@@ -162,7 +162,7 @@ bool v_force(const char* param)
 
 bool v_proc(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t proc = -1;
     Streader* sr = init_c_streader(param);
@@ -175,7 +175,7 @@ bool v_proc(const char* param)
 
 bool v_hit(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t hit = -1;
     Streader* sr = init_c_streader(param);
@@ -186,7 +186,7 @@ bool v_hit(const char* param)
 
 bool v_key(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     char key[KQT_KEY_LENGTH_MAX + 1] = "";
     Streader* sr = init_c_streader(param);
@@ -210,7 +210,7 @@ bool v_key(const char* param)
 
 bool v_nonneg_float(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double value = NAN;
     Streader* sr = init_c_streader(param);
@@ -221,7 +221,7 @@ bool v_nonneg_float(const char* param)
 
 bool v_nonneg_ts(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     Tstamp* ts = TSTAMP_AUTO;
     Streader* sr = init_c_streader(param);
@@ -233,7 +233,7 @@ bool v_nonneg_ts(const char* param)
 
 bool v_note_entry(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t ne = -1;
     Streader* sr = init_c_streader(param);
@@ -244,7 +244,7 @@ bool v_note_entry(const char* param)
 
 bool v_pattern(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t pat = -1;
     Streader* sr = init_c_streader(param);
@@ -255,7 +255,7 @@ bool v_pattern(const char* param)
 
 bool v_piref(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     Streader* sr = init_c_streader(param);
     return Streader_read_piref(sr, NULL);
 }
@@ -263,14 +263,14 @@ bool v_piref(const char* param)
 
 bool v_pitch(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
     return v_finite_float(param);
 }
 
 
 bool v_song(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t song = -2;
     Streader* sr = init_c_streader(param);
@@ -283,7 +283,7 @@ bool v_song(const char* param)
 
 bool v_system(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t system = -1;
     Streader* sr = init_c_streader(param);
@@ -294,7 +294,7 @@ bool v_system(const char* param)
 
 bool v_sustain(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double sustain = NAN;
     Streader* sr = init_c_streader(param);
@@ -307,7 +307,7 @@ bool v_sustain(const char* param)
 
 bool v_tempo(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double tempo = NAN;
     Streader* sr = init_c_streader(param);
@@ -318,7 +318,7 @@ bool v_tempo(const char* param)
 
 bool v_track(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t track = -2;
     Streader* sr = init_c_streader(param);
@@ -331,7 +331,7 @@ bool v_track(const char* param)
 
 bool v_tremolo_depth(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double depth = NAN;
     Streader* sr = init_c_streader(param);
@@ -342,7 +342,7 @@ bool v_tremolo_depth(const char* param)
 
 bool v_tuning_table(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     int64_t tt_index = -1;
     Streader* sr = init_c_streader(param);
@@ -355,7 +355,7 @@ bool v_tuning_table(const char* param)
 
 bool v_var_name(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     Streader* sr = init_c_streader(param);
 
@@ -367,7 +367,7 @@ bool v_var_name(const char* param)
 
 bool v_volume(const char* param)
 {
-    assert(param != NULL);
+    rassert(param != NULL);
 
     double vol = NAN;
     Streader* sr = init_c_streader(param);

--- a/src/lib/player/Pitch_controls.c
+++ b/src/lib/player/Pitch_controls.c
@@ -25,9 +25,9 @@
 
 void Pitch_controls_init(Pitch_controls* pc, int32_t audio_rate, double tempo)
 {
-    assert(pc != NULL);
-    assert(audio_rate > 0);
-    assert(tempo > 0);
+    rassert(pc != NULL);
+    rassert(audio_rate > 0);
+    rassert(tempo > 0);
 
     pc->pitch = NAN;
     pc->orig_carried_pitch = NAN;
@@ -43,8 +43,8 @@ void Pitch_controls_init(Pitch_controls* pc, int32_t audio_rate, double tempo)
 
 void Pitch_controls_set_audio_rate(Pitch_controls* pc, int32_t audio_rate)
 {
-    assert(pc != NULL);
-    assert(audio_rate > 0);
+    rassert(pc != NULL);
+    rassert(audio_rate > 0);
 
     Slider_set_audio_rate(&pc->slider, audio_rate);
     LFO_set_audio_rate(&pc->vibrato, audio_rate);
@@ -55,8 +55,8 @@ void Pitch_controls_set_audio_rate(Pitch_controls* pc, int32_t audio_rate)
 
 void Pitch_controls_set_tempo(Pitch_controls* pc, double tempo)
 {
-    assert(pc != NULL);
-    assert(tempo > 0);
+    rassert(pc != NULL);
+    rassert(tempo > 0);
 
     Slider_set_tempo(&pc->slider, tempo);
     LFO_set_tempo(&pc->vibrato, tempo);
@@ -67,7 +67,7 @@ void Pitch_controls_set_tempo(Pitch_controls* pc, double tempo)
 
 void Pitch_controls_reset(Pitch_controls* pc)
 {
-    assert(pc != NULL);
+    rassert(pc != NULL);
 
     pc->pitch = NAN;
     pc->orig_carried_pitch = NAN;
@@ -82,9 +82,9 @@ void Pitch_controls_reset(Pitch_controls* pc)
 void Pitch_controls_copy(
         Pitch_controls* restrict dest, const Pitch_controls* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(src != dest);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(src != dest);
 
     dest->pitch = src->pitch;
     dest->orig_carried_pitch = src->orig_carried_pitch;

--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -40,7 +40,7 @@
 
 static void Player_update_sliders_and_lfos_audio_rate(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     const int32_t rate = player->audio_rate;
 
@@ -64,12 +64,12 @@ Player* new_Player(
         int32_t event_buffer_size,
         int voice_count)
 {
-    assert(module != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
-    assert(audio_buffer_size <= KQT_AUDIO_BUFFER_SIZE_MAX);
-    assert(voice_count >= 0);
-    assert(voice_count <= KQT_VOICES_MAX);
+    rassert(module != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
+    rassert(audio_buffer_size <= KQT_AUDIO_BUFFER_SIZE_MAX);
+    rassert(voice_count >= 0);
+    rassert(voice_count <= KQT_VOICES_MAX);
 
     Player* player = memory_alloc_item(Player);
     if (player == NULL)
@@ -202,22 +202,22 @@ Player* new_Player(
 
 const Event_handler* Player_get_event_handler(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return player->event_handler;
 }
 
 
 Device_states* Player_get_device_states(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return player->device_states;
 }
 
 
 bool Player_reserve_voice_state_space(Player* player, int32_t size)
 {
-    assert(player != NULL);
-    assert(size >= 0);
+    rassert(player != NULL);
+    rassert(size >= 0);
 
     return Voice_pool_reserve_state_space(player->voices, size);
 }
@@ -225,8 +225,8 @@ bool Player_reserve_voice_state_space(Player* player, int32_t size)
 
 bool Player_alloc_channel_cv_state(Player* player, const Au_control_vars* aucv)
 {
-    assert(player != NULL);
-    assert(aucv != NULL);
+    rassert(player != NULL);
+    rassert(aucv != NULL);
 
     Au_control_var_iter* iter = Au_control_var_iter_init(AU_CONTROL_VAR_ITER_AUTO, aucv);
     const char* var_name = NULL;
@@ -249,8 +249,8 @@ bool Player_alloc_channel_cv_state(Player* player, const Au_control_vars* aucv)
 
 bool Player_alloc_channel_streams(Player* player, const Au_streams* streams)
 {
-    assert(player != NULL);
-    assert(streams != NULL);
+    rassert(player != NULL);
+    rassert(streams != NULL);
 
     Stream_target_dev_iter* iter =
         Stream_target_dev_iter_init(STREAM_TARGET_DEV_ITER_AUTO, streams);
@@ -273,14 +273,14 @@ bool Player_alloc_channel_streams(Player* player, const Au_streams* streams)
 
 bool Player_refresh_env_state(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return Env_state_refresh_space(player->estate);
 }
 
 
 bool Player_refresh_bind_state(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     Event_cache* caches[KQT_CHANNELS_MAX] = { NULL };
     for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
@@ -304,9 +304,9 @@ bool Player_refresh_bind_state(Player* player)
 
 bool Player_create_tuning_state(Player* player, int index)
 {
-    assert(player != NULL);
-    assert(index >= 0);
-    assert(index < KQT_TUNING_TABLES_MAX);
+    rassert(player != NULL);
+    rassert(index >= 0);
+    rassert(index < KQT_TUNING_TABLES_MAX);
 
     if (player->master_params.tuning_states[index] == NULL)
     {
@@ -325,9 +325,9 @@ bool Player_create_tuning_state(Player* player, int index)
 
 void Player_reset(Player* player, int track_num)
 {
-    assert(player != NULL);
-    assert(track_num >= -1);
-    assert(track_num < KQT_TRACKS_MAX);
+    rassert(player != NULL);
+    rassert(track_num >= -1);
+    rassert(track_num < KQT_TRACKS_MAX);
 
     Master_params_reset(&player->master_params);
 
@@ -363,8 +363,8 @@ void Player_reset(Player* player, int track_num)
 
 bool Player_set_audio_rate(Player* player, int32_t rate)
 {
-    assert(player != NULL);
-    assert(rate > 0);
+    rassert(player != NULL);
+    rassert(rate > 0);
 
     if (player->audio_rate == rate)
         return true;
@@ -387,15 +387,15 @@ bool Player_set_audio_rate(Player* player, int32_t rate)
 
 int32_t Player_get_audio_rate(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return player->audio_rate;
 }
 
 
 bool Player_set_audio_buffer_size(Player* player, int32_t size)
 {
-    assert(player != NULL);
-    assert(size >= 0);
+    rassert(player != NULL);
+    rassert(size >= 0);
 
     if (player->audio_buffer_size == size)
         return true;
@@ -442,14 +442,14 @@ bool Player_set_audio_buffer_size(Player* player, int32_t size)
 
 int32_t Player_get_audio_buffer_size(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return player->audio_buffer_size;
 }
 
 
 int64_t Player_get_nanoseconds(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     static const int64_t ns_second = 1000000000LL;
 
@@ -468,9 +468,9 @@ int64_t Player_get_nanoseconds(const Player* player)
 static void Player_process_voices(
         Player* player, int32_t render_start, int32_t frame_count)
 {
-    assert(player != NULL);
-    assert(render_start >= 0);
-    assert(frame_count >= 0);
+    rassert(player != NULL);
+    rassert(render_start >= 0);
+    rassert(frame_count >= 0);
 
     if (frame_count == 0)
         return;
@@ -607,7 +607,7 @@ static bool Player_update_receive(Player* player)
 
 static void Player_flush_receive(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     while (Player_update_receive(player))
         ;
@@ -619,9 +619,9 @@ static void Player_flush_receive(Player* player)
 static void Player_apply_master_volume(
         Player* player, int32_t buf_start, int32_t buf_stop)
 {
-    assert(player != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(player != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     static const int CONTROL_WB_MASTER_VOLUME = WORK_BUFFER_IMPL_1;
 
@@ -648,7 +648,7 @@ static void Player_apply_master_volume(
     // Get access to mixed output
     Device_state* master_state = Device_states_get_state(
             player->device_states, Device_get_id((const Device*)player->module));
-    assert(master_state != NULL);
+    rassert(master_state != NULL);
 
     for (int32_t port = 0; port < KQT_DEVICE_PORTS_MAX; ++port)
     {
@@ -668,7 +668,7 @@ static void Player_apply_master_volume(
 
 static void Player_init_final(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     Master_params_set_starting_tempo(&player->master_params);
 
@@ -701,9 +701,9 @@ static void Player_init_final(Player* player)
 
 void Player_play(Player* player, int32_t nframes)
 {
-    assert(player != NULL);
-    assert(player->audio_buffer_size > 0);
-    assert(nframes >= 0);
+    rassert(player != NULL);
+    rassert(player->audio_buffer_size > 0);
+    rassert(nframes >= 0);
 
     Player_flush_receive(player);
 
@@ -712,7 +712,7 @@ void Player_play(Player* player, int32_t nframes)
     nframes = min(nframes, player->audio_buffer_size);
 
     const Connections* connections = Module_get_connections(player->module);
-    assert(connections != NULL);
+    rassert(connections != NULL);
 
     Device_states_clear_audio_buffers(player->device_states, 0, nframes);
     Connections_clear_buffers(connections, player->device_states, 0, nframes);
@@ -740,7 +740,7 @@ void Player_play(Player* player, int32_t nframes)
         // Don't add padding audio if stopped during this call
         if (was_playing && Player_has_stopped(player))
         {
-            assert(to_be_rendered == 0);
+            rassert(to_be_rendered == 0);
             break;
         }
 
@@ -797,7 +797,7 @@ void Player_play(Player* player, int32_t nframes)
     {
         Device_state* master_state = Device_states_get_state(
                 player->device_states, Device_get_id((const Device*)player->module));
-        assert(master_state != NULL);
+        rassert(master_state != NULL);
 
         // Note: we only access as many ports as we can output
         for (int32_t port = 0; port < KQT_BUFFERS_MAX; ++port)
@@ -837,8 +837,8 @@ void Player_play(Player* player, int32_t nframes)
 
 void Player_skip(Player* player, int64_t nframes)
 {
-    assert(player != NULL);
-    assert(nframes >= 0);
+    rassert(player != NULL);
+    rassert(nframes >= 0);
 
     // Clear buffers as we're not providing meaningful output
     Event_buffer_clear(player->event_buffer);
@@ -866,7 +866,7 @@ void Player_skip(Player* player, int64_t nframes)
 
         if (Player_has_stopped(player))
         {
-            assert(to_be_skipped == 0);
+            rassert(to_be_skipped == 0);
             break;
         }
 
@@ -889,22 +889,22 @@ void Player_skip(Player* player, int64_t nframes)
 
 int32_t Player_get_frames_available(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return player->audio_frames_available;
 }
 
 
 const float* Player_get_audio(const Player* player, int channel)
 {
-    assert(player != NULL);
-    assert(channel == 0 || channel == 1);
+    rassert(player != NULL);
+    rassert(channel == 0 || channel == 1);
     return player->audio_buffers[channel];
 }
 
 
 const char* Player_get_events(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     if (player->events_returned)
     {
@@ -920,17 +920,17 @@ const char* Player_get_events(Player* player)
 
 bool Player_has_stopped(const Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
     return (player->master_params.playback_state == PLAYBACK_STOPPED);
 }
 
 
 bool Player_fire(Player* player, int ch, Streader* event_reader)
 {
-    assert(player != NULL);
-    assert(ch >= 0);
-    assert(ch < KQT_CHANNELS_MAX);
-    assert(event_reader != NULL);
+    rassert(player != NULL);
+    rassert(ch >= 0);
+    rassert(ch < KQT_CHANNELS_MAX);
+    rassert(event_reader != NULL);
 
     if (Streader_is_error_set(event_reader))
         return false;
@@ -988,7 +988,7 @@ bool Player_fire(Player* player, int ch, Streader* event_reader)
             break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     if (!Streader_match_char(event_reader, ']'))

--- a/src/lib/player/Player_seq.c
+++ b/src/lib/player/Player_seq.c
@@ -188,7 +188,7 @@ void Player_process_event(
             else                                                         \
                 Player_process_event(player, ch_num, name, value, skip); \
         }                                                                \
-        else (void)0
+        else ignore(0)
 
         switch (type)
         {

--- a/src/lib/player/Player_seq.c
+++ b/src/lib/player/Player_seq.c
@@ -32,10 +32,10 @@ bool get_event_type_info(
         char* ret_name,
         Event_type* ret_type)
 {
-    assert(desc_reader != NULL);
-    assert(names != NULL);
-    assert(ret_name != NULL);
-    assert(ret_type != NULL);
+    rassert(desc_reader != NULL);
+    rassert(names != NULL);
+    rassert(ret_name != NULL);
+    rassert(ret_type != NULL);
 
     if (Streader_is_error_set(desc_reader))
         return false;
@@ -55,7 +55,7 @@ bool get_event_type_info(
         return false;
     }
 
-    assert(Event_is_valid(*ret_type));
+    rassert(Event_is_valid(*ret_type));
     return true;
 }
 
@@ -68,10 +68,10 @@ static bool process_expr(
         const Value* meta,
         Value* ret_value)
 {
-    assert(expr_reader != NULL);
-    assert(estate != NULL);
-    assert(random != NULL);
-    assert(ret_value != NULL);
+    rassert(expr_reader != NULL);
+    rassert(estate != NULL);
+    rassert(random != NULL);
+    rassert(ret_value != NULL);
 
     if (Streader_is_error_set(expr_reader))
         return false;
@@ -120,16 +120,16 @@ static void Player_process_expr_event(
 void Player_process_event(
         Player* player, int ch_num, const char* event_name, const Value* arg, bool skip)
 {
-    assert(player != NULL);
-    assert(implies(!skip, !Event_buffer_is_full(player->event_buffer)));
-    assert(ch_num >= 0);
-    assert(ch_num < KQT_CHANNELS_MAX);
-    assert(event_name != NULL);
-    assert(arg != NULL);
+    rassert(player != NULL);
+    rassert(implies(!skip, !Event_buffer_is_full(player->event_buffer)));
+    rassert(ch_num >= 0);
+    rassert(ch_num < KQT_CHANNELS_MAX);
+    rassert(event_name != NULL);
+    rassert(arg != NULL);
 
     const Event_names* event_names = Event_handler_get_names(player->event_handler);
     const Event_type type = Event_names_get(event_names, event_name);
-    assert(type != Event_NONE);
+    rassert(type != Event_NONE);
 
     if (!Event_is_query(type) &&
             !Event_is_auto(type) &&
@@ -240,7 +240,7 @@ void Player_process_event(
             break;
 
             default:
-                assert(false);
+                rassert(false);
         }
 
 #undef try_process
@@ -257,11 +257,11 @@ static void Player_process_expr_event(
         const Value* meta,
         bool skip)
 {
-    assert(player != NULL);
-    assert(implies(!skip, !Event_buffer_is_full(player->event_buffer)));
-    assert(ch_num >= 0);
-    assert(ch_num < KQT_CHANNELS_MAX);
-    assert(trigger_desc != NULL);
+    rassert(player != NULL);
+    rassert(implies(!skip, !Event_buffer_is_full(player->event_buffer)));
+    rassert(ch_num >= 0);
+    rassert(ch_num < KQT_CHANNELS_MAX);
+    rassert(trigger_desc != NULL);
 
     Streader* sr =
         Streader_init(STREADER_AUTO, trigger_desc, (int64_t)strlen(trigger_desc));
@@ -350,9 +350,9 @@ void Player_reset_channels(Player* player)
 
 static void Player_start_pattern_playback_mode(Player* player)
 {
-    assert(player != NULL);
-    assert(player->master_params.pattern_playback_flag);
-    assert(player->master_params.playback_state == PLAYBACK_PATTERN);
+    rassert(player != NULL);
+    rassert(player->master_params.pattern_playback_flag);
+    rassert(player->master_params.playback_state == PLAYBACK_PATTERN);
 
     player->master_params.pattern_playback_flag = false;
 
@@ -374,9 +374,9 @@ static void Player_start_pattern_playback_mode(Player* player)
 static void Player_set_new_playback_position(
         Player* player, const Pat_inst_ref* target_piref, const Tstamp* target_row)
 {
-    assert(player != NULL);
-    assert(target_piref != NULL);
-    assert(target_row != NULL);
+    rassert(player != NULL);
+    rassert(target_piref != NULL);
+    rassert(target_row != NULL);
 
     Pat_inst_ref actual_target_piref = *target_piref;
     Tstamp* actual_target_row = Tstamp_copy(TSTAMP_AUTO, target_row);
@@ -456,10 +456,10 @@ bool Player_check_perform_goto(Player* player)
 
 void Player_process_cgiters(Player* player, Tstamp* limit, bool skip)
 {
-    assert(player != NULL);
-    assert(!Player_has_stopped(player));
-    assert(limit != NULL);
-    assert(Tstamp_cmp(limit, TSTAMP_AUTO) >= 0);
+    rassert(player != NULL);
+    rassert(!Player_has_stopped(player));
+    rassert(limit != NULL);
+    rassert(Tstamp_cmp(limit, TSTAMP_AUTO) >= 0);
 
     // Check pattern playback start
     if (player->master_params.pattern_playback_flag)
@@ -506,7 +506,7 @@ void Player_process_cgiters(Player* player, Tstamp* limit, bool skip)
         if (tr != NULL)
         {
             // Process trigger row
-            assert(tr->head->next != NULL);
+            rassert(tr->head->next != NULL);
             Trigger_list* trl = tr->head->next;
 
             // Skip triggers if resuming
@@ -531,7 +531,7 @@ void Player_process_cgiters(Player* player, Tstamp* limit, bool skip)
                 if (at_active_jump)
                 {
                     // Process our next Jump context
-                    assert(next_jc != NULL);
+                    rassert(next_jc != NULL);
                     if (next_jc->counter > 0)
                     {
                         player->master_params.do_jump = true;
@@ -593,7 +593,7 @@ void Player_process_cgiters(Player* player, Tstamp* limit, bool skip)
                             // Break if started event skipping
                             if (Event_buffer_is_skipping(player->event_buffer))
                             {
-                                assert(Event_buffer_is_full(player->event_buffer));
+                                rassert(Event_buffer_is_full(player->event_buffer));
                                 Tstamp_set(limit, 0, 0);
 
                                 // Make sure we get this row again next time
@@ -632,7 +632,7 @@ void Player_process_cgiters(Player* player, Tstamp* limit, bool skip)
                             &player->master_params.cur_pos.pat_pos,
                             i,
                             player->master_params.cur_trigger);
-                        assert(next_jc != NULL);
+                        rassert(next_jc != NULL);
                     }
 
                     --next_jc->counter;
@@ -781,10 +781,10 @@ static void update_tempo_slide(Master_params* master_params)
 
 void Player_update_sliders_and_lfos_tempo(Player* player)
 {
-    assert(player != NULL);
+    rassert(player != NULL);
 
     const double tempo = player->master_params.tempo;
-    assert(isfinite(tempo));
+    rassert(isfinite(tempo));
 
     Master_params* mp = &player->master_params;
     Slider_set_tempo(&mp->volume_slider, tempo);
@@ -805,9 +805,9 @@ void Player_update_sliders_and_lfos_tempo(Player* player)
 
 int32_t Player_move_forwards(Player* player, int32_t nframes, bool skip)
 {
-    assert(player != NULL);
-    assert(!Player_has_stopped(player));
-    assert(nframes >= 0);
+    rassert(player != NULL);
+    rassert(!Player_has_stopped(player));
+    rassert(nframes >= 0);
 
     // Process tempo
     update_tempo_slide(&player->master_params);
@@ -863,7 +863,7 @@ int32_t Player_move_forwards(Player* player, int32_t nframes, bool skip)
     // Get actual number of frames to be rendered
     double dframes =
         Tstamp_toframes(limit, player->master_params.tempo, player->audio_rate);
-    assert(dframes >= 0.0);
+    rassert(dframes >= 0.0);
 
     int32_t to_be_rendered = (int32_t)dframes;
     player->frame_remainder += dframes - to_be_rendered;
@@ -873,7 +873,7 @@ int32_t Player_move_forwards(Player* player, int32_t nframes, bool skip)
         player->frame_remainder -= 1.0;
     }
 
-    assert(to_be_rendered <= nframes);
+    rassert(to_be_rendered <= nframes);
 
     return to_be_rendered;
 }

--- a/src/lib/player/Position.c
+++ b/src/lib/player/Position.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2016
  *
  * This file is part of Kunquat.
  *
@@ -21,7 +21,7 @@
 
 void Position_init(Position* pos)
 {
-    assert(pos != NULL);
+    rassert(pos != NULL);
 
     pos->track = -1;
     pos->system = 0;

--- a/src/lib/player/Slider.c
+++ b/src/lib/player/Slider.c
@@ -30,8 +30,8 @@ static void Slider_update_time(Slider* slider, int32_t audio_rate, double tempo)
 
 Slider* Slider_init(Slider* slider, Slide_mode mode)
 {
-    assert(slider != NULL);
-    assert(mode == SLIDE_MODE_LINEAR || mode == SLIDE_MODE_EXP);
+    rassert(slider != NULL);
+    rassert(mode == SLIDE_MODE_LINEAR || mode == SLIDE_MODE_EXP);
 
     slider->mode = mode;
     slider->audio_rate = DEFAULT_AUDIO_RATE;
@@ -52,9 +52,9 @@ Slider* Slider_init(Slider* slider, Slide_mode mode)
 
 Slider* Slider_copy(Slider* restrict dest, const Slider* restrict src)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(dest != src);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(dest != src);
 
     memcpy(dest, src, sizeof(Slider));
 
@@ -64,9 +64,9 @@ Slider* Slider_copy(Slider* restrict dest, const Slider* restrict src)
 
 void Slider_start(Slider* slider, double target, double start)
 {
-    assert(slider != NULL);
-    assert(isfinite(target));
-    assert(isfinite(start));
+    rassert(slider != NULL);
+    rassert(isfinite(target));
+    rassert(isfinite(start));
 
     slider->from = start;
     slider->to = target;
@@ -89,7 +89,7 @@ void Slider_start(Slider* slider, double target, double start)
 
 double Slider_get_value(const Slider* slider)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
 
     if (slider->progress >= 1)
         return slider->to;
@@ -103,7 +103,7 @@ double Slider_get_value(const Slider* slider)
 
 double Slider_step(Slider* slider)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
 
     slider->progress += slider->progress_update;
 
@@ -113,8 +113,8 @@ double Slider_step(Slider* slider)
 
 double Slider_skip(Slider* slider, int64_t steps)
 {
-    assert(slider != NULL);
-    assert(steps >= 0);
+    rassert(slider != NULL);
+    rassert(steps >= 0);
 
     slider->progress += slider->progress_update * (double)steps;
 
@@ -124,7 +124,7 @@ double Slider_skip(Slider* slider, int64_t steps)
 
 int32_t Slider_estimate_active_steps_left(const Slider* slider)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
 
     if (!Slider_in_progress(slider))
         return 0;
@@ -138,7 +138,7 @@ int32_t Slider_estimate_active_steps_left(const Slider* slider)
 
 void Slider_break(Slider* slider)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
 
     slider->progress = 1;
 
@@ -148,8 +148,8 @@ void Slider_break(Slider* slider)
 
 void Slider_change_target(Slider* slider, double target)
 {
-    assert(slider != NULL);
-    assert(isfinite(target));
+    rassert(slider != NULL);
+    rassert(isfinite(target));
 
     if (slider->progress < 1)
         Slider_start(slider, target, Slider_get_value(slider));
@@ -160,8 +160,8 @@ void Slider_change_target(Slider* slider, double target)
 
 void Slider_set_length(Slider* slider, const Tstamp* length)
 {
-    assert(slider != NULL);
-    assert(length != NULL);
+    rassert(slider != NULL);
+    rassert(length != NULL);
 
     Tstamp_copy(&slider->length, length);
     if (slider->progress < 1)
@@ -173,8 +173,8 @@ void Slider_set_length(Slider* slider, const Tstamp* length)
 
 void Slider_set_audio_rate(Slider* slider, int32_t audio_rate)
 {
-    assert(slider != NULL);
-    assert(audio_rate > 0);
+    rassert(slider != NULL);
+    rassert(audio_rate > 0);
 
     if (slider->audio_rate == audio_rate)
         return;
@@ -187,9 +187,9 @@ void Slider_set_audio_rate(Slider* slider, int32_t audio_rate)
 
 void Slider_set_tempo(Slider* slider, double tempo)
 {
-    assert(slider != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(slider != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     if (slider->tempo == tempo)
         return;
@@ -202,7 +202,7 @@ void Slider_set_tempo(Slider* slider, double tempo)
 
 static void Slider_update_time(Slider* slider, int32_t audio_rate, double tempo)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
 
     slider->audio_rate = audio_rate;
     slider->tempo = tempo;
@@ -217,7 +217,7 @@ static void Slider_update_time(Slider* slider, int32_t audio_rate, double tempo)
 
 bool Slider_in_progress(const Slider* slider)
 {
-    assert(slider != NULL);
+    rassert(slider != NULL);
     return (slider->progress < 1);
 }
 
@@ -229,11 +229,11 @@ void Slider_change_range(
         double to_start,
         double to_end)
 {
-    assert(slider != NULL);
-    assert(isfinite(from_start));
-    assert(isfinite(from_end));
-    assert(isfinite(to_start));
-    assert(isfinite(to_end));
+    rassert(slider != NULL);
+    rassert(isfinite(from_start));
+    rassert(isfinite(from_end));
+    rassert(isfinite(to_start));
+    rassert(isfinite(to_end));
 
     const double start_norm = get_range_norm(slider->from, from_start, from_end);
     const double target_norm = get_range_norm(slider->to, from_start, from_end);

--- a/src/lib/player/Time_env_state.c
+++ b/src/lib/player/Time_env_state.c
@@ -126,7 +126,7 @@ int32_t Time_env_state_process(
             {
                 // Get next value through calculated update value
                 // (faster than accessing the envelope directly)
-                rassert(isfinite(update_value));
+                dassert(isfinite(update_value));
                 cur_value += update_value * scale_factor * slowdown_fac;
                 value = clamp(cur_value, min_value, max_value);
             }
@@ -165,7 +165,7 @@ int32_t Time_env_state_process(
         }
 
         // Apply envelope value
-        rassert(isfinite(value));
+        dassert(isfinite(value));
         env_buf[i] = (float)value;
 
         // Update envelope position
@@ -187,7 +187,7 @@ int32_t Time_env_state_process(
             if (new_pos > loop_end[0])
             {
                 const double loop_len = loop_end[0] - loop_start[0];
-                rassert(loop_len >= 0);
+                dassert(loop_len >= 0);
                 new_pos = loop_end[0];
 
                 if (loop_len > 0)
@@ -195,8 +195,8 @@ int32_t Time_env_state_process(
                     const double exceed = new_pos - loop_end[0];
                     const double offset = fmod(exceed, loop_len);
                     new_pos = loop_start[0] + offset;
-                    rassert(new_pos >= loop_start[0]);
-                    rassert(new_pos <= loop_end[0]);
+                    dassert(new_pos >= loop_start[0]);
+                    dassert(new_pos <= loop_end[0]);
 
                     // Following iteration will check if this index is too low,
                     // so no need to find the exact result in a loop

--- a/src/lib/player/Time_env_state.c
+++ b/src/lib/player/Time_env_state.c
@@ -29,7 +29,7 @@
 
 void Time_env_state_init(Time_env_state* testate)
 {
-    assert(testate != NULL);
+    rassert(testate != NULL);
 
     testate->is_finished = false;
     testate->cur_pos = 0;
@@ -57,19 +57,19 @@ int32_t Time_env_state_process(
         int32_t buf_stop,
         int32_t audio_rate)
 {
-    assert(testate != NULL);
-    assert(env != NULL);
-    assert(isfinite(scale_amount));
-    assert(isfinite(scale_center));
-    assert(sustain >= 0);
-    assert(sustain <= 1);
-    assert(isfinite(min_value));
-    assert(isfinite(max_value));
-    assert(pitch_wb != NULL);
-    assert(env_buf != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
+    rassert(testate != NULL);
+    rassert(env != NULL);
+    rassert(isfinite(scale_amount));
+    rassert(isfinite(scale_center));
+    rassert(sustain >= 0);
+    rassert(sustain <= 1);
+    rassert(isfinite(min_value));
+    rassert(isfinite(max_value));
+    rassert(pitch_wb != NULL);
+    rassert(env_buf != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
 
     if (testate->is_finished)
         return buf_start;
@@ -126,7 +126,7 @@ int32_t Time_env_state_process(
             {
                 // Get next value through calculated update value
                 // (faster than accessing the envelope directly)
-                assert(isfinite(update_value));
+                rassert(isfinite(update_value));
                 cur_value += update_value * scale_factor * slowdown_fac;
                 value = clamp(cur_value, min_value, max_value);
             }
@@ -136,7 +136,7 @@ int32_t Time_env_state_process(
                 ++next_node_index;
                 if ((loop_end_index >= 0) && (loop_end_index < next_node_index))
                 {
-                    assert(loop_start_index >= 0);
+                    rassert(loop_start_index >= 0);
                     next_node_index = loop_start_index;
                 }
 
@@ -165,7 +165,7 @@ int32_t Time_env_state_process(
         }
 
         // Apply envelope value
-        assert(isfinite(value));
+        rassert(isfinite(value));
         env_buf[i] = (float)value;
 
         // Update envelope position
@@ -187,7 +187,7 @@ int32_t Time_env_state_process(
             if (new_pos > loop_end[0])
             {
                 const double loop_len = loop_end[0] - loop_start[0];
-                assert(loop_len >= 0);
+                rassert(loop_len >= 0);
                 new_pos = loop_end[0];
 
                 if (loop_len > 0)
@@ -195,8 +195,8 @@ int32_t Time_env_state_process(
                     const double exceed = new_pos - loop_end[0];
                     const double offset = fmod(exceed, loop_len);
                     new_pos = loop_start[0] + offset;
-                    assert(new_pos >= loop_start[0]);
-                    assert(new_pos <= loop_end[0]);
+                    rassert(new_pos >= loop_start[0]);
+                    rassert(new_pos <= loop_end[0]);
 
                     // Following iteration will check if this index is too low,
                     // so no need to find the exact result in a loop

--- a/src/lib/player/Tuning_state.c
+++ b/src/lib/player/Tuning_state.c
@@ -38,14 +38,14 @@ Tuning_state* new_Tuning_state(void)
 
 bool Tuning_state_can_retune(const Tuning_state* ts)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
     return (ts->note_count > 0);
 }
 
 
 void Tuning_state_reset(Tuning_state* ts, const Tuning_table* table)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
 
     if (table == NULL)
     {
@@ -76,8 +76,8 @@ void Tuning_state_reset(Tuning_state* ts, const Tuning_table* table)
 
 void Tuning_state_set_global_offset(Tuning_state* ts, double offset)
 {
-    assert(ts != NULL);
-    assert(isfinite(offset));
+    rassert(ts != NULL);
+    rassert(isfinite(offset));
 
     ts->global_offset = offset;
 
@@ -88,9 +88,9 @@ void Tuning_state_set_global_offset(Tuning_state* ts, double offset)
 void Tuning_state_set_fixed_pitch(
         Tuning_state* ts, const Tuning_table* table, double pitch)
 {
-    assert(ts != NULL);
-    assert(table != NULL);
-    assert(isfinite(pitch));
+    rassert(ts != NULL);
+    rassert(table != NULL);
+    rassert(isfinite(pitch));
 
     const int note_index = Tuning_table_get_nearest_note_index(table, pitch);
     ts->fixed_point = note_index;
@@ -101,9 +101,9 @@ void Tuning_state_set_fixed_pitch(
 
 void Tuning_state_retune(Tuning_state* ts, const Tuning_table* table, double new_ref)
 {
-    assert(ts != NULL);
-    assert(table != NULL);
-    assert(isfinite(new_ref));
+    rassert(ts != NULL);
+    rassert(table != NULL);
+    rassert(isfinite(new_ref));
 
     const int note_count = ts->note_count;
     if (note_count == 0)
@@ -147,9 +147,9 @@ void Tuning_state_retune(Tuning_state* ts, const Tuning_table* table, double new
 double Tuning_state_get_retuned_pitch(
         const Tuning_state* ts, const Tuning_table* table, double cents)
 {
-    assert(ts != NULL);
-    assert(table != NULL);
-    assert(isfinite(cents));
+    rassert(ts != NULL);
+    rassert(table != NULL);
+    rassert(isfinite(cents));
 
     if (ts->note_count == 0)
         return cents;
@@ -166,9 +166,9 @@ double Tuning_state_get_retuned_pitch(
 bool Tuning_state_retune_with_source(
         Tuning_state* ts, const Tuning_table* table, const Tuning_table* source)
 {
-    assert(ts != NULL);
-    assert(table != NULL);
-    assert(source != NULL);
+    rassert(ts != NULL);
+    rassert(table != NULL);
+    rassert(source != NULL);
 
     if (Tuning_table_get_note_count(table) != Tuning_table_get_note_count(source))
         return false;
@@ -182,7 +182,7 @@ bool Tuning_state_retune_with_source(
 
 double Tuning_state_get_estimated_drift(const Tuning_state* ts)
 {
-    assert(ts != NULL);
+    rassert(ts != NULL);
     return ts->drift;
 }
 

--- a/src/lib/player/Voice.c
+++ b/src/lib/player/Voice.c
@@ -58,8 +58,8 @@ Voice* new_Voice(void)
 
 bool Voice_reserve_state_space(Voice* voice, int32_t state_size)
 {
-    assert(voice != NULL);
-    assert(state_size >= 0);
+    rassert(voice != NULL);
+    rassert(state_size >= 0);
 
     if (state_size <= voice->state_size)
         return true;
@@ -77,8 +77,8 @@ bool Voice_reserve_state_space(Voice* voice, int32_t state_size)
 
 int Voice_cmp(const Voice* v1, const Voice* v2)
 {
-    assert(v1 != NULL);
-    assert(v2 != NULL);
+    rassert(v1 != NULL);
+    rassert(v2 != NULL);
 
     return (int)v1->prio - (int)v2->prio;
 }
@@ -86,21 +86,21 @@ int Voice_cmp(const Voice* v1, const Voice* v2)
 
 uint64_t Voice_id(const Voice* voice)
 {
-    assert(voice != NULL);
+    rassert(voice != NULL);
     return voice->id;
 }
 
 
 uint64_t Voice_get_group_id(const Voice* voice)
 {
-    assert(voice != NULL);
+    rassert(voice != NULL);
     return voice->group_id;
 }
 
 
 const Processor* Voice_get_proc(const Voice* voice)
 {
-    assert(voice != NULL);
+    rassert(voice != NULL);
     return voice->proc;
 }
 
@@ -112,9 +112,9 @@ void Voice_init(
         const Proc_state* proc_state,
         uint64_t seed)
 {
-    assert(voice != NULL);
-    assert(proc != NULL);
-    assert(proc_state != NULL);
+    rassert(voice != NULL);
+    rassert(proc != NULL);
+    rassert(proc_state != NULL);
 
     voice->prio = VOICE_PRIO_NEW;
     voice->proc = proc;
@@ -134,7 +134,7 @@ void Voice_init(
 
 void Voice_reset(Voice* voice)
 {
-    assert(voice != NULL);
+    rassert(voice != NULL);
 
     voice->id = 0;
     voice->group_id = 0;
@@ -156,12 +156,12 @@ int32_t Voice_render(
         int32_t buf_stop,
         double tempo)
 {
-    assert(voice != NULL);
-    assert(voice->proc != NULL);
-    assert(dstates != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= buf_start);
+    rassert(voice != NULL);
+    rassert(voice->proc != NULL);
+    rassert(dstates != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= buf_start);
 
     if (voice->prio == VOICE_PRIO_INACTIVE)
         return buf_stop;

--- a/src/lib/player/Voice_group.c
+++ b/src/lib/player/Voice_group.c
@@ -25,11 +25,11 @@
 Voice_group* Voice_group_init(
         Voice_group* vg, Voice** voices, int offset, int vp_size)
 {
-    assert(vg != NULL);
-    assert(voices != NULL);
-    assert(offset >= 0);
-    assert(offset < vp_size);
-    assert(vp_size > 0);
+    rassert(vg != NULL);
+    rassert(voices != NULL);
+    rassert(offset >= 0);
+    rassert(offset < vp_size);
+    rassert(vp_size > 0);
 
     vg->voices = voices + offset;
 
@@ -44,7 +44,7 @@ Voice_group* Voice_group_init(
 
     for (int i = offset + 1; i < vp_size; ++i)
     {
-        assert(voices[i] != NULL);
+        rassert(voices[i] != NULL);
         if (Voice_get_group_id(voices[i]) != group_id)
             break;
         ++vg->size;
@@ -59,14 +59,14 @@ Voice_group* Voice_group_init(
 
 int Voice_group_get_size(const Voice_group* vg)
 {
-    assert(vg != NULL);
+    rassert(vg != NULL);
     return vg->size;
 }
 
 
 int Voice_group_get_active_count(const Voice_group* vg)
 {
-    assert(vg != NULL);
+    rassert(vg != NULL);
 
     int count = 0;
     for (int i = 0; i < vg->size; ++i)
@@ -81,9 +81,9 @@ int Voice_group_get_active_count(const Voice_group* vg)
 
 Voice* Voice_group_get_voice(Voice_group* vg, int index)
 {
-    assert(vg != NULL);
-    assert(index >= 0);
-    assert(index < Voice_group_get_size(vg));
+    rassert(vg != NULL);
+    rassert(index >= 0);
+    rassert(index < Voice_group_get_size(vg));
 
     return vg->voices[index];
 }
@@ -91,7 +91,7 @@ Voice* Voice_group_get_voice(Voice_group* vg, int index)
 
 Voice* Voice_group_get_voice_by_proc(Voice_group* vg, uint32_t proc_id)
 {
-    assert(vg != NULL);
+    rassert(vg != NULL);
 
     for (int i = 0; i < vg->size; ++i)
     {
@@ -106,7 +106,7 @@ Voice* Voice_group_get_voice_by_proc(Voice_group* vg, uint32_t proc_id)
 
 void Voice_group_deactivate_all(Voice_group* vg)
 {
-    assert(vg != NULL);
+    rassert(vg != NULL);
 
     for (int i = 0; i < vg->size; ++i)
         Voice_reset(vg->voices[i]);
@@ -117,7 +117,7 @@ void Voice_group_deactivate_all(Voice_group* vg)
 
 void Voice_group_deactivate_unreachable(Voice_group* vg)
 {
-    assert(vg != NULL);
+    rassert(vg != NULL);
 
     for (int i = 0; i < vg->size; ++i)
     {

--- a/src/lib/player/Voice_pool.c
+++ b/src/lib/player/Voice_pool.c
@@ -25,7 +25,7 @@
 
 Voice_pool* new_Voice_pool(int size)
 {
-    assert(size >= 0);
+    rassert(size >= 0);
 
     Voice_pool* pool = memory_alloc_item(Voice_pool);
     if (pool == NULL)
@@ -69,8 +69,8 @@ Voice_pool* new_Voice_pool(int size)
 
 bool Voice_pool_reserve_state_space(Voice_pool* pool, int32_t state_size)
 {
-    assert(pool != NULL);
-    assert(state_size >= 0);
+    rassert(pool != NULL);
+    rassert(state_size >= 0);
 
     if (state_size <= pool->state_size)
         return true;
@@ -88,8 +88,8 @@ bool Voice_pool_reserve_state_space(Voice_pool* pool, int32_t state_size)
 
 bool Voice_pool_resize(Voice_pool* pool, int size)
 {
-    assert(pool != NULL);
-    assert(size > 0);
+    rassert(pool != NULL);
+    rassert(size > 0);
 
     int new_size = size;
     if (new_size == pool->size)
@@ -147,14 +147,14 @@ bool Voice_pool_resize(Voice_pool* pool, int size)
 
 int Voice_pool_get_size(const Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
     return pool->size;
 }
 
 
 uint64_t Voice_pool_new_group_id(Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
     ++pool->new_group_id;
     return pool->new_group_id;
 }
@@ -162,7 +162,7 @@ uint64_t Voice_pool_new_group_id(Voice_pool* pool)
 
 Voice* Voice_pool_get_voice(Voice_pool* pool, Voice* voice, uint64_t id)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
 
     if (pool->size == 0)
         return NULL;
@@ -202,7 +202,7 @@ static uint64_t get_voice_group_prio(const Voice* voice)
 
 static void Voice_pool_sort_groups(Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
 
     // Simple insertion sort based on group IDs
     for (uint16_t i = 1; i < pool->size; ++i)
@@ -228,7 +228,7 @@ static void Voice_pool_sort_groups(Voice_pool* pool)
 
 Voice_group* Voice_pool_start_group_iteration(Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
 
     Voice_pool_sort_groups(pool);
 
@@ -244,7 +244,7 @@ Voice_group* Voice_pool_start_group_iteration(Voice_pool* pool)
 
 Voice_group* Voice_pool_get_next_group(Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
 
     if (pool->group_iter_offset >= pool->size)
         return NULL;
@@ -262,7 +262,7 @@ Voice_group* Voice_pool_get_next_group(Voice_pool* pool)
 
 void Voice_pool_reset(Voice_pool* pool)
 {
-    assert(pool != NULL);
+    rassert(pool != NULL);
 
     for (uint16_t i = 0; i < pool->size; ++i)
         Voice_reset(pool->voices[i]);

--- a/src/lib/player/Work_buffer.c
+++ b/src/lib/player/Work_buffer.c
@@ -40,8 +40,8 @@ struct Work_buffer
 
 Work_buffer* new_Work_buffer(int32_t size)
 {
-    assert(size >= 0);
-    assert(size <= WORK_BUFFER_SIZE_MAX);
+    rassert(size >= 0);
+    rassert(size <= WORK_BUFFER_SIZE_MAX);
 
     Work_buffer* buffer = memory_alloc_item(Work_buffer);
     if (buffer == NULL)
@@ -71,9 +71,9 @@ Work_buffer* new_Work_buffer(int32_t size)
 
 bool Work_buffer_resize(Work_buffer* buffer, int32_t new_size)
 {
-    assert(buffer != NULL);
-    assert(new_size >= 0);
-    assert(new_size <= WORK_BUFFER_SIZE_MAX);
+    rassert(buffer != NULL);
+    rassert(new_size >= 0);
+    rassert(new_size <= WORK_BUFFER_SIZE_MAX);
 
     if (new_size == 0)
     {
@@ -100,11 +100,11 @@ bool Work_buffer_resize(Work_buffer* buffer, int32_t new_size)
 
 void Work_buffer_clear(Work_buffer* buffer, int32_t buf_start, int32_t buf_stop)
 {
-    assert(buffer != NULL);
-    assert(buf_start >= -1);
-    assert(buf_start <= Work_buffer_get_size(buffer));
-    assert(buf_stop >= -1);
-    assert(buf_stop <= Work_buffer_get_size(buffer) + 1);
+    rassert(buffer != NULL);
+    rassert(buf_start >= -1);
+    rassert(buf_start <= Work_buffer_get_size(buffer));
+    rassert(buf_stop >= -1);
+    rassert(buf_stop <= Work_buffer_get_size(buffer) + 1);
 
     float* fcontents = Work_buffer_get_contents_mut(buffer);
     for (int32_t i = buf_start; i < buf_stop; ++i)
@@ -118,21 +118,21 @@ void Work_buffer_clear(Work_buffer* buffer, int32_t buf_start, int32_t buf_stop)
 
 int32_t Work_buffer_get_size(const Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
     return buffer->size;
 }
 
 
 const float* Work_buffer_get_contents(const Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
     return (float*)buffer->contents + 1;
 }
 
 
 float* Work_buffer_get_contents_mut(Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
 
     Work_buffer_clear_const_start(buffer);
 
@@ -142,14 +142,14 @@ float* Work_buffer_get_contents_mut(Work_buffer* buffer)
 
 float* Work_buffer_get_contents_mut_keep_const(Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
     return (float*)buffer->contents + 1;
 }
 
 
 int32_t* Work_buffer_get_contents_int_mut(Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
 
     Work_buffer_clear_const_start(buffer);
 
@@ -163,13 +163,13 @@ void Work_buffer_copy(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(dest != NULL);
-    assert(src != NULL);
-    assert(dest != src);
-    assert(buf_start >= -1);
-    assert(buf_start <= Work_buffer_get_size(dest));
-    assert(buf_stop >= -1);
-    assert(buf_stop <= Work_buffer_get_size(dest) + 1);
+    rassert(dest != NULL);
+    rassert(src != NULL);
+    rassert(dest != src);
+    rassert(buf_start >= -1);
+    rassert(buf_start <= Work_buffer_get_size(dest));
+    rassert(buf_stop >= -1);
+    rassert(buf_stop <= Work_buffer_get_size(dest) + 1);
 
     if (buf_start >= buf_stop)
         return;
@@ -181,7 +181,7 @@ void Work_buffer_copy(
     const char* src_start =
         (char*)src->contents + (actual_start * WORK_BUFFER_ELEM_SIZE);
     const int32_t elem_count = actual_stop - actual_start;
-    assert(elem_count >= 0);
+    rassert(elem_count >= 0);
     memcpy(dest_start, src_start, (size_t)(elem_count * WORK_BUFFER_ELEM_SIZE));
 
     Work_buffer_set_const_start(dest, Work_buffer_get_const_start(src));
@@ -192,8 +192,8 @@ void Work_buffer_copy(
 
 void Work_buffer_set_const_start(Work_buffer* buffer, int32_t start)
 {
-    assert(buffer != NULL);
-    assert(start >= 0);
+    rassert(buffer != NULL);
+    rassert(start >= 0);
 
     buffer->const_start = start;
 
@@ -203,7 +203,7 @@ void Work_buffer_set_const_start(Work_buffer* buffer, int32_t start)
 
 void Work_buffer_clear_const_start(Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
     buffer->const_start = INT32_MAX;
     return;
 }
@@ -211,7 +211,7 @@ void Work_buffer_clear_const_start(Work_buffer* buffer)
 
 int32_t Work_buffer_get_const_start(const Work_buffer* buffer)
 {
-    assert(buffer != NULL);
+    rassert(buffer != NULL);
     return buffer->const_start;
 }
 
@@ -222,13 +222,13 @@ void Work_buffer_mix(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(buffer != NULL);
-    assert(in != NULL);
-    assert(Work_buffer_get_size(buffer) == Work_buffer_get_size(in));
-    assert(buf_start >= -1);
-    assert(buf_start <= Work_buffer_get_size(buffer));
-    assert(buf_stop >= -1);
-    assert(buf_stop <= Work_buffer_get_size(buffer) + 1);
+    rassert(buffer != NULL);
+    rassert(in != NULL);
+    rassert(Work_buffer_get_size(buffer) == Work_buffer_get_size(in));
+    rassert(buf_start >= -1);
+    rassert(buf_start <= Work_buffer_get_size(buffer));
+    rassert(buf_stop >= -1);
+    rassert(buf_stop <= Work_buffer_get_size(buffer) + 1);
 
     if (buffer == in)
         return;

--- a/src/lib/player/Work_buffers.c
+++ b/src/lib/player/Work_buffers.c
@@ -31,8 +31,8 @@ struct Work_buffers
 
 Work_buffers* new_Work_buffers(int32_t buf_size)
 {
-    assert(buf_size >= 0);
-    assert(buf_size <= WORK_BUFFER_SIZE_MAX);
+    rassert(buf_size >= 0);
+    rassert(buf_size <= WORK_BUFFER_SIZE_MAX);
 
     Work_buffers* buffers = memory_alloc_item(Work_buffers);
     if (buffers == NULL)
@@ -59,9 +59,9 @@ Work_buffers* new_Work_buffers(int32_t buf_size)
 
 bool Work_buffers_resize(Work_buffers* buffers, int32_t new_size)
 {
-    assert(buffers != NULL);
-    assert(new_size >= 0);
-    assert(new_size <= WORK_BUFFER_SIZE_MAX);
+    rassert(buffers != NULL);
+    rassert(new_size >= 0);
+    rassert(new_size <= WORK_BUFFER_SIZE_MAX);
 
     for (int i = 0; i < WORK_BUFFER_COUNT_; ++i)
     {
@@ -76,8 +76,8 @@ bool Work_buffers_resize(Work_buffers* buffers, int32_t new_size)
 const Work_buffer* Work_buffers_get_buffer(
         const Work_buffers* buffers, Work_buffer_type type)
 {
-    assert(buffers != NULL);
-    assert(type < WORK_BUFFER_COUNT_);
+    rassert(buffers != NULL);
+    rassert(type < WORK_BUFFER_COUNT_);
 
     return buffers->buffers[type];
 }
@@ -86,8 +86,8 @@ const Work_buffer* Work_buffers_get_buffer(
 Work_buffer* Work_buffers_get_buffer_mut(
         const Work_buffers* buffers, Work_buffer_type type)
 {
-    assert(buffers != NULL);
-    assert(type < WORK_BUFFER_COUNT_);
+    rassert(buffers != NULL);
+    rassert(type < WORK_BUFFER_COUNT_);
 
     return buffers->buffers[type];
 }
@@ -96,8 +96,8 @@ Work_buffer* Work_buffers_get_buffer_mut(
 const float* Work_buffers_get_buffer_contents(
         const Work_buffers* buffers, Work_buffer_type type)
 {
-    assert(buffers != NULL);
-    assert(type < WORK_BUFFER_COUNT_);
+    rassert(buffers != NULL);
+    rassert(type < WORK_BUFFER_COUNT_);
 
     return Work_buffer_get_contents(buffers->buffers[type]);
 }
@@ -106,8 +106,8 @@ const float* Work_buffers_get_buffer_contents(
 float* Work_buffers_get_buffer_contents_mut(
         const Work_buffers* buffers, Work_buffer_type type)
 {
-    assert(buffers != NULL);
-    assert(type < WORK_BUFFER_COUNT_);
+    rassert(buffers != NULL);
+    rassert(type < WORK_BUFFER_COUNT_);
 
     return Work_buffer_get_contents_mut(buffers->buffers[type]);
 }
@@ -116,8 +116,8 @@ float* Work_buffers_get_buffer_contents_mut(
 int32_t* Work_buffers_get_buffer_contents_int_mut(
         const Work_buffers* buffers, Work_buffer_type type)
 {
-    assert(buffers != NULL);
-    assert(type < WORK_BUFFER_COUNT_);
+    rassert(buffers != NULL);
+    rassert(type < WORK_BUFFER_COUNT_);
 
     return Work_buffer_get_contents_int_mut(buffers->buffers[type]);
 }

--- a/src/lib/player/devices/Au_state.c
+++ b/src/lib/player/devices/Au_state.c
@@ -35,7 +35,7 @@ static bool Au_state_init(
         int32_t audio_rate,
         int32_t audio_buffer_size)
 {
-    assert(au_state != NULL);
+    rassert(au_state != NULL);
 
     if (!Device_state_init(&au_state->parent, device, audio_rate, audio_buffer_size))
         return false;
@@ -56,8 +56,8 @@ static void mix_interface_connection(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(out_ds != NULL);
-    assert(in_ds != NULL);
+    rassert(out_ds != NULL);
+    rassert(in_ds != NULL);
 
     for (int port = 0; port < KQT_DEVICE_PORTS_MAX; ++port)
     {
@@ -81,11 +81,11 @@ static void Au_state_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Au_state* au_state = (Au_state*)dstate;
 
@@ -101,7 +101,7 @@ static void Au_state_render_mixed(
         //Connections_clear_buffers(au->connections, dstates, buf_start, buf_stop);
 
         Device_states* dstates = au_state->dstates;
-        assert(dstates != NULL);
+        rassert(dstates != NULL);
 
         // Fill input interface buffers
         Device_state* in_iface_ds = Device_states_get_state(
@@ -132,9 +132,9 @@ static void Au_state_render_mixed(
 Device_state* new_Au_state(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Au_state* au_state = memory_alloc_item(Au_state);
     if (au_state == NULL)
@@ -154,8 +154,8 @@ Device_state* new_Au_state(
 
 void Au_state_set_device_states(Au_state* au_state, Device_states* dstates)
 {
-    assert(au_state != NULL);
-    assert(dstates != NULL);
+    rassert(au_state != NULL);
+    rassert(dstates != NULL);
 
     au_state->dstates = dstates;
 
@@ -165,7 +165,7 @@ void Au_state_set_device_states(Au_state* au_state, Device_states* dstates)
 
 void Au_state_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Au_state* au_state = (Au_state*)dstate;
     au_state->bypass = false;

--- a/src/lib/player/devices/Device_state.c
+++ b/src/lib/player/devices/Device_state.c
@@ -33,10 +33,10 @@ bool Device_state_init(
         int32_t audio_rate,
         int32_t audio_buffer_size)
 {
-    assert(ds != NULL);
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(ds != NULL);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     ds->device = device;
     ds->device_id = Device_get_id(ds->device);
@@ -76,9 +76,9 @@ bool Device_state_init(
 Device_state* new_Device_state_plain(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Device_state* ds = memory_alloc_item(Device_state);
     if (ds == NULL)
@@ -96,8 +96,8 @@ Device_state* new_Device_state_plain(
 
 int Device_state_cmp(const Device_state* ds1, const Device_state* ds2)
 {
-    assert(ds1 != NULL);
-    assert(ds2 != NULL);
+    rassert(ds1 != NULL);
+    rassert(ds2 != NULL);
 
     if (ds1->device_id < ds2->device_id)
         return -1;
@@ -109,15 +109,15 @@ int Device_state_cmp(const Device_state* ds1, const Device_state* ds2)
 
 const Device* Device_state_get_device(const Device_state* ds)
 {
-    assert(ds != NULL);
+    rassert(ds != NULL);
     return ds->device;
 }
 
 
 void Device_state_set_node_state(Device_state* ds, Device_node_state node_state)
 {
-    assert(ds != NULL);
-    assert(node_state < DEVICE_NODE_STATE_COUNT);
+    rassert(ds != NULL);
+    rassert(node_state < DEVICE_NODE_STATE_COUNT);
 
     ds->node_state = node_state;
 
@@ -127,15 +127,15 @@ void Device_state_set_node_state(Device_state* ds, Device_node_state node_state)
 
 Device_node_state Device_state_get_node_state(const Device_state* ds)
 {
-    assert(ds != NULL);
+    rassert(ds != NULL);
     return ds->node_state;
 }
 
 
 bool Device_state_set_audio_rate(Device_state* ds, int32_t audio_rate)
 {
-    assert(ds != NULL);
-    assert(audio_rate > 0);
+    rassert(ds != NULL);
+    rassert(audio_rate > 0);
 
     if (ds->audio_rate == audio_rate)
         return true;
@@ -151,15 +151,15 @@ bool Device_state_set_audio_rate(Device_state* ds, int32_t audio_rate)
 
 int32_t Device_state_get_audio_rate(const Device_state* ds)
 {
-    assert(ds != NULL);
+    rassert(ds != NULL);
     return ds->audio_rate;
 }
 
 
 bool Device_state_set_audio_buffer_size(Device_state* ds, int32_t size)
 {
-    assert(ds != NULL);
-    assert(size >= 0);
+    rassert(ds != NULL);
+    rassert(size >= 0);
 
     ds->audio_buffer_size = min(ds->audio_buffer_size, size);
 
@@ -184,8 +184,8 @@ bool Device_state_set_audio_buffer_size(Device_state* ds, int32_t size)
 
 bool Device_state_allocate_space(Device_state* ds, char* key)
 {
-    assert(ds != NULL);
-    assert(key != NULL);
+    rassert(ds != NULL);
+    rassert(key != NULL);
 
     return true;
 }
@@ -193,10 +193,10 @@ bool Device_state_allocate_space(Device_state* ds, char* key)
 
 bool Device_state_add_audio_buffer(Device_state* ds, Device_port_type type, int port)
 {
-    assert(ds != NULL);
-    assert(type == DEVICE_PORT_TYPE_RECEIVE || type == DEVICE_PORT_TYPE_SEND);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(ds != NULL);
+    rassert(type == DEVICE_PORT_TYPE_RECEIVE || type == DEVICE_PORT_TYPE_SEND);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     if (ds->buffers[type][port] != NULL)
         return true;
@@ -214,9 +214,9 @@ bool Device_state_add_audio_buffer(Device_state* ds, Device_port_type type, int 
 
 void Device_state_clear_audio_buffers(Device_state* ds, int32_t start, int32_t stop)
 {
-    assert(ds != NULL);
-    assert(start >= 0);
-    assert(stop >= start);
+    rassert(ds != NULL);
+    rassert(start >= 0);
+    rassert(stop >= start);
 
     for (int port = 0; port < KQT_DEVICE_PORTS_MAX; ++port)
     {
@@ -238,10 +238,10 @@ void Device_state_clear_audio_buffers(Device_state* ds, int32_t start, int32_t s
 Work_buffer* Device_state_get_audio_buffer(
         const Device_state* ds, Device_port_type type, int port)
 {
-    assert(ds != NULL);
-    assert(type < DEVICE_PORT_TYPES);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(ds != NULL);
+    rassert(type < DEVICE_PORT_TYPES);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     if ((type == DEVICE_PORT_TYPE_RECEIVE) &&
             !Device_state_is_input_port_connected(ds, port))
@@ -254,10 +254,10 @@ Work_buffer* Device_state_get_audio_buffer(
 float* Device_state_get_audio_buffer_contents_mut(
         const Device_state* ds, Device_port_type type, int port)
 {
-    assert(ds != NULL);
-    assert(type < DEVICE_PORT_TYPES);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(ds != NULL);
+    rassert(type < DEVICE_PORT_TYPES);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     Work_buffer* wb = Device_state_get_audio_buffer(ds, type, port);
     if (wb == NULL)
@@ -269,9 +269,9 @@ float* Device_state_get_audio_buffer_contents_mut(
 
 void Device_state_mark_input_port_connected(Device_state* ds, int port)
 {
-    assert(ds != NULL);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(ds != NULL);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     Bit_array_set(ds->in_connected, port, true);
 
@@ -281,9 +281,9 @@ void Device_state_mark_input_port_connected(Device_state* ds, int port)
 
 bool Device_state_is_input_port_connected(const Device_state* ds, int port)
 {
-    assert(ds != NULL);
-    assert(port >= 0);
-    assert(port < KQT_DEVICE_PORTS_MAX);
+    rassert(ds != NULL);
+    rassert(port >= 0);
+    rassert(port < KQT_DEVICE_PORTS_MAX);
 
     return Bit_array_get(ds->in_connected, port);
 }
@@ -291,9 +291,9 @@ bool Device_state_is_input_port_connected(const Device_state* ds, int port)
 
 void Device_state_set_tempo(Device_state* ds, double tempo)
 {
-    assert(ds != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(ds != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     if (ds->set_tempo != NULL)
         ds->set_tempo(ds, tempo);
@@ -304,7 +304,7 @@ void Device_state_set_tempo(Device_state* ds, double tempo)
 
 void Device_state_reset(Device_state* ds)
 {
-    assert(ds != NULL);
+    rassert(ds != NULL);
 
     if (ds->reset != NULL)
         ds->reset(ds);
@@ -320,13 +320,13 @@ void Device_state_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(ds != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(ds != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
-    assert(ds->node_state == DEVICE_NODE_STATE_REACHED);
+    rassert(ds->node_state == DEVICE_NODE_STATE_REACHED);
 
     if (Device_get_mixed_signals(ds->device) && (ds->render_mixed != NULL))
         ds->render_mixed(ds, wbs, buf_start, buf_stop, tempo);

--- a/src/lib/player/devices/Proc_state.c
+++ b/src/lib/player/devices/Proc_state.c
@@ -54,10 +54,10 @@ bool Proc_state_init(
         int32_t audio_rate,
         int32_t audio_buffer_size)
 {
-    assert(proc_state != NULL);
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(proc_state != NULL);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     proc_state->destroy = NULL;
     proc_state->set_audio_rate = NULL;
@@ -92,8 +92,8 @@ bool Proc_state_init(
 
 bool Proc_state_set_audio_rate(Device_state* dstate, int32_t audio_rate)
 {
-    assert(dstate != NULL);
-    assert(audio_rate > 0);
+    rassert(dstate != NULL);
+    rassert(audio_rate > 0);
 
     Proc_state* proc_state = (Proc_state*)dstate;
     if (proc_state->set_audio_rate != NULL)
@@ -105,9 +105,9 @@ bool Proc_state_set_audio_rate(Device_state* dstate, int32_t audio_rate)
 
 void Proc_state_set_tempo(Device_state* dstate, double tempo)
 {
-    assert(dstate != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Proc_state* proc_state = (Proc_state*)dstate;
     if (proc_state->set_tempo != NULL)
@@ -119,7 +119,7 @@ void Proc_state_set_tempo(Device_state* dstate, double tempo)
 
 void Proc_state_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Proc_state* proc_state = (Proc_state*)dstate;
     if (proc_state->reset != NULL)
@@ -136,11 +136,11 @@ void Proc_state_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Proc_state* proc_state = (Proc_state*)dstate;
     if (proc_state->render_mixed != NULL)
@@ -152,7 +152,7 @@ void Proc_state_render_mixed(
 
 void Proc_state_clear_history(Proc_state* proc_state)
 {
-    assert(proc_state != NULL);
+    rassert(proc_state != NULL);
 
     if (proc_state->clear_history != NULL)
         proc_state->clear_history(proc_state);
@@ -163,7 +163,7 @@ void Proc_state_clear_history(Proc_state* proc_state)
 
 void Proc_state_clear_voice_buffers(Proc_state* proc_state)
 {
-    assert(proc_state != NULL);
+    rassert(proc_state != NULL);
 
     for (Device_port_type port_type = DEVICE_PORT_TYPE_RECEIVE;
             port_type < DEVICE_PORT_TYPES; ++port_type)
@@ -183,10 +183,10 @@ void Proc_state_clear_voice_buffers(Proc_state* proc_state)
 const Work_buffer* Proc_state_get_voice_buffer(
         const Proc_state* proc_state, Device_port_type port_type, int port_num)
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_num >= 0);
-    assert(port_num < KQT_DEVICE_PORTS_MAX);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_num >= 0);
+    rassert(port_num < KQT_DEVICE_PORTS_MAX);
 
     if ((port_type == DEVICE_PORT_TYPE_RECEIVE) &&
             !Device_state_is_input_port_connected(&proc_state->parent, port_num))
@@ -199,10 +199,10 @@ const Work_buffer* Proc_state_get_voice_buffer(
 Work_buffer* Proc_state_get_voice_buffer_mut(
         Proc_state* proc_state, Device_port_type port_type, int port_num)
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_num >= 0);
-    assert(port_num < KQT_DEVICE_PORTS_MAX);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_num >= 0);
+    rassert(port_num < KQT_DEVICE_PORTS_MAX);
 
     if ((port_type == DEVICE_PORT_TYPE_RECEIVE) &&
             !Device_state_is_input_port_connected(&proc_state->parent, port_num))
@@ -215,10 +215,10 @@ Work_buffer* Proc_state_get_voice_buffer_mut(
 const float* Proc_state_get_voice_buffer_contents(
         const Proc_state* proc_state, Device_port_type port_type, int port_num)
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_num >= 0);
-    assert(port_num < KQT_DEVICE_PORTS_MAX);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_num >= 0);
+    rassert(port_num < KQT_DEVICE_PORTS_MAX);
 
     const Work_buffer* wb = Proc_state_get_voice_buffer(proc_state, port_type, port_num);
     if (wb == NULL)
@@ -231,10 +231,10 @@ const float* Proc_state_get_voice_buffer_contents(
 float* Proc_state_get_voice_buffer_contents_mut(
         Proc_state* proc_state, Device_port_type port_type, int port_num)
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_num >= 0);
-    assert(port_num < KQT_DEVICE_PORTS_MAX);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_num >= 0);
+    rassert(port_num < KQT_DEVICE_PORTS_MAX);
 
     Work_buffer* wb =
         Proc_state_get_voice_buffer_mut(proc_state, port_type, port_num);
@@ -248,9 +248,9 @@ float* Proc_state_get_voice_buffer_contents_mut(
 void Proc_state_cv_generic_set(
         Device_state* dstate, const char* key, const Value* value)
 {
-    assert(dstate != NULL);
-    assert(key != NULL);
-    assert(value != NULL);
+    rassert(dstate != NULL);
+    rassert(key != NULL);
+    rassert(value != NULL);
 
     const Device_impl* dimpl = dstate->device->dimpl;
 
@@ -287,7 +287,7 @@ void Proc_state_cv_generic_set(
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return;
@@ -297,10 +297,10 @@ void Proc_state_cv_generic_set(
 static bool Proc_state_add_buffer(
         Device_state* dstate, Device_port_type port_type, int port_num)
 {
-    assert(dstate != NULL);
-    assert(port_type == DEVICE_PORT_TYPE_RECEIVE || port_type == DEVICE_PORT_TYPE_SEND);
-    assert(port_num >= 0);
-    assert(port_num < KQT_DEVICE_PORTS_MAX);
+    rassert(dstate != NULL);
+    rassert(port_type == DEVICE_PORT_TYPE_RECEIVE || port_type == DEVICE_PORT_TYPE_SEND);
+    rassert(port_num >= 0);
+    rassert(port_num < KQT_DEVICE_PORTS_MAX);
 
     Proc_state* proc_state = (Proc_state*)dstate;
 
@@ -319,8 +319,8 @@ static bool Proc_state_add_buffer(
 
 static bool Proc_state_set_audio_buffer_size(Device_state* dstate, int32_t new_size)
 {
-    assert(dstate != NULL);
-    assert(new_size >= 0);
+    rassert(dstate != NULL);
+    rassert(new_size >= 0);
 
     Proc_state* proc_state = (Proc_state*)dstate;
 
@@ -344,7 +344,7 @@ static bool Proc_state_set_audio_buffer_size(Device_state* dstate, int32_t new_s
 
 static void Proc_state_deinit(Proc_state* proc_state)
 {
-    assert(proc_state != NULL);
+    rassert(proc_state != NULL);
 
     for (Device_port_type port_type = DEVICE_PORT_TYPE_RECEIVE;
             port_type < DEVICE_PORT_TYPES; ++port_type)

--- a/src/lib/player/devices/Voice_state.c
+++ b/src/lib/player/devices/Voice_state.c
@@ -29,9 +29,9 @@
 
 Voice_state* Voice_state_init(Voice_state* state, Random* rand_p, Random* rand_s)
 {
-    assert(state != NULL);
-    assert(rand_p != NULL);
-    assert(rand_s != NULL);
+    rassert(state != NULL);
+    rassert(rand_p != NULL);
+    rassert(rand_s != NULL);
 
     Voice_state_clear(state);
     state->active = true;
@@ -55,7 +55,7 @@ Voice_state* Voice_state_init(Voice_state* state, Random* rand_p, Random* rand_s
 
 Voice_state* Voice_state_clear(Voice_state* state)
 {
-    assert(state != NULL);
+    rassert(state != NULL);
 
     state->active = false;
     state->has_finished = false;
@@ -89,13 +89,13 @@ int32_t Voice_state_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     vstate->has_release_data = false;
     vstate->release_stop = buf_start;
@@ -113,7 +113,7 @@ int32_t Voice_state_render_voice(
     // Call the implementation
     const int32_t impl_render_stop = vstate->render_voice(
             vstate, proc_state, au_state, wbs, buf_start, buf_stop, tempo);
-    assert(impl_render_stop <= buf_stop);
+    rassert(impl_render_stop <= buf_stop);
 
     return impl_render_stop;
 }
@@ -125,10 +125,10 @@ void Voice_state_mix_signals(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= buf_start);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= buf_start);
 
     for (int32_t port = 0; port < KQT_DEVICE_PORTS_MAX; ++port)
     {
@@ -147,8 +147,8 @@ void Voice_state_mix_signals(
 
 void Voice_state_mark_release_data(Voice_state* vstate, int32_t release_stop)
 {
-    assert(vstate != NULL);
-    assert(release_stop >= 0);
+    rassert(vstate != NULL);
+    rassert(release_stop >= 0);
 
     vstate->has_release_data = true;
     vstate->release_stop = release_stop;
@@ -159,7 +159,7 @@ void Voice_state_mark_release_data(Voice_state* vstate, int32_t release_stop)
 
 void Voice_state_set_finished(Voice_state* vstate)
 {
-    assert(vstate != NULL);
+    rassert(vstate != NULL);
     vstate->has_finished = true;
     return;
 }
@@ -171,10 +171,10 @@ void Voice_state_cv_generic_set(
         const char* key,
         const Value* value)
 {
-    assert(vstate != NULL);
-    assert(dstate != NULL);
-    assert(key != NULL);
-    assert(value != NULL);
+    rassert(vstate != NULL);
+    rassert(dstate != NULL);
+    rassert(key != NULL);
+    rassert(value != NULL);
 
     const Device_impl* dimpl = dstate->device->dimpl;
 
@@ -211,7 +211,7 @@ void Voice_state_cv_generic_set(
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     return;

--- a/src/lib/player/devices/processors/Add_state.c
+++ b/src/lib/player/devices/processors/Add_state.c
@@ -77,16 +77,16 @@ static int32_t Add_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(tempo > 0);
 
     const Device_state* dstate = &proc_state->parent;
     const Proc_add* add = (Proc_add*)proc_state->parent.device->dimpl;
     Add_vstate* add_state = (Add_vstate*)vstate;
-    assert(is_p2(ADD_BASE_FUNC_SIZE));
+    rassert(is_p2(ADD_BASE_FUNC_SIZE));
 
     // Get frequencies
     Work_buffer* freqs_wb = Proc_state_get_voice_buffer_mut(
@@ -223,8 +223,8 @@ static int32_t Add_vstate_render_voice(
 
 void Add_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Add_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Debug_state.c
+++ b/src/lib/player/devices/processors/Debug_state.c
@@ -29,11 +29,11 @@ static int32_t Debug_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(tempo > 0);
 
     const Processor* proc = (const Processor*)proc_state->parent.device;
 
@@ -131,8 +131,8 @@ static int32_t Debug_vstate_render_voice(
 
 void Debug_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Debug_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Delay_state.c
+++ b/src/lib/player/devices/processors/Delay_state.c
@@ -41,7 +41,7 @@ typedef struct Delay_pstate
 
 static void del_Delay_pstate(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Delay_pstate* dpstate = (Delay_pstate*)dstate;
 
@@ -62,8 +62,8 @@ static void del_Delay_pstate(Device_state* dstate)
 
 static bool Delay_pstate_set_audio_rate(Device_state* dstate, int32_t audio_rate)
 {
-    assert(dstate != NULL);
-    assert(audio_rate > 0);
+    rassert(dstate != NULL);
+    rassert(audio_rate > 0);
 
     Delay_pstate* dpstate = (Delay_pstate*)dstate;
 
@@ -89,7 +89,7 @@ static bool Delay_pstate_set_audio_rate(Device_state* dstate, int32_t audio_rate
 
 static void Delay_pstate_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Delay_pstate* dpstate = (Delay_pstate*)dstate;
 
@@ -130,10 +130,10 @@ static void Delay_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(buf_start <= buf_stop);
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start <= buf_stop);
+    rassert(tempo > 0);
 
     Delay_pstate* dpstate = (Delay_pstate*)dstate;
 
@@ -154,7 +154,7 @@ static void Delay_pstate_render_mixed(
     };
 
     const int32_t delay_buf_size = Work_buffer_get_size(dpstate->bufs[0]);
-    assert(delay_buf_size == Work_buffer_get_size(dpstate->bufs[1]));
+    rassert(delay_buf_size == Work_buffer_get_size(dpstate->bufs[1]));
     const int32_t delay_max = delay_buf_size - 1;
 
     static const int DELAY_WORK_BUFFER_TOTAL_OFFSETS = WORK_BUFFER_IMPL_1;
@@ -196,7 +196,7 @@ static void Delay_pstate_render_mixed(
             continue;
 
         const float* history = history_data[ch];
-        assert(history != NULL);
+        rassert(history != NULL);
 
         for (int32_t i = buf_start; i < buf_stop; ++i)
         {
@@ -205,8 +205,8 @@ static void Delay_pstate_render_mixed(
             // Get buffer positions
             const int32_t cur_pos = (int32_t)floor(total_offset);
             const double remainder = total_offset - (double)cur_pos;
-            assert(cur_pos <= (int32_t)i);
-            assert(implies(cur_pos == (int32_t)i, remainder == 0));
+            rassert(cur_pos <= (int32_t)i);
+            rassert(implies(cur_pos == (int32_t)i, remainder == 0));
             const int32_t next_pos = cur_pos + 1;
 
             // Get audio frames
@@ -216,18 +216,18 @@ static void Delay_pstate_render_mixed(
             if (cur_pos >= 0)
             {
                 const int32_t in_cur_pos = buf_start + cur_pos;
-                assert(in_cur_pos < (int32_t)buf_stop);
+                rassert(in_cur_pos < (int32_t)buf_stop);
                 cur_val = in[in_cur_pos];
 
                 const int32_t in_next_pos = min(buf_start + next_pos, i);
-                assert(in_next_pos < (int32_t)buf_stop);
+                rassert(in_next_pos < (int32_t)buf_stop);
                 next_val = in[in_next_pos];
             }
             else
             {
                 const int32_t cur_delay_buf_pos =
                     (cur_dpstate_buf_pos + cur_pos + delay_buf_size) % delay_buf_size;
-                assert(cur_delay_buf_pos >= 0);
+                rassert(cur_delay_buf_pos >= 0);
 
                 cur_val = history[cur_delay_buf_pos];
 
@@ -236,13 +236,13 @@ static void Delay_pstate_render_mixed(
                     const int32_t next_delay_buf_pos =
                         (cur_dpstate_buf_pos + next_pos + delay_buf_size) %
                         delay_buf_size;
-                    assert(next_delay_buf_pos >= 0);
+                    rassert(next_delay_buf_pos >= 0);
 
                     next_val = history[next_delay_buf_pos];
                 }
                 else
                 {
-                    assert(next_pos == 0);
+                    rassert(next_pos == 0);
                     next_val = in[buf_start];
                 }
             }
@@ -264,7 +264,7 @@ static void Delay_pstate_render_mixed(
             continue;
 
         float* history = history_data[ch];
-        assert(history != NULL);
+        rassert(history != NULL);
 
         cur_dpstate_buf_pos = dpstate->buf_pos;
 
@@ -275,7 +275,7 @@ static void Delay_pstate_render_mixed(
             ++cur_dpstate_buf_pos;
             if (cur_dpstate_buf_pos >= delay_buf_size)
             {
-                assert(cur_dpstate_buf_pos == delay_buf_size);
+                rassert(cur_dpstate_buf_pos == delay_buf_size);
                 cur_dpstate_buf_pos = 0;
             }
         }
@@ -289,7 +289,7 @@ static void Delay_pstate_render_mixed(
 
 static void Delay_pstate_clear_history(Proc_state* proc_state)
 {
-    assert(proc_state != NULL);
+    rassert(proc_state != NULL);
 
     Delay_pstate* dpstate = (Delay_pstate*)proc_state;
 
@@ -308,9 +308,9 @@ static void Delay_pstate_clear_history(Proc_state* proc_state)
 Device_state* new_Delay_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Delay_pstate* dpstate = memory_alloc_item(Delay_pstate);
     if (dpstate == NULL)
@@ -353,7 +353,7 @@ Device_state* new_Delay_pstate(
 bool Delay_pstate_set_max_delay(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
     ignore(indices);
     ignore(value);
 

--- a/src/lib/player/devices/processors/Envgen_state.c
+++ b/src/lib/player/devices/processors/Envgen_state.c
@@ -68,14 +68,14 @@ static int32_t Envgen_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     const Proc_envgen* egen = (Proc_envgen*)proc_state->parent.device->dimpl;
     Envgen_vstate* egen_state = (Envgen_vstate*)vstate;
@@ -196,7 +196,7 @@ static int32_t Envgen_vstate_render_voice(
                     const double vol_clamped = min(1, force_scale);
                     const float factor =
                         (float)Envelope_get_value(egen->force_env, vol_clamped);
-                    assert(isfinite(factor));
+                    rassert(isfinite(factor));
                     out_buffer[i] *= factor;
                 }
             }
@@ -272,8 +272,8 @@ static int32_t Envgen_vstate_render_voice(
 
 void Envgen_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Envgen_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Filter.c
+++ b/src/lib/player/devices/processors/Filter.c
@@ -28,7 +28,7 @@
 /*
 void simple_lowpass_fir_create(int n, double f, double* coeffs)
 {
-    assert(coeffs != NULL);
+    rassert(coeffs != NULL);
 
     for (int i = 0; i <= n; ++i)
         coeffs[i] = 2 * f * sinc(PI * f * (2 * i - n));
@@ -40,10 +40,10 @@ void simple_lowpass_fir_create(int n, double f, double* coeffs)
 
 void one_pole_filter_create(double f, int bandform, double coeffs[1], double* mul)
 {
-    assert(0 < f);
-    assert(f < 0.5);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0 < f);
+    rassert(f < 0.5);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -63,11 +63,11 @@ void one_pole_filter_create(double f, int bandform, double coeffs[1], double* mu
 void two_pole_bandpass_filter_create(
         double f1, double f2, double coeffs[2], double* mul)
 {
-    assert(0 < f1);
-    assert(f1 < f2);
-    assert(f2 < 0.5);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0 < f1);
+    rassert(f1 < f2);
+    rassert(f2 < 0.5);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -88,12 +88,12 @@ void two_pole_bandpass_filter_create(
 void two_pole_filter_create(
         double f, double q, int bandform, double coeffs[2], double* mul)
 {
-    assert(0 < f);
-    assert(f < 0.5);
-    assert(q >= 0.5);
-    assert(q <= 1000);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0 < f);
+    rassert(f < 0.5);
+    rassert(q >= 0.5);
+    rassert(q <= 1000);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -114,13 +114,13 @@ void two_pole_filter_create(
 void four_pole_bandpass_filter_create(
         double f1, double f2, double q, double coeffs[4], double* mul)
 {
-    assert(0  < f1);
-    assert(f1 < f2);
-    assert(f2 < 0.5);
-    assert(q >= 0.5);
-    assert(q <= 1000);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0  < f1);
+    rassert(f1 < f2);
+    rassert(f2 < 0.5);
+    rassert(q >= 0.5);
+    rassert(q <= 1000);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -154,11 +154,11 @@ void butterworth_filter_create(
         int n, double f, int bandform, double coeffs[n], double* mul)
 
 {
-    assert(0 < f);
-    assert(n > 0);
-    assert(f < 0.5);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0 < f);
+    rassert(n > 0);
+    rassert(f < 0.5);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -195,12 +195,12 @@ void butterworth_filter_create(
 void butterworth_bandpass_filter_create(
         int n, double f1, double f2, double coeffs[2*n], double* mul)
 {
-    assert(0  < f1);
-    assert(f1 < f2);
-    assert(f2 < 0.5);
-    assert(n > 0);
-    assert(coeffs != NULL);
-    assert(mul != NULL);
+    rassert(0  < f1);
+    rassert(f1 < f2);
+    rassert(f2 < 0.5);
+    rassert(n > 0);
+    rassert(coeffs != NULL);
+    rassert(mul != NULL);
 
     //    static int created = 0;
     //    fprintf(stderr, "  %d \n", ++created);
@@ -249,8 +249,8 @@ void butterworth_bandpass_filter_create(
 double iir_filter_strict_cascade(
         int n, const double coeffs[n], double buf[n], double var)
 {
-    assert(coeffs != NULL);
-    assert(buf != NULL);
+    rassert(coeffs != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < (n & ~((int)1)); i += 2)
     {
@@ -273,8 +273,8 @@ double iir_filter_strict_cascade(
 double iir_filter_strict_transposed_cascade(
         int n, const double coeffs[n], double buf[n], double var)
 {
-    assert(coeffs != NULL);
-    assert(buf != NULL);
+    rassert(coeffs != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < (n & ~((int)1)); i += 2)
     {
@@ -295,7 +295,7 @@ double iir_filter_strict_transposed_cascade(
 
 double dc_zero_filter(int n, double buf[n], double var)
 {
-    assert(buf != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < n; ++i)
     {
@@ -310,8 +310,8 @@ double dc_zero_filter(int n, double buf[n], double var)
 
 double dc_nq_zero_filter(int n, double buf[2*n], double var, int* s)
 {
-    assert(buf != NULL);
-    assert(s != NULL);
+    rassert(buf != NULL);
+    rassert(s != NULL);
 
     var = dc_zero_filter(n, buf + (*s & n), var);
     *s = ~*s;
@@ -322,7 +322,7 @@ double dc_nq_zero_filter(int n, double buf[2*n], double var, int* s)
 
 double dc_pole_filter(int n, double buf[n], double var)
 {
-    assert(buf != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < n; ++i)
     {
@@ -336,7 +336,7 @@ double dc_pole_filter(int n, double buf[n], double var)
 
 double nq_pole_filter(int n, double buf[n], double var)
 {
-    assert(buf != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < n; ++i)
     {
@@ -351,8 +351,8 @@ double nq_pole_filter(int n, double buf[n], double var)
 #if 0
 static void buffer(float* histbuf, const float* restrict sourcebuf, int n, int nframes)
 {
-    assert(histbuf != NULL);
-    assert(sourcebuf != NULL);
+    rassert(histbuf != NULL);
+    rassert(sourcebuf != NULL);
 
     if (nframes < n)
     {

--- a/src/lib/player/devices/processors/Filter.h
+++ b/src/lib/player/devices/processors/Filter.h
@@ -73,9 +73,9 @@ double iir_filter_strict_cascade(
 static inline double iir_filter_strict_cascade_even_order(
         int n, const double coeffs[n], double buf[n], double var)
 {
-    assert((n & 1) == 0);
-    assert(coeffs != NULL);
-    assert(buf != NULL);
+    rassert((n & 1) == 0);
+    rassert(coeffs != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < (n & ~((int)1)); i += 2)
     {
@@ -98,7 +98,7 @@ double dc_zero_filter(int n, double buf[n], double var);
 
 static inline double nq_zero_filter(int n, double buf[n], double var)
 {
-    assert(buf != NULL);
+    rassert(buf != NULL);
 
     for (int i = 0; i < n; ++i)
     {

--- a/src/lib/player/devices/processors/Filter.h
+++ b/src/lib/player/devices/processors/Filter.h
@@ -29,7 +29,7 @@
 /*         {                                                               \ */
 /*             (var) oper (buf0)[i0] * (buf1)[i1];                         \ */
 /*         }                                                               \ */
-/*     } else (void)0 */
+/*     } else ignore(0) */
 
 
 /* #define cyclic_dprod(n, coeffs, bsize, buf, k, var, oper)                      \ */
@@ -40,7 +40,7 @@
 /*         dprod((coeffs), (buf), filter_i, filter_j, (n), (bsize), (var), oper); \ */
 /*         filter_j -= (bsize);                                                   \ */
 /*         dprod((coeffs), (buf), filter_i, filter_j, (n), (bsize), (var), oper); \ */
-/*     } else (void)0 */
+/*     } else ignore(0) */
 
 
 void one_pole_filter_create(double f, int bandform, double coeffs[1], double *mul);

--- a/src/lib/player/devices/processors/Filter_state.c
+++ b/src/lib/player/devices/processors/Filter_state.c
@@ -64,7 +64,7 @@ typedef struct Filter_state_impl
 
 static void Filter_state_impl_init(Filter_state_impl* fimpl, const Proc_filter* filter)
 {
-    assert(fimpl != NULL);
+    rassert(fimpl != NULL);
 
     fimpl->anything_rendered = false;
 
@@ -111,9 +111,9 @@ static void Filter_state_impl_apply_filter_settings(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(fimpl != NULL);
-    assert(in_buffers != NULL);
-    assert(out_buffers != NULL);
+    rassert(fimpl != NULL);
+    rassert(in_buffers != NULL);
+    rassert(out_buffers != NULL);
 
     if ((fimpl->lowpass_state_used == -1) && (fimpl->lowpass_xfade_state_used == -1))
     {
@@ -125,7 +125,7 @@ static void Filter_state_impl_apply_filter_settings(
         return;
     }
 
-    assert(fimpl->lowpass_state_used != fimpl->lowpass_xfade_state_used);
+    rassert(fimpl->lowpass_state_used != fimpl->lowpass_xfade_state_used);
 
     // Get filter states used
     Single_filter_state* in_fst = (fimpl->lowpass_state_used > -1) ?
@@ -198,7 +198,7 @@ static void Filter_state_impl_apply_filter_settings(
 
 static double get_cutoff_freq(double param)
 {
-    assert(isfinite(param));
+    rassert(isfinite(param));
 
     if (param >= CUTOFF_INF_LIMIT)
         return INFINITY;
@@ -222,7 +222,7 @@ static double get_resonance(double param)
 
 static double get_xfade_step(double audio_rate, double true_lowpass, double resonance)
 {
-    assert(audio_rate > 0);
+    rassert(audio_rate > 0);
 
     if (true_lowpass >= audio_rate * 0.5)
         return FILTER_XFADE_SPEED_MAX / audio_rate;
@@ -248,11 +248,11 @@ static void Filter_state_impl_apply_input_buffers(
         int32_t buf_stop,
         int32_t audio_rate)
 {
-    assert(fimpl != NULL);
-    assert(wbs != NULL);
-    assert(in_buffers != NULL);
-    assert(out_buffers != NULL);
-    assert(audio_rate > 0);
+    rassert(fimpl != NULL);
+    rassert(wbs != NULL);
+    rassert(in_buffers != NULL);
+    rassert(out_buffers != NULL);
+    rassert(audio_rate > 0);
 
     float* cutoffs = Work_buffers_get_buffer_contents_mut(wbs, CONTROL_WB_CUTOFF);
 
@@ -313,7 +313,7 @@ static void Filter_state_impl_apply_input_buffers(
                 force = 1;
 
             double factor = Envelope_get_value(proc->au_params->env_force_filter, force);
-            assert(isfinite(factor));
+            rassert(isfinite(factor));
             cutoff += (factor * 100) - 100;
         }
         // */
@@ -417,7 +417,7 @@ typedef struct Filter_pstate
 
 static void Filter_pstate_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     const Proc_filter* filter = (const Proc_filter*)dstate->device->dimpl;
 
@@ -452,10 +452,10 @@ static void Filter_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Filter_pstate* fpstate = (Filter_pstate*)dstate;
 
@@ -497,9 +497,9 @@ static void Filter_pstate_render_mixed(
 bool Filter_pstate_set_cutoff(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Filter_pstate* fpstate = (Filter_pstate*)dstate;
     fpstate->state_impl.def_cutoff = value;
@@ -511,9 +511,9 @@ bool Filter_pstate_set_cutoff(
 bool Filter_pstate_set_resonance(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Filter_pstate* fpstate = (Filter_pstate*)dstate;
     fpstate->state_impl.def_resonance = value;
@@ -525,9 +525,9 @@ bool Filter_pstate_set_resonance(
 Device_state* new_Filter_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Filter_pstate* fpstate = memory_alloc_item(Filter_pstate);
     if ((fpstate == NULL) ||
@@ -570,14 +570,14 @@ static int32_t Filter_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Filter_vstate* fvstate = (Filter_vstate*)vstate;
 
@@ -628,8 +628,8 @@ static int32_t Filter_vstate_render_voice(
 
 void Filter_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Filter_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Force_state.c
+++ b/src/lib/player/devices/processors/Force_state.c
@@ -76,14 +76,14 @@ static int32_t Force_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     // Get pitch input
     Work_buffer* pitches_wb = Proc_state_get_voice_buffer_mut(
@@ -253,7 +253,7 @@ static int32_t Force_vstate_render_voice(
         {
             // Apply force release envelope
             const Envelope* env = force->force_release_env;
-            assert(env != NULL);
+            rassert(env != NULL);
 
             const int32_t env_force_rel_stop = Time_env_state_process(
                     &fvstate->release_env_state,
@@ -341,8 +341,8 @@ static int32_t Force_vstate_render_voice(
 
 void Force_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Force_vstate_render_voice;
 
@@ -375,8 +375,8 @@ void Force_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 
 Force_controls* Force_vstate_get_force_controls_mut(Voice_state* vstate)
 {
-    assert(vstate != NULL);
-    assert(vstate->is_force_state);
+    rassert(vstate != NULL);
+    rassert(vstate->is_force_state);
 
     Force_vstate* fvstate = (Force_vstate*)vstate;
 

--- a/src/lib/player/devices/processors/Freeverb_allpass.c
+++ b/src/lib/player/devices/processors/Freeverb_allpass.c
@@ -34,7 +34,7 @@ struct Freeverb_allpass
 
 Freeverb_allpass* new_Freeverb_allpass(int32_t buffer_size)
 {
-    assert(buffer_size > 0);
+    rassert(buffer_size > 0);
 
     Freeverb_allpass* allpass = memory_alloc_item(Freeverb_allpass);
     if (allpass == NULL)
@@ -59,9 +59,9 @@ Freeverb_allpass* new_Freeverb_allpass(int32_t buffer_size)
 
 void Freeverb_allpass_set_feedback(Freeverb_allpass* allpass, float feedback)
 {
-    assert(allpass != NULL);
-    assert(feedback > -1);
-    assert(feedback < 1);
+    rassert(allpass != NULL);
+    rassert(feedback > -1);
+    rassert(feedback < 1);
     allpass->feedback = feedback;
     return;
 }
@@ -70,10 +70,10 @@ void Freeverb_allpass_set_feedback(Freeverb_allpass* allpass, float feedback)
 void Freeverb_allpass_process(
         Freeverb_allpass* allpass, float* buffer, int32_t buf_start, int32_t buf_stop)
 {
-    assert(allpass != NULL);
-    assert(buffer != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop > buf_start);
+    rassert(allpass != NULL);
+    rassert(buffer != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop > buf_start);
 
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
@@ -94,8 +94,8 @@ void Freeverb_allpass_process(
 
 bool Freeverb_allpass_resize_buffer(Freeverb_allpass* allpass, int32_t new_size)
 {
-    assert(allpass != NULL);
-    assert(new_size > 0);
+    rassert(allpass != NULL);
+    rassert(new_size > 0);
 
     if (new_size == allpass->buffer_size)
         return true;
@@ -115,8 +115,8 @@ bool Freeverb_allpass_resize_buffer(Freeverb_allpass* allpass, int32_t new_size)
 
 void Freeverb_allpass_clear(Freeverb_allpass* allpass)
 {
-    assert(allpass != NULL);
-    assert(allpass->buffer != NULL);
+    rassert(allpass != NULL);
+    rassert(allpass->buffer != NULL);
 
     for (int32_t i = 0; i < allpass->buffer_size; ++i)
         allpass->buffer[i] = 0;

--- a/src/lib/player/devices/processors/Freeverb_comb.c
+++ b/src/lib/player/devices/processors/Freeverb_comb.c
@@ -34,7 +34,7 @@ struct Freeverb_comb
 
 Freeverb_comb* new_Freeverb_comb(int32_t buffer_size)
 {
-    assert(buffer_size > 0);
+    rassert(buffer_size > 0);
 
     Freeverb_comb* comb = memory_alloc_item(Freeverb_comb);
     if (comb == NULL)
@@ -67,13 +67,13 @@ void Freeverb_comb_process(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(comb != NULL);
-    assert(out_buf != NULL);
-    assert(in_buf != NULL);
-    assert(refls != NULL);
-    assert(damps != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop > buf_start);
+    rassert(comb != NULL);
+    rassert(out_buf != NULL);
+    rassert(in_buf != NULL);
+    rassert(refls != NULL);
+    rassert(damps != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop > buf_start);
 
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
@@ -98,8 +98,8 @@ void Freeverb_comb_process(
 
 bool Freeverb_comb_resize_buffer(Freeverb_comb* comb, int32_t new_size)
 {
-    assert(comb != NULL);
-    assert(new_size > 0);
+    rassert(comb != NULL);
+    rassert(new_size > 0);
 
     if (new_size == comb->buffer_size)
         return true;
@@ -119,8 +119,8 @@ bool Freeverb_comb_resize_buffer(Freeverb_comb* comb, int32_t new_size)
 
 void Freeverb_comb_clear(Freeverb_comb* comb)
 {
-    assert(comb != NULL);
-    assert(comb->buffer != NULL);
+    rassert(comb != NULL);
+    rassert(comb->buffer != NULL);
 
     comb->filter_store = 0;
 

--- a/src/lib/player/devices/processors/Freeverb_state.c
+++ b/src/lib/player/devices/processors/Freeverb_state.c
@@ -64,7 +64,7 @@ typedef struct Freeverb_pstate
 
 static void del_Freeverb_pstate(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Freeverb_pstate* fpstate = (Freeverb_pstate*)dstate;
 
@@ -85,7 +85,7 @@ static void del_Freeverb_pstate(Device_state* dstate)
 
 static void Freeverb_pstate_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Freeverb_pstate* fstate = (Freeverb_pstate*)dstate;
 
@@ -109,8 +109,8 @@ static void Freeverb_pstate_reset(Device_state* dstate)
 
 static bool Freeverb_pstate_set_audio_rate(Device_state* dstate, int32_t audio_rate)
 {
-    assert(dstate != NULL);
-    assert(audio_rate > 0);
+    rassert(dstate != NULL);
+    rassert(audio_rate > 0);
 
     Freeverb_pstate* fstate = (Freeverb_pstate*)dstate;
 
@@ -150,7 +150,7 @@ static bool Freeverb_pstate_set_audio_rate(Device_state* dstate, int32_t audio_r
 
 static void Freeverb_pstate_clear_history(Proc_state* proc_state)
 {
-    assert(proc_state != NULL);
+    rassert(proc_state != NULL);
 
     Freeverb_pstate_reset((Device_state*)proc_state);
 
@@ -189,10 +189,10 @@ static void Freeverb_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(tempo > 0);
 
     Freeverb_pstate* fstate = (Freeverb_pstate*)dstate;
 
@@ -334,9 +334,9 @@ static void Freeverb_pstate_render_mixed(
 Device_state* new_Freeverb_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Freeverb_pstate* fpstate = memory_alloc_item(Freeverb_pstate);
     if (fpstate == NULL)

--- a/src/lib/player/devices/processors/Gaincomp_state.c
+++ b/src/lib/player/devices/processors/Gaincomp_state.c
@@ -33,11 +33,11 @@ static void distort(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(gc != NULL);
-    assert(in_buffer != NULL);
-    assert(out_buffer != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(gc != NULL);
+    rassert(in_buffer != NULL);
+    rassert(out_buffer != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     if (gc->is_map_enabled && (gc->map != NULL))
     {
@@ -87,10 +87,10 @@ static void Gaincomp_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(tempo > 0);
 
     // Get input
     Work_buffer* in_buffers[] =
@@ -121,9 +121,9 @@ static void Gaincomp_pstate_render_mixed(
 Device_state* new_Gaincomp_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Proc_state* proc_state =
         new_Proc_state_default(device, audio_rate, audio_buffer_size);
@@ -145,14 +145,14 @@ static int32_t Gaincomp_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     // Get input
     Work_buffer* in_buffers[] =
@@ -191,8 +191,8 @@ static int32_t Gaincomp_vstate_render_voice(
 
 void Gaincomp_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Gaincomp_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Noise_state.c
+++ b/src/lib/player/devices/processors/Noise_state.c
@@ -40,9 +40,9 @@ typedef struct Noise_pstate
 Device_state* new_Noise_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Noise_pstate* noise_state = memory_alloc_item(Noise_pstate);
     if (noise_state == NULL)
@@ -82,11 +82,11 @@ static int32_t Noise_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(tempo > 0);
 
 //    double max_amp = 0;
 //  fprintf(stderr, "bufs are %p and %p\n", ins->bufs[0], ins->bufs[1]);
@@ -139,8 +139,8 @@ static int32_t Noise_vstate_render_voice(
 
 void Noise_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Noise_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Padsynth_state.c
+++ b/src/lib/player/devices/processors/Padsynth_state.c
@@ -72,11 +72,11 @@ static int32_t Padsynth_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(tempo > 0);
 
     if (buf_start == buf_stop)
         return buf_start;
@@ -192,8 +192,8 @@ static int32_t Padsynth_vstate_render_voice(
 
 void Padsynth_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Padsynth_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Panning_state.c
+++ b/src/lib/player/devices/processors/Panning_state.c
@@ -57,14 +57,14 @@ static void apply_panning(
         int32_t buf_stop,
         int32_t audio_rate)
 {
-    assert(isfinite(def_pan));
-    assert(def_pan >= -1);
-    assert(def_pan <= 1);
-    assert(in_buffers != NULL);
-    assert(out_buffers != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
+    rassert(isfinite(def_pan));
+    rassert(def_pan >= -1);
+    rassert(def_pan <= 1);
+    rassert(in_buffers != NULL);
+    rassert(out_buffers != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
 
     float* pannings = Work_buffers_get_buffer_contents_mut(wbs, CONTROL_WB_PANNING);
 
@@ -133,10 +133,10 @@ static void Panning_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Panning_pstate* ppstate = (Panning_pstate*)dstate;
 
@@ -171,9 +171,9 @@ static void Panning_pstate_render_mixed(
 bool Panning_pstate_set_panning(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
-    assert(isfinite(value));
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
+    rassert(isfinite(value));
 
     Panning_pstate* ppstate = (Panning_pstate*)dstate;
     ppstate->def_panning = value;
@@ -185,9 +185,9 @@ bool Panning_pstate_set_panning(
 Device_state* new_Panning_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Panning_pstate* ppstate = memory_alloc_item(Panning_pstate);
     if ((ppstate == NULL) ||
@@ -225,14 +225,14 @@ static int32_t Panning_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Panning_vstate* pvstate = (Panning_vstate*)vstate;
 
@@ -273,8 +273,8 @@ static int32_t Panning_vstate_render_voice(
 
 void Panning_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Panning_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Pitch_state.c
+++ b/src/lib/player/devices/processors/Pitch_state.c
@@ -65,14 +65,14 @@ static int32_t Pitch_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     // Get output
     Work_buffer* out_wb = Proc_state_get_voice_buffer_mut(
@@ -183,7 +183,7 @@ static int32_t Pitch_vstate_render_voice(
         for (int32_t i = buf_start; i < buf_stop; ++i)
         {
             // Adjust actual pitch according to the current arpeggio state
-            assert(!isnan(pvstate->arpeggio_tones[0]));
+            rassert(!isnan(pvstate->arpeggio_tones[0]));
             const double diff = (pvstate->arpeggio_tones[pvstate->arpeggio_tone_index] -
                     pvstate->arpeggio_ref_pitch);
             out_buf[i] += (float)diff;
@@ -213,8 +213,8 @@ static int32_t Pitch_vstate_render_voice(
 
 void Pitch_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Pitch_vstate_render_voice;
 
@@ -242,8 +242,8 @@ void Pitch_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 
 void Pitch_vstate_set_controls(Voice_state* vstate, const Pitch_controls* controls)
 {
-    assert(vstate != NULL);
-    assert(controls != NULL);
+    rassert(vstate != NULL);
+    rassert(controls != NULL);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
 
@@ -264,11 +264,11 @@ void Pitch_vstate_arpeggio_on(
         double ref_pitch,
         double tones[KQT_ARPEGGIO_TONES_MAX])
 {
-    assert(vstate != NULL);
-    assert(isfinite(speed));
-    assert(speed > 0);
-    assert(isfinite(ref_pitch));
-    assert(tones != NULL);
+    rassert(vstate != NULL);
+    rassert(isfinite(speed));
+    rassert(speed > 0);
+    rassert(isfinite(ref_pitch));
+    rassert(tones != NULL);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
 
@@ -287,7 +287,7 @@ void Pitch_vstate_arpeggio_on(
 
 void Pitch_vstate_arpeggio_off(Voice_state* vstate)
 {
-    assert(vstate != NULL);
+    rassert(vstate != NULL);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
     pvstate->is_arpeggio_enabled = false;
@@ -299,7 +299,7 @@ void Pitch_vstate_arpeggio_off(Voice_state* vstate)
 void Pitch_vstate_update_arpeggio_tones(
         Voice_state* vstate, double tones[KQT_ARPEGGIO_TONES_MAX])
 {
-    assert(vstate != NULL);
+    rassert(vstate != NULL);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
     memcpy(pvstate->arpeggio_tones, tones, KQT_ARPEGGIO_TONES_MAX * sizeof(double));
@@ -310,9 +310,9 @@ void Pitch_vstate_update_arpeggio_tones(
 
 void Pitch_vstate_update_arpeggio_speed(Voice_state* vstate, double speed)
 {
-    assert(vstate != NULL);
-    assert(isfinite(speed));
-    assert(speed > 0);
+    rassert(vstate != NULL);
+    rassert(isfinite(speed));
+    rassert(speed > 0);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
     pvstate->arpeggio_speed = speed;
@@ -323,7 +323,7 @@ void Pitch_vstate_update_arpeggio_speed(Voice_state* vstate, double speed)
 
 void Pitch_vstate_reset_arpeggio(Voice_state* vstate)
 {
-    assert(vstate != NULL);
+    rassert(vstate != NULL);
 
     Pitch_vstate* pvstate = (Pitch_vstate*)vstate;
     pvstate->arpeggio_tones[0] = pvstate->arpeggio_tones[1] = NAN;

--- a/src/lib/player/devices/processors/Proc_state_utils.c
+++ b/src/lib/player/devices/processors/Proc_state_utils.c
@@ -33,9 +33,9 @@
 Proc_state* new_Proc_state_default(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Proc_state* pstate = memory_alloc_item(Proc_state);
     if ((pstate == NULL) ||
@@ -56,13 +56,13 @@ static void get_mixed_audio_buffers(
         int32_t port_stop,
         float* bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(bufs != NULL);
 
     Device_state* dstate = (Device_state*)proc_state;
 
@@ -76,12 +76,12 @@ static void get_mixed_audio_buffers(
 void Proc_state_get_mixed_audio_in_buffers(
         Proc_state* proc_state, int32_t port_start, int32_t port_stop, float* in_bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(in_bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(in_bufs != NULL);
 
     get_mixed_audio_buffers(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, port_start, port_stop, in_bufs);
@@ -96,12 +96,12 @@ void Proc_state_get_mixed_audio_out_buffers(
         int32_t port_stop,
         float* out_bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(out_bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(out_bufs != NULL);
 
     get_mixed_audio_buffers(
             proc_state, DEVICE_PORT_TYPE_SEND, port_start, port_stop, out_bufs);
@@ -117,13 +117,13 @@ static void get_voice_audio_buffers(
         int32_t port_stop,
         float* bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_type < DEVICE_PORT_TYPES);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_type < DEVICE_PORT_TYPES);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(bufs != NULL);
 
     for (int32_t i = 0, port = port_start; port < port_stop; ++i, ++port)
         bufs[i] = Proc_state_get_voice_buffer_contents_mut(proc_state, port_type, port);
@@ -135,12 +135,12 @@ static void get_voice_audio_buffers(
 void Proc_state_get_voice_audio_in_buffers(
         Proc_state* proc_state, int32_t port_start, int32_t port_stop, float* in_bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(in_bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(in_bufs != NULL);
 
     get_voice_audio_buffers(
             proc_state, DEVICE_PORT_TYPE_RECEIVE, port_start, port_stop, in_bufs);
@@ -155,12 +155,12 @@ void Proc_state_get_voice_audio_out_buffers(
         int32_t port_stop,
         float* out_bufs[])
 {
-    assert(proc_state != NULL);
-    assert(port_start >= 0);
-    assert(port_start < KQT_DEVICE_PORTS_MAX);
-    assert(port_stop >= port_start);
-    assert(port_stop <= KQT_DEVICE_PORTS_MAX);
-    assert(out_bufs != NULL);
+    rassert(proc_state != NULL);
+    rassert(port_start >= 0);
+    rassert(port_start < KQT_DEVICE_PORTS_MAX);
+    rassert(port_stop >= port_start);
+    rassert(port_stop <= KQT_DEVICE_PORTS_MAX);
+    rassert(out_bufs != NULL);
 
     get_voice_audio_buffers(
             proc_state, DEVICE_PORT_TYPE_SEND, port_start, port_stop, out_bufs);
@@ -177,12 +177,12 @@ void Proc_ramp_attack(
         int32_t buf_stop,
         int32_t audio_rate)
 {
-    assert(vstate != NULL);
-    assert(buf_count > 0);
-    assert(out_bufs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(audio_rate > 0);
+    rassert(vstate != NULL);
+    rassert(buf_count > 0);
+    rassert(out_bufs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(audio_rate > 0);
 
     const float start_ramp_attack = (float)vstate->ramp_attack;
     const float inc = (float)(RAMP_ATTACK_TIME / audio_rate);
@@ -213,9 +213,9 @@ void Proc_fill_freq_buffer(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(freqs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(freqs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     float* freqs_data = Work_buffer_get_contents_mut_keep_const(freqs);
 
@@ -258,9 +258,9 @@ void Proc_fill_scale_buffer(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(scales != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(scales != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     float* scales_data = Work_buffer_get_contents_mut_keep_const(scales);
 
@@ -300,7 +300,7 @@ void Proc_fill_scale_buffer(
 Cond_work_buffer* Cond_work_buffer_init(
         Cond_work_buffer* cwb, const Work_buffer* wb, float def_value)
 {
-    assert(cwb != NULL);
+    rassert(cwb != NULL);
 
     cwb->index_mask = 0;
     cwb->def_value = def_value;

--- a/src/lib/player/devices/processors/Proc_state_utils.h
+++ b/src/lib/player/devices/processors/Proc_state_utils.h
@@ -216,7 +216,7 @@ Cond_work_buffer* Cond_work_buffer_init(
 static inline float Cond_work_buffer_get_value(
         const Cond_work_buffer* cwb, int32_t index)
 {
-    assert(cwb != NULL);
+    rassert(cwb != NULL);
     return cwb->wb_contents[index & cwb->index_mask];
 }
 

--- a/src/lib/player/devices/processors/Ringmod_state.c
+++ b/src/lib/player/devices/processors/Ringmod_state.c
@@ -51,11 +51,11 @@ static void multiply_signals(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(in1_buffers != NULL);
-    assert(in2_buffers != NULL);
-    assert(out_buffers != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
+    rassert(in1_buffers != NULL);
+    rassert(in2_buffers != NULL);
+    rassert(out_buffers != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
 
     for (int ch = 0; ch < 2; ++ch)
     {
@@ -81,10 +81,10 @@ static void Ringmod_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Proc_state* proc_state = (Proc_state*)dstate;
 
@@ -112,9 +112,9 @@ static void Ringmod_pstate_render_mixed(
 Device_state* new_Ringmod_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Proc_state* proc_state =
         new_Proc_state_default(device, audio_rate, audio_buffer_size);
@@ -136,14 +136,14 @@ static int32_t Ringmod_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     // Get inputs
     float* in1_buffers[2] = { NULL };
@@ -175,8 +175,8 @@ static int32_t Ringmod_vstate_render_voice(
 
 void Ringmod_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Ringmod_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Sample_state.c
+++ b/src/lib/player/devices/processors/Sample_state.c
@@ -288,7 +288,7 @@ static int32_t Sample_render(
         const float diff = next_value - cur_value;      \
         (out_value) = cur_value + (lerp_value * diff);  \
     }                                                   \
-    else (void)0
+    else ignore(0)
 
     if (!sample->is_float)
     {

--- a/src/lib/player/devices/processors/Sample_state.c
+++ b/src/lib/player/devices/processors/Sample_state.c
@@ -83,18 +83,18 @@ static int32_t Sample_render(
         double middle_freq,
         double vol_scale)
 {
-    assert(sample != NULL);
-    assert(params != NULL);
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(wbs != NULL);
-    assert(audio_rate > 0);
-    assert(tempo > 0);
-    assert(vol_scale >= 0);
+    rassert(sample != NULL);
+    rassert(params != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(wbs != NULL);
+    rassert(audio_rate > 0);
+    rassert(tempo > 0);
+    rassert(vol_scale >= 0);
     ignore(tempo);
 
     // This implementation does not support larger sample lengths :-P
-    assert(sample->len < INT32_MAX - 1);
+    rassert(sample->len < INT32_MAX - 1);
 
     if (sample->len == 0)
     {
@@ -265,14 +265,14 @@ static int32_t Sample_render(
                         loop_pos = step_count - loop_pos;
                     cur_pos = loop_start + loop_pos;
                     positions[i] = cur_pos;
-                    assert(cur_pos >= 0);
+                    rassert(cur_pos >= 0);
                 }
             }
         }
         break;
 
         default:
-            assert(false);
+            rassert(false);
     }
 
     // Get sample frames
@@ -364,7 +364,7 @@ static int32_t Sample_render(
             break;
 
             default:
-                assert(false);
+                rassert(false);
         }
     }
     else
@@ -393,7 +393,7 @@ static int32_t Sample_render(
     if ((sample->channels == 1) && (abufs[0] != NULL) && (abufs[1] != NULL))
     {
         const int32_t frame_count = new_buf_stop - buf_start;
-        assert(frame_count >= 0);
+        rassert(frame_count >= 0);
         memcpy(abufs[1] + buf_start,
                 abufs[0] + buf_start,
                 sizeof(float) * (size_t)frame_count);
@@ -416,11 +416,11 @@ static int32_t Sample_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(tempo > 0);
 
     const Processor* proc = (const Processor*)proc_state->parent.device;
 
@@ -443,7 +443,7 @@ static int32_t Sample_vstate_render_voice(
         const Sample_entry* entry = NULL;
         if (vstate->hit_index >= 0)
         {
-            assert(vstate->hit_index < KQT_HITS_MAX);
+            rassert(vstate->hit_index < KQT_HITS_MAX);
 
             const Hit_map* map =
                 Device_params_get_hit_map(proc->parent.dparams, "p_hm_hit_map.json");
@@ -503,7 +503,7 @@ static int32_t Sample_vstate_render_voice(
         sample_state->cents = entry->cents;
     }
 
-    assert(sample_state->sample < SAMPLES_MAX);
+    rassert(sample_state->sample < SAMPLES_MAX);
 
     // Find sample params
     char header_key[] = "smp_XXX/p_sh_sample.json";
@@ -521,8 +521,8 @@ static int32_t Sample_vstate_render_voice(
         return buf_start;
     }
 
-    assert(header->mid_freq > 0);
-    assert(header->format > SAMPLE_FORMAT_NONE);
+    rassert(header->mid_freq > 0);
+    rassert(header->format > SAMPLE_FORMAT_NONE);
 
     // Find sample data
     static const char* extensions[] =
@@ -576,8 +576,8 @@ static int32_t Sample_vstate_render_voice(
 
 void Sample_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Sample_vstate_render_voice;
 

--- a/src/lib/player/devices/processors/Stream_state.c
+++ b/src/lib/player/devices/processors/Stream_state.c
@@ -41,9 +41,9 @@ static void apply_controls(
         int32_t buf_stop,
         double tempo)
 {
-    assert(controls != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= buf_start);
+    rassert(controls != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= buf_start);
 
     Linear_controls_set_tempo(controls, tempo);
 
@@ -69,8 +69,8 @@ typedef struct Stream_pstate
 
 static bool Stream_pstate_set_audio_rate(Device_state* dstate, int32_t audio_rate)
 {
-    assert(dstate != NULL);
-    assert(audio_rate > 0);
+    rassert(dstate != NULL);
+    rassert(audio_rate > 0);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -82,7 +82,7 @@ static bool Stream_pstate_set_audio_rate(Device_state* dstate, int32_t audio_rat
 
 static void Stream_pstate_reset(Device_state* dstate)
 {
-    assert(dstate != NULL);
+    rassert(dstate != NULL);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -104,10 +104,10 @@ static void Stream_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -124,9 +124,9 @@ static void Stream_pstate_render_mixed(
 Device_state* new_Stream_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Stream_pstate* spstate = memory_alloc_item(Stream_pstate);
     if ((spstate == NULL) ||
@@ -156,8 +156,8 @@ Device_state* new_Stream_pstate(
 bool Stream_pstate_set_init_value(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
     ignore(value);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
@@ -174,8 +174,8 @@ bool Stream_pstate_set_init_value(
 bool Stream_pstate_set_init_osc_speed(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
     ignore(value);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
@@ -192,8 +192,8 @@ bool Stream_pstate_set_init_osc_speed(
 bool Stream_pstate_set_init_osc_depth(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
     ignore(value);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
@@ -209,8 +209,8 @@ bool Stream_pstate_set_init_osc_depth(
 
 void Stream_pstate_set_value(Device_state* dstate, double value)
 {
-    assert(dstate != NULL);
-    assert(isfinite(value));
+    rassert(dstate != NULL);
+    rassert(isfinite(value));
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -222,8 +222,8 @@ void Stream_pstate_set_value(Device_state* dstate, double value)
 
 void Stream_pstate_slide_target(Device_state* dstate, double value)
 {
-    assert(dstate != NULL);
-    assert(isfinite(value));
+    rassert(dstate != NULL);
+    rassert(isfinite(value));
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -235,8 +235,8 @@ void Stream_pstate_slide_target(Device_state* dstate, double value)
 
 void Stream_pstate_slide_length(Device_state* dstate, const Tstamp* length)
 {
-    assert(dstate != NULL);
-    assert(length != NULL);
+    rassert(dstate != NULL);
+    rassert(length != NULL);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -248,8 +248,8 @@ void Stream_pstate_slide_length(Device_state* dstate, const Tstamp* length)
 
 void Stream_pstate_set_osc_speed(Device_state* dstate, double speed)
 {
-    assert(dstate != NULL);
-    assert(isfinite(speed));
+    rassert(dstate != NULL);
+    rassert(isfinite(speed));
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -261,8 +261,8 @@ void Stream_pstate_set_osc_speed(Device_state* dstate, double speed)
 
 void Stream_pstate_set_osc_depth(Device_state* dstate, double depth)
 {
-    assert(dstate != NULL);
-    assert(isfinite(depth));
+    rassert(dstate != NULL);
+    rassert(isfinite(depth));
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -274,8 +274,8 @@ void Stream_pstate_set_osc_depth(Device_state* dstate, double depth)
 
 void Stream_pstate_set_osc_speed_slide(Device_state* dstate, const Tstamp* length)
 {
-    assert(dstate != NULL);
-    assert(length != NULL);
+    rassert(dstate != NULL);
+    rassert(length != NULL);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -287,8 +287,8 @@ void Stream_pstate_set_osc_speed_slide(Device_state* dstate, const Tstamp* lengt
 
 void Stream_pstate_set_osc_depth_slide(Device_state* dstate, const Tstamp* length)
 {
-    assert(dstate != NULL);
-    assert(length != NULL);
+    rassert(dstate != NULL);
+    rassert(length != NULL);
 
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
@@ -320,14 +320,14 @@ static int32_t Stream_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Stream_vstate* svstate = (Stream_vstate*)vstate;
 
@@ -348,8 +348,8 @@ static int32_t Stream_vstate_render_voice(
 
 void Stream_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Stream_vstate_render_voice;
 
@@ -374,8 +374,8 @@ void Stream_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 
 const Linear_controls* Stream_vstate_get_controls(const Voice_state* vstate)
 {
-    assert(vstate != NULL);
-    assert(vstate->is_stream_state);
+    rassert(vstate != NULL);
+    rassert(vstate->is_stream_state);
 
     const Stream_vstate* svstate = (const Stream_vstate*)vstate;
 
@@ -385,9 +385,9 @@ const Linear_controls* Stream_vstate_get_controls(const Voice_state* vstate)
 
 void Stream_vstate_set_controls(Voice_state* vstate, const Linear_controls* controls)
 {
-    assert(vstate != NULL);
-    assert(vstate->is_stream_state);
-    assert(controls != NULL);
+    rassert(vstate != NULL);
+    rassert(vstate->is_stream_state);
+    rassert(controls != NULL);
 
     Stream_vstate* svstate = (Stream_vstate*)vstate;
 

--- a/src/lib/player/devices/processors/Volume_state.c
+++ b/src/lib/player/devices/processors/Volume_state.c
@@ -56,11 +56,11 @@ static void apply_volume(
         int32_t buf_start,
         int32_t buf_stop)
 {
-    assert(buf_count > 0);
-    assert(in_buffers != NULL);
-    assert(out_buffers != NULL);
-    assert(isfinite(global_vol));
-    assert(buf_start >= 0);
+    rassert(buf_count > 0);
+    rassert(in_buffers != NULL);
+    rassert(out_buffers != NULL);
+    rassert(isfinite(global_vol));
+    rassert(buf_start >= 0);
 
     const float global_scale = (float)dB_to_scale(global_vol);
 
@@ -104,8 +104,8 @@ typedef struct Volume_pstate
 bool Volume_pstate_set_volume(
         Device_state* dstate, const Key_indices indices, double value)
 {
-    assert(dstate != NULL);
-    assert(indices != NULL);
+    rassert(dstate != NULL);
+    rassert(indices != NULL);
 
     Volume_pstate* vpstate = (Volume_pstate*)dstate;
     vpstate->volume = isfinite(value) ? value : 0.0;
@@ -121,10 +121,10 @@ static void Volume_pstate_render_mixed(
         int32_t buf_stop,
         double tempo)
 {
-    assert(dstate != NULL);
-    assert(wbs != NULL);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(dstate != NULL);
+    rassert(wbs != NULL);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     Volume_pstate* vpstate = (Volume_pstate*)dstate;
 
@@ -152,9 +152,9 @@ static void Volume_pstate_render_mixed(
 Device_state* new_Volume_pstate(
         const Device* device, int32_t audio_rate, int32_t audio_buffer_size)
 {
-    assert(device != NULL);
-    assert(audio_rate > 0);
-    assert(audio_buffer_size >= 0);
+    rassert(device != NULL);
+    rassert(audio_rate > 0);
+    rassert(audio_buffer_size >= 0);
 
     Volume_pstate* vol_state = memory_alloc_item(Volume_pstate);
     if ((vol_state == NULL) ||
@@ -193,14 +193,14 @@ static int32_t Volume_vstate_render_voice(
         int32_t buf_stop,
         double tempo)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
-    assert(au_state != NULL);
-    assert(wbs != NULL);
-    assert(buf_start >= 0);
-    assert(buf_stop >= 0);
-    assert(isfinite(tempo));
-    assert(tempo > 0);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
+    rassert(au_state != NULL);
+    rassert(wbs != NULL);
+    rassert(buf_start >= 0);
+    rassert(buf_stop >= 0);
+    rassert(isfinite(tempo));
+    rassert(tempo > 0);
 
     // Get control stream
     float* volume_buf = Proc_state_get_voice_buffer_contents_mut(
@@ -238,8 +238,8 @@ static int32_t Volume_vstate_render_voice(
 
 void Volume_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 {
-    assert(vstate != NULL);
-    assert(proc_state != NULL);
+    rassert(vstate != NULL);
+    rassert(proc_state != NULL);
 
     vstate->render_voice = Volume_vstate_render_voice;
 

--- a/src/lib/player/events/Event_au_bypass.c
+++ b/src/lib/player/events/Event_au_bypass.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -33,13 +33,13 @@ bool Event_au_bypass_on_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
 
     au_state->bypass = true;
 
@@ -67,13 +67,13 @@ bool Event_au_bypass_off_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
 
     au_state->bypass = false;
 

--- a/src/lib/player/events/Event_au_control_vars.c
+++ b/src/lib/player/events/Event_au_control_vars.c
@@ -31,13 +31,13 @@ bool Event_au_set_cv_value_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
 
     const char* var_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_CONTROL_VAR);

--- a/src/lib/player/events/Event_au_set_sustain.c
+++ b/src/lib/player/events/Event_au_set_sustain.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -31,14 +31,14 @@ bool Event_au_set_sustain_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     au_state->sustain = value->value.float_type;
 

--- a/src/lib/player/events/Event_au_streams.c
+++ b/src/lib/player/events/Event_au_streams.c
@@ -28,9 +28,9 @@
 static Device_state* get_target_dstate(
         const Audio_unit* au, Device_states* dstates, const char* stream_name)
 {
-    assert(au != NULL);
-    assert(dstates != NULL);
-    assert(stream_name != NULL);
+    rassert(au != NULL);
+    rassert(dstates != NULL);
+    rassert(stream_name != NULL);
 
     const Au_streams* streams = Audio_unit_get_streams(au);
     if (streams == NULL)
@@ -62,14 +62,14 @@ bool Event_au_set_stream_value_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -96,14 +96,14 @@ bool Event_au_slide_stream_target_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -130,14 +130,14 @@ bool Event_au_slide_stream_length_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -164,14 +164,14 @@ bool Event_au_stream_osc_speed_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -198,14 +198,14 @@ bool Event_au_stream_osc_depth_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -232,14 +232,14 @@ bool Event_au_stream_osc_speed_slide_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -266,14 +266,14 @@ bool Event_au_stream_osc_depth_slide_process(
         Device_states* dstates,
         const Value* value)
 {
-    assert(au != NULL);
-    assert(au_params != NULL);
-    assert(au_state != NULL);
-    assert(master_params != NULL);
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(au != NULL);
+    rassert(au_params != NULL);
+    rassert(au_state != NULL);
+    rassert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);

--- a/src/lib/player/events/Event_channel_arpeggio.c
+++ b/src/lib/player/events/Event_channel_arpeggio.c
@@ -33,9 +33,9 @@ bool Event_channel_arpeggio_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     if (isnan(ch->arpeggio_ref))
@@ -65,9 +65,9 @@ bool Event_channel_arpeggio_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     for (int i = 0; i < KQT_PROCESSORS_MAX; ++i)
@@ -89,11 +89,11 @@ bool Event_channel_set_arpeggio_index_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     ch->arpeggio_edit_pos = (int)value->value.int_type;
 
@@ -107,11 +107,11 @@ bool Event_channel_set_arpeggio_note_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     if (isnan(ch->arpeggio_tones[ch->arpeggio_edit_pos]) &&
             ch->arpeggio_edit_pos < KQT_ARPEGGIO_TONES_MAX - 1)
@@ -141,11 +141,11 @@ bool Event_channel_set_arpeggio_speed_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     ch->arpeggio_speed = value->value.float_type;
 
@@ -168,9 +168,9 @@ bool Event_channel_reset_arpeggio_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     ch->arpeggio_ref = NAN;

--- a/src/lib/player/events/Event_channel_control_vars.c
+++ b/src/lib/player/events/Event_channel_control_vars.c
@@ -26,8 +26,8 @@
 
 static bool try_update_cv(Channel* ch, const Value* value)
 {
-    assert(ch != NULL);
-    assert(value != NULL);
+    rassert(ch != NULL);
+    rassert(value != NULL);
 
     const char* var_name =
         Active_names_get(ch->parent.active_names, ACTIVE_CAT_CONTROL_VAR);
@@ -43,16 +43,16 @@ static bool try_update_cv(Channel* ch, const Value* value)
 
 static void set_cv_value_generic(Channel* ch, Device_states* dstates, const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(value != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(value != NULL);
 
     if (!try_update_cv(ch, value))
         return;
 
     const char* var_name =
         Active_names_get(ch->parent.active_names, ACTIVE_CAT_CONTROL_VAR);
-    assert(var_name != NULL);
+    rassert(var_name != NULL);
 
     const Audio_unit* au = Module_get_au_from_input(ch->parent.module, ch->au_input);
     if (au == NULL)
@@ -74,8 +74,8 @@ static void set_cv_value_generic(Channel* ch, Device_states* dstates, const Valu
 
 static void set_cv_carry(Channel* ch, Device_states* dstates, bool enabled)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
 
     const char* var_name =
         Active_names_get(ch->parent.active_names, ACTIVE_CAT_CONTROL_VAR);
@@ -94,11 +94,11 @@ bool Event_channel_set_cv_name_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     return set_active_name(&ch->parent, ACTIVE_CAT_CONTROL_VAR, value);
 }
@@ -110,11 +110,11 @@ bool Event_channel_set_cv_value_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(Value_type_is_realtime(value->type));
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(Value_type_is_realtime(value->type));
 
     set_cv_value_generic(ch, dstates, value);
 
@@ -128,9 +128,9 @@ bool Event_channel_carry_cv_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     set_cv_carry(ch, dstates, true);
@@ -145,9 +145,9 @@ bool Event_channel_carry_cv_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     set_cv_carry(ch, dstates, false);

--- a/src/lib/player/events/Event_channel_expressions.c
+++ b/src/lib/player/events/Event_channel_expressions.c
@@ -33,11 +33,11 @@ bool Event_channel_set_init_expression_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     return set_active_name(&channel->parent, ACTIVE_CAT_INIT_EXPRESSION, value);
 }
@@ -49,11 +49,11 @@ bool Event_channel_apply_expression_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     set_active_name(&channel->parent, ACTIVE_CAT_EXPRESSION, value);
 
@@ -95,9 +95,9 @@ bool Event_channel_carry_expression_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     channel->carry_expression = true;
@@ -112,9 +112,9 @@ bool Event_channel_carry_expression_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     channel->carry_expression = false;

--- a/src/lib/player/events/Event_channel_force.c
+++ b/src/lib/player/events/Event_channel_force.c
@@ -42,11 +42,11 @@ bool Event_channel_set_force_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const double force = value->value.float_type;
 
@@ -76,11 +76,11 @@ bool Event_channel_slide_force_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     double slide_target = value->value.float_type;
 
@@ -114,11 +114,11 @@ bool Event_channel_slide_force_length_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->force_slide_length, &value->value.Tstamp_type);
 
@@ -144,11 +144,11 @@ bool Event_channel_tremolo_speed_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     ch->tremolo_speed = value->value.float_type;
 
@@ -186,11 +186,11 @@ bool Event_channel_tremolo_depth_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const double actual_depth = value->value.float_type;
     ch->tremolo_depth = actual_depth;
@@ -227,11 +227,11 @@ bool Event_channel_tremolo_speed_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->tremolo_speed_slide, &value->value.Tstamp_type);
 
@@ -257,11 +257,11 @@ bool Event_channel_tremolo_depth_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->tremolo_depth_slide, &value->value.Tstamp_type);
 
@@ -287,9 +287,9 @@ bool Event_channel_carry_force_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     ch->carry_force = true;
@@ -304,9 +304,9 @@ bool Event_channel_carry_force_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     ch->carry_force = false;

--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -50,15 +50,15 @@ bool Event_channel_note_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(ch->freq != NULL);
-    assert(*ch->freq > 0);
-    assert(ch->tempo != NULL);
-    assert(*ch->tempo > 0);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(ch->freq != NULL);
+    rassert(*ch->freq > 0);
+    rassert(ch->tempo != NULL);
+    rassert(*ch->tempo > 0);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     // Move the old Voices to the background
     Event_channel_note_off_process(ch, dstates, master_params, NULL);
@@ -234,13 +234,13 @@ bool Event_channel_hit_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(ch->freq != NULL);
-    assert(ch->tempo != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(ch != NULL);
+    rassert(ch->freq != NULL);
+    rassert(ch->tempo != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     // Move the old Voices to the background
     Event_channel_note_off_process(ch, dstates, master_params, NULL);
@@ -380,9 +380,9 @@ bool Event_channel_note_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     for (int i = 0; i < KQT_PROCESSORS_MAX; ++i)

--- a/src/lib/player/events/Event_channel_pitch.c
+++ b/src/lib/player/events/Event_channel_pitch.c
@@ -38,11 +38,11 @@ bool Event_channel_slide_pitch_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     double pitch = value->value.float_type;
 
@@ -85,11 +85,11 @@ bool Event_channel_slide_pitch_length_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->pitch_slide_length, &value->value.Tstamp_type);
 
@@ -114,11 +114,11 @@ bool Event_channel_vibrato_speed_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     ch->vibrato_speed = value->value.float_type;
 
@@ -148,11 +148,11 @@ bool Event_channel_vibrato_depth_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const double actual_depth = value->value.float_type * 5; // unit is 5 cents
     ch->vibrato_depth = actual_depth;
@@ -183,11 +183,11 @@ bool Event_channel_vibrato_speed_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->vibrato_speed_slide, &value->value.Tstamp_type);
 
@@ -212,11 +212,11 @@ bool Event_channel_vibrato_depth_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&ch->vibrato_depth_slide, &value->value.Tstamp_type);
 
@@ -241,9 +241,9 @@ bool Event_channel_carry_pitch_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     ch->carry_pitch = true;
@@ -258,9 +258,9 @@ bool Event_channel_carry_pitch_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     ch->carry_pitch = false;

--- a/src/lib/player/events/Event_channel_streams.c
+++ b/src/lib/player/events/Event_channel_streams.c
@@ -33,11 +33,11 @@ bool Event_channel_set_stream_name_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     return set_active_name(&channel->parent, ACTIVE_CAT_STREAM, value);
 }
@@ -49,11 +49,11 @@ bool Event_channel_set_stream_value_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -79,8 +79,8 @@ bool Event_channel_set_stream_value_process(
 static void ensure_valid_stream(
         Channel_stream_state* ss, const char* stream_name, const Voice_state* vstate)
 {
-    assert(ss != NULL);
-    assert(stream_name != NULL);
+    rassert(ss != NULL);
+    rassert(stream_name != NULL);
 
     const Linear_controls* controls = Channel_stream_state_get_controls(ss, stream_name);
     if (controls == NULL)
@@ -105,11 +105,11 @@ bool Event_channel_slide_stream_target_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -141,11 +141,11 @@ bool Event_channel_slide_stream_length_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -177,11 +177,11 @@ bool Event_channel_stream_osc_speed_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -213,11 +213,11 @@ bool Event_channel_stream_osc_depth_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -249,11 +249,11 @@ bool Event_channel_stream_osc_speed_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -286,11 +286,11 @@ bool Event_channel_stream_osc_depth_slide_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     const char* stream_name =
         Active_names_get(channel->parent.active_names, ACTIVE_CAT_STREAM);
@@ -323,9 +323,9 @@ bool Event_channel_carry_stream_on_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     const char* stream_name =
@@ -345,9 +345,9 @@ bool Event_channel_carry_stream_off_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(channel != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
+    rassert(channel != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     const char* stream_name =

--- a/src/lib/player/events/Event_channel_targets.c
+++ b/src/lib/player/events/Event_channel_targets.c
@@ -29,11 +29,11 @@ bool Event_channel_set_au_input_process(
         const Master_params* master_params,
         const Value* value)
 {
-    assert(ch != NULL);
-    assert(dstates != NULL);
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(ch != NULL);
+    rassert(dstates != NULL);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     ch->au_input = (int)value->value.int_type;
 

--- a/src/lib/player/events/Event_common.h
+++ b/src/lib/player/events/Event_common.h
@@ -35,7 +35,7 @@
         if ((ch_state)->fg[(proc)] == NULL)            \
             continue;                                  \
     }                                                  \
-    else (void)0
+    else ignore(0)
 
 
 #endif // KQT_EVENT_COMMON_H

--- a/src/lib/player/events/Event_control_env.c
+++ b/src/lib/player/events/Event_control_env.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -32,10 +32,10 @@
 bool Event_control_env_set_var_name_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     return set_active_name(&channel->parent, ACTIVE_CAT_ENV, value);
 }
@@ -44,9 +44,9 @@ bool Event_control_env_set_var_name_process(
 bool Event_control_env_set_var_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
-    assert(value != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
+    rassert(value != NULL);
 
     Env_var* var = Env_state_get_var(
             global_state->estate,

--- a/src/lib/player/events/Event_control_goto.c
+++ b/src/lib/player/events/Event_control_goto.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -31,8 +31,8 @@
 bool Event_control_goto_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
     ignore(value);
 
     Master_params* master_params = (Master_params*)global_state;
@@ -55,10 +55,10 @@ bool Event_control_goto_process(
 bool Event_control_set_goto_row_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Master_params* master_params = (Master_params*)global_state;
     Tstamp_copy(&master_params->goto_target_row, &value->value.Tstamp_type);
@@ -70,10 +70,10 @@ bool Event_control_set_goto_row_process(
 bool Event_control_set_goto_pat_inst_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_PAT_INST_REF);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_PAT_INST_REF);
 
     Master_params* master_params = (Master_params*)global_state;
     master_params->goto_target_piref = value->value.Pat_inst_ref_type;

--- a/src/lib/player/events/Event_control_infinite.c
+++ b/src/lib/player/events/Event_control_infinite.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -29,8 +29,8 @@
 bool Event_control_infinite_on_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
     ignore(value);
 
     Master_params* master_params = (Master_params*)global_state;
@@ -43,8 +43,8 @@ bool Event_control_infinite_on_process(
 bool Event_control_infinite_off_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
     ignore(value);
 
     Master_params* master_params = (Master_params*)global_state;

--- a/src/lib/player/events/Event_control_pause.c
+++ b/src/lib/player/events/Event_control_pause.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -27,8 +27,8 @@
 bool Event_control_pause_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
     ignore(value);
 
     global_state->pause = true;
@@ -39,8 +39,8 @@ bool Event_control_pause_process(
 bool Event_control_resume_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
     ignore(value);
 
     global_state->pause = false;

--- a/src/lib/player/events/Event_control_play_pattern.c
+++ b/src/lib/player/events/Event_control_play_pattern.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -29,10 +29,10 @@
 bool Event_control_play_pattern_process(
         General_state* global_state, Channel* channel, const Value* value)
 {
-    assert(global_state != NULL);
-    assert(channel != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_PAT_INST_REF);
+    rassert(global_state != NULL);
+    rassert(channel != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_PAT_INST_REF);
 
     Master_params* master_params = (Master_params*)global_state;
     master_params->playback_state = PLAYBACK_PATTERN;

--- a/src/lib/player/events/Event_general_call.c
+++ b/src/lib/player/events/Event_general_call.c
@@ -25,16 +25,16 @@
 
 bool Event_general_call_name_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
-    assert(value != NULL);
+    rassert(gstate != NULL);
+    rassert(value != NULL);
     return value->type == VALUE_TYPE_STRING;
 }
 
 
 bool Event_general_call_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
-    assert(value != NULL);
+    rassert(gstate != NULL);
+    rassert(value != NULL);
     return true;
 }
 

--- a/src/lib/player/events/Event_general_comment.c
+++ b/src/lib/player/events/Event_general_comment.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -25,8 +25,8 @@
 
 bool Event_general_comment_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
-    assert(value != NULL);
+    rassert(gstate != NULL);
+    rassert(value != NULL);
     return value->type == VALUE_TYPE_STRING;
 }
 

--- a/src/lib/player/events/Event_general_cond.c
+++ b/src/lib/player/events/Event_general_cond.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -30,8 +30,8 @@
 
 bool Event_general_cond_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
-    assert(value != NULL);
+    rassert(gstate != NULL);
+    rassert(value != NULL);
 
     if (value->type != VALUE_TYPE_BOOL)
         return false;
@@ -47,11 +47,11 @@ bool Event_general_cond_process(General_state* gstate, const Value* value)
 
 bool Event_general_if_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
+    rassert(gstate != NULL);
     ignore(value);
 
     ++gstate->cond_level_index;
-    assert(gstate->cond_level_index >= 0);
+    rassert(gstate->cond_level_index >= 0);
     if (gstate->cond_level_index < COND_LEVELS_MAX)
     {
         gstate->cond_levels[gstate->cond_level_index].cond_for_exec = true;
@@ -69,11 +69,11 @@ bool Event_general_if_process(General_state* gstate, const Value* value)
 
 bool Event_general_else_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
+    rassert(gstate != NULL);
     ignore(value);
 
     ++gstate->cond_level_index;
-    assert(gstate->cond_level_index >= 0);
+    rassert(gstate->cond_level_index >= 0);
     if (gstate->cond_level_index < COND_LEVELS_MAX)
     {
         gstate->cond_levels[gstate->cond_level_index].cond_for_exec = false;
@@ -89,7 +89,7 @@ bool Event_general_else_process(General_state* gstate, const Value* value)
 
 bool Event_general_end_if_process(General_state* gstate, const Value* value)
 {
-    assert(gstate != NULL);
+    rassert(gstate != NULL);
     ignore(value);
 
     if (gstate->cond_level_index >= 0)
@@ -98,7 +98,7 @@ bool Event_general_end_if_process(General_state* gstate, const Value* value)
     if (gstate->cond_level_index < gstate->last_cond_match)
     {
         --gstate->last_cond_match;
-        assert(gstate->cond_level_index == gstate->last_cond_match);
+        rassert(gstate->cond_level_index == gstate->last_cond_match);
     }
 
 #if 0

--- a/src/lib/player/events/Event_master_jump.c
+++ b/src/lib/player/events/Event_master_jump.c
@@ -28,9 +28,9 @@
 bool Event_master_set_jump_counter_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     master_params->jump_counter = (int16_t)value->value.int_type;
 
@@ -41,9 +41,9 @@ bool Event_master_set_jump_counter_process(
 bool Event_master_set_jump_row_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&master_params->jump_target_row, &value->value.Tstamp_type);
 
@@ -54,9 +54,9 @@ bool Event_master_set_jump_row_process(
 bool Event_master_set_jump_pat_inst_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_PAT_INST_REF);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_PAT_INST_REF);
 
     master_params->jump_target_piref = value->value.Pat_inst_ref_type;
 
@@ -66,7 +66,7 @@ bool Event_master_set_jump_pat_inst_process(
 
 bool Event_master_jump_process(Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     if (master_params->jump_counter <= 0)

--- a/src/lib/player/events/Event_master_pattern_delay.c
+++ b/src/lib/player/events/Event_master_pattern_delay.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -27,9 +27,9 @@
 bool Event_master_pattern_delay_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Tstamp_copy(&master_params->delay_left, &value->value.Tstamp_type);
     return true;

--- a/src/lib/player/events/Event_master_retuning.c
+++ b/src/lib/player/events/Event_master_retuning.c
@@ -31,9 +31,9 @@ static void get_tuning_info(
         Tuning_state** out_tuning_state,
         const Tuning_table** out_tuning_table)
 {
-    assert(master_params != NULL);
-    assert(out_tuning_state != NULL);
-    assert(out_tuning_table != NULL);
+    rassert(master_params != NULL);
+    rassert(out_tuning_state != NULL);
+    rassert(out_tuning_table != NULL);
 
     const int index = master_params->cur_tuning_state;
     if (index < 0 || index >= KQT_TUNING_TABLES_MAX)
@@ -56,9 +56,9 @@ static void get_tuning_info(
 
 bool Event_master_set_retuner_process(Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     master_params->cur_tuning_state = (int)value->value.int_type;
 
@@ -78,9 +78,9 @@ bool Event_master_set_retuner_process(Master_params* master_params, const Value*
 bool Event_master_set_retuner_fixed_pitch_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     Tuning_state* state = NULL;
     const Tuning_table* table = NULL;
@@ -97,9 +97,9 @@ bool Event_master_set_retuner_fixed_pitch_process(
 bool Event_master_set_retuner_tuning_center_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     Tuning_state* state = NULL;
     const Tuning_table* table = NULL;
@@ -116,9 +116,9 @@ bool Event_master_set_retuner_tuning_center_process(
 bool Event_master_set_retuner_pitch_offset_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     Tuning_state* state = NULL;
     const Tuning_table* table = NULL;
@@ -135,9 +135,9 @@ bool Event_master_set_retuner_pitch_offset_process(
 bool Event_master_mimic_retuner_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_INT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_INT);
 
     const int source_index = (int)value->value.int_type;
     if (source_index < 0 || source_index >= KQT_TUNING_TABLES_MAX)
@@ -159,7 +159,7 @@ bool Event_master_mimic_retuner_process(
 bool Event_master_reset_retuner_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
+    rassert(master_params != NULL);
     ignore(value);
 
     Tuning_state* state = NULL;

--- a/src/lib/player/events/Event_master_tempo.c
+++ b/src/lib/player/events/Event_master_tempo.c
@@ -27,9 +27,9 @@
 bool Event_master_set_tempo_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     master_params->tempo_settings_changed = true;
     master_params->tempo = value->value.float_type;
@@ -41,7 +41,7 @@ bool Event_master_set_tempo_process(
 
 static void set_tempo_slide_update(Master_params* master_params)
 {
-    assert(master_params != NULL);
+    rassert(master_params != NULL);
 
     const double rems_total =
             (double)Tstamp_get_beats(&master_params->tempo_slide_length) *
@@ -58,9 +58,9 @@ static void set_tempo_slide_update(Master_params* master_params)
 bool Event_master_slide_tempo_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     master_params->tempo_settings_changed = true;
 
@@ -87,9 +87,9 @@ bool Event_master_slide_tempo_process(
 bool Event_master_slide_tempo_length_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     master_params->tempo_settings_changed = true;
 

--- a/src/lib/player/events/Event_master_volume.c
+++ b/src/lib/player/events/Event_master_volume.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2016
  *
  * This file is part of Kunquat.
  *
@@ -26,9 +26,9 @@
 bool Event_master_set_volume_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     master_params->volume = exp2(value->value.float_type / 6);
     Slider_break(&master_params->volume_slider);
@@ -40,9 +40,9 @@ bool Event_master_set_volume_process(
 bool Event_master_slide_volume_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_FLOAT);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_FLOAT);
 
     const double target = exp2(value->value.float_type / 6);
 
@@ -58,9 +58,9 @@ bool Event_master_slide_volume_process(
 bool Event_master_slide_volume_length_process(
         Master_params* master_params, const Value* value)
 {
-    assert(master_params != NULL);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_TSTAMP);
+    rassert(master_params != NULL);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_TSTAMP);
 
     Slider_set_length(&master_params->volume_slider, &value->value.Tstamp_type);
 

--- a/src/lib/player/events/note_setup.c
+++ b/src/lib/player/events/note_setup.c
@@ -32,19 +32,19 @@ void reserve_voice(
         int proc_num,
         uint64_t rand_seed)
 {
-    assert(ch != NULL);
-    assert(ch->freq != NULL);
-    assert(*ch->freq > 0);
-    assert(ch->tempo != NULL);
-    assert(*ch->tempo > 0);
-    assert(au != NULL);
-    assert(proc_state != NULL);
-    assert(proc_num >= 0);
-    assert(proc_num < KQT_PROCESSORS_MAX);
+    rassert(ch != NULL);
+    rassert(ch->freq != NULL);
+    rassert(*ch->freq > 0);
+    rassert(ch->tempo != NULL);
+    rassert(*ch->tempo > 0);
+    rassert(au != NULL);
+    rassert(proc_state != NULL);
+    rassert(proc_num >= 0);
+    rassert(proc_num < KQT_PROCESSORS_MAX);
 
     ++ch->fg_count;
     ch->fg[proc_num] = Voice_pool_get_voice(ch->pool, NULL, 0);
-    assert(ch->fg[proc_num] != NULL);
+    rassert(ch->fg[proc_num] != NULL);
 //    fprintf(stderr, "allocated Voice %p\n", (void*)ch->fg[proc_num]);
     ch->fg_id[proc_num] = Voice_id(ch->fg[proc_num]);
 

--- a/src/lib/player/events/set_active_name.c
+++ b/src/lib/player/events/set_active_name.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2011-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2011-2016
  *
  * This file is part of Kunquat.
  *
@@ -25,10 +25,10 @@
 
 bool set_active_name(General_state* gstate, Active_cat cat, const Value* value)
 {
-    assert(gstate != NULL);
-    assert(cat < ACTIVE_CAT_COUNT);
-    assert(value != NULL);
-    assert(value->type == VALUE_TYPE_STRING);
+    rassert(gstate != NULL);
+    rassert(cat < ACTIVE_CAT_COUNT);
+    rassert(value != NULL);
+    rassert(value->type == VALUE_TYPE_STRING);
 
     Active_names_set(gstate->active_names, cat, value->value.string_type);
 

--- a/src/lib/player/events/stream_utils.c
+++ b/src/lib/player/events/stream_utils.c
@@ -29,9 +29,9 @@
 
 Voice_state* get_target_stream_vstate(Channel* channel, const char* stream_name)
 {
-    assert(channel != NULL);
-    assert(stream_name != NULL);
-    assert(is_valid_var_name(stream_name));
+    rassert(channel != NULL);
+    rassert(stream_name != NULL);
+    rassert(is_valid_var_name(stream_name));
 
     const Audio_unit* au =
         Module_get_au_from_input(channel->parent.module, channel->au_input);
@@ -46,7 +46,7 @@ Voice_state* get_target_stream_vstate(Channel* channel, const char* stream_name)
     if (proc_index < 0)
         return NULL;
 
-    assert(proc_index < KQT_PROCESSORS_MAX);
+    rassert(proc_index < KQT_PROCESSORS_MAX);
     if (channel->fg[proc_index] == NULL)
         return NULL;
 

--- a/src/lib/string/Streader.c
+++ b/src/lib/string/Streader.c
@@ -28,9 +28,9 @@
 
 Streader* Streader_init(Streader* sr, const char* str, int64_t len)
 {
-    assert(sr != NULL);
-    assert(str != NULL || len == 0);
-    assert(len >= 0);
+    rassert(sr != NULL);
+    rassert(str != NULL || len == 0);
+    rassert(len >= 0);
 
     sr->pos = 0;
     sr->len = len;
@@ -44,22 +44,22 @@ Streader* Streader_init(Streader* sr, const char* str, int64_t len)
 
 bool Streader_is_error_set(const Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     return Error_is_set(&sr->error);
 }
 
 
 const char* Streader_get_error_desc(const Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     return Error_get_desc(&sr->error);
 }
 
 
 void Streader_set_error(Streader* sr, const char* format, ...)
 {
-    assert(sr != NULL);
-    assert(format != NULL);
+    rassert(sr != NULL);
+    rassert(format != NULL);
 
     va_list args;
     va_start(args, format);
@@ -73,8 +73,8 @@ void Streader_set_error(Streader* sr, const char* format, ...)
 
 void Streader_set_memory_error(Streader* sr, const char* format, ...)
 {
-    assert(sr != NULL);
-    assert(format != NULL);
+    rassert(sr != NULL);
+    rassert(format != NULL);
 
     va_list args;
     va_start(args, format);
@@ -88,7 +88,7 @@ void Streader_set_memory_error(Streader* sr, const char* format, ...)
 
 void Streader_clear_error(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
     Error_clear(&sr->error);
     return;
 }
@@ -96,19 +96,19 @@ void Streader_clear_error(Streader* sr)
 
 static bool Streader_end_reached(const Streader* sr)
 {
-    assert(sr != NULL);
-    assert(sr->pos <= sr->len);
+    rassert(sr != NULL);
+    rassert(sr->pos <= sr->len);
 
     return sr->pos == sr->len;
 }
 
 
-#define CUR_CH (assert(!Streader_end_reached(sr)), sr->str[sr->pos])
+#define CUR_CH (rassert(!Streader_end_reached(sr)), sr->str[sr->pos])
 
 
 const char* Streader_get_remaining_data(const Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_end_reached(sr))
         return NULL;
@@ -119,7 +119,7 @@ const char* Streader_get_remaining_data(const Streader* sr)
 
 static void print_wrong_char(char dest[5], char ch)
 {
-    assert(dest != NULL);
+    rassert(dest != NULL);
 
     if (isprint(ch))
         snprintf(dest, 5, "'%c'", ch);
@@ -132,7 +132,7 @@ static void print_wrong_char(char dest[5], char ch)
 
 bool Streader_skip_whitespace(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -145,7 +145,7 @@ bool Streader_skip_whitespace(Streader* sr)
         ++sr->pos;
     }
 
-    assert(sr->pos <= sr->len);
+    rassert(sr->pos <= sr->len);
 
     return true;
 }
@@ -153,8 +153,8 @@ bool Streader_skip_whitespace(Streader* sr)
 
 bool Streader_has_data(Streader* sr)
 {
-    assert(sr != NULL);
-    assert(!Streader_is_error_set(sr));
+    rassert(sr != NULL);
+    rassert(!Streader_is_error_set(sr));
 
     Streader_skip_whitespace(sr);
     return !Streader_end_reached(sr);
@@ -163,7 +163,7 @@ bool Streader_has_data(Streader* sr)
 
 bool Streader_match_char(Streader* sr, char ch)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -198,8 +198,8 @@ bool Streader_match_char(Streader* sr, char ch)
 
 bool Streader_try_match_char(Streader* sr, char ch)
 {
-    assert(sr != NULL);
-    assert(!Streader_is_error_set(sr));
+    rassert(sr != NULL);
+    rassert(!Streader_is_error_set(sr));
 
     const int64_t start_pos = sr->pos;
     const bool success = Streader_match_char(sr, ch);
@@ -215,11 +215,11 @@ bool Streader_try_match_char(Streader* sr, char ch)
 
 static bool Streader_match_char_seq(Streader* sr, const char* seq)
 {
-    assert(sr != NULL);
-    assert(seq != NULL);
+    rassert(sr != NULL);
+    rassert(seq != NULL);
 
-    assert(!Streader_is_error_set(sr));
-    assert(!Streader_end_reached(sr));
+    rassert(!Streader_is_error_set(sr));
+    rassert(!Streader_end_reached(sr));
 
     // Check that we have enough data
     const int64_t expected_len = (int64_t)strlen(seq);
@@ -260,9 +260,9 @@ static bool Streader_match_char_seq(Streader* sr, const char* seq)
 
 static bool Streader_try_match_char_seq(Streader* sr, const char* seq)
 {
-    assert(sr != NULL);
-    assert(!Streader_is_error_set(sr));
-    assert(seq != NULL);
+    rassert(sr != NULL);
+    rassert(!Streader_is_error_set(sr));
+    rassert(seq != NULL);
 
     const int64_t start_pos = sr->pos;
     const bool success = Streader_match_char_seq(sr, seq);
@@ -278,8 +278,8 @@ static bool Streader_try_match_char_seq(Streader* sr, const char* seq)
 
 bool Streader_match_string(Streader* sr, const char* str)
 {
-    assert(sr != NULL);
-    assert(str != NULL);
+    rassert(sr != NULL);
+    rassert(str != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -331,7 +331,7 @@ bool Streader_match_string(Streader* sr, const char* str)
 
 bool Streader_read_null(Streader* sr)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -350,7 +350,7 @@ bool Streader_read_null(Streader* sr)
 
 bool Streader_read_bool(Streader* sr, bool* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -383,7 +383,7 @@ bool Streader_read_bool(Streader* sr, bool* dest)
 
 bool Streader_read_int(Streader* sr, int64_t* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -482,7 +482,7 @@ bool Streader_read_int(Streader* sr, int64_t* dest)
 
 bool Streader_read_float(Streader* sr, double* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -521,7 +521,7 @@ bool Streader_read_float(Streader* sr, double* dest)
             if (significant_digits_read < SIGNIFICANT_MAX)
             {
                 // Store the digit into our significand
-                assert(significand < INT64_MAX / 10);
+                rassert(significand < INT64_MAX / 10);
                 significand *= 10;
                 significand += (int64_t)(CUR_CH - '0');
                 ++significant_digits_read;
@@ -551,7 +551,7 @@ bool Streader_read_float(Streader* sr, double* dest)
             if (significant_digits_read < SIGNIFICANT_MAX)
             {
                 // Append digit to our significand and compensate in shift
-                assert(significand < INT64_MAX / 10);
+                rassert(significand < INT64_MAX / 10);
                 significand *= 10;
                 significand += (int64_t)(CUR_CH - '0');
                 --significand_shift;
@@ -596,7 +596,7 @@ bool Streader_read_float(Streader* sr, double* dest)
 
         while (!Streader_end_reached(sr) && isdigit(CUR_CH))
         {
-            assert(exponent < INT_MAX / 10);
+            rassert(exponent < INT_MAX / 10);
             exponent *= 10;
             exponent += (int)(CUR_CH - '0');
 
@@ -654,8 +654,8 @@ bool Streader_read_float(Streader* sr, double* dest)
 
 bool Streader_read_string(Streader* sr, int64_t max_bytes, char* dest)
 {
-    assert(sr != NULL);
-    assert(max_bytes >= 0);
+    rassert(sr != NULL);
+    rassert(max_bytes >= 0);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -748,8 +748,8 @@ bool Streader_read_string(Streader* sr, int64_t max_bytes, char* dest)
                         return false;
                     }
 
-                    assert(value >= 0);
-                    assert(value < 0x10);
+                    rassert(value >= 0);
+                    rassert(value < 0x10);
 
                     code *= 0x10;
                     code += value;
@@ -812,12 +812,12 @@ bool Streader_read_string(Streader* sr, int64_t max_bytes, char* dest)
         Streader_set_error(sr, "Unexpected end of data");
         return false;
     }
-    assert(CUR_CH == '\"');
+    rassert(CUR_CH == '\"');
     ++sr->pos;
 
     if (max_bytes > 0 && dest != NULL)
     {
-        assert(write_pos < max_bytes);
+        rassert(write_pos < max_bytes);
         dest[write_pos] = '\0';
     }
 
@@ -827,7 +827,7 @@ bool Streader_read_string(Streader* sr, int64_t max_bytes, char* dest)
 
 bool Streader_read_tstamp(Streader* sr, Tstamp* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -864,8 +864,8 @@ bool Streader_read_tstamp(Streader* sr, Tstamp* dest)
 
 static void recover(Streader* sr, int64_t pos)
 {
-    assert(sr != NULL);
-    assert(pos <= sr->pos);
+    rassert(sr != NULL);
+    rassert(pos <= sr->pos);
 
     Streader_clear_error(sr);
     sr->pos = pos;
@@ -876,7 +876,7 @@ static void recover(Streader* sr, int64_t pos)
 
 bool Streader_read_finite_rt(Streader* sr, Value* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -910,7 +910,7 @@ bool Streader_read_finite_rt(Streader* sr, Value* dest)
 
 bool Streader_read_piref(Streader* sr, Pat_inst_ref* dest)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -962,7 +962,7 @@ bool Streader_read_piref(Streader* sr, Pat_inst_ref* dest)
 
 bool Streader_read_list(Streader* sr, List_item_reader ir, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1006,7 +1006,7 @@ bool Streader_read_list(Streader* sr, List_item_reader ir, void* userdata)
 
 bool Streader_read_dict(Streader* sr, Dict_item_reader ir, void* userdata)
 {
-    assert(sr != NULL);
+    rassert(sr != NULL);
 
     if (Streader_is_error_set(sr))
         return false;
@@ -1051,8 +1051,8 @@ bool Streader_read_dict(Streader* sr, Dict_item_reader ir, void* userdata)
 
 bool Streader_readf(Streader* sr, const char* format, ...)
 {
-    assert(sr != NULL);
-    assert(format != NULL);
+    rassert(sr != NULL);
+    rassert(format != NULL);
 
     va_list args;
     va_start(args, format);
@@ -1097,7 +1097,7 @@ bool Streader_readf(Streader* sr, const char* format, ...)
                 {
                     Streader_readf_str_info info =
                         va_arg(args, Streader_readf_str_info);
-                    assert(info.guard == Streader_readf_str_guard);
+                    rassert(info.guard == Streader_readf_str_guard);
 
                     const int64_t max_bytes = info.max_bytes;
                     char* dest = info.dest;
@@ -1142,7 +1142,7 @@ bool Streader_readf(Streader* sr, const char* format, ...)
                 break;
 
                 default:
-                    assert(false);
+                    rassert(false);
             }
         }
         else

--- a/src/lib/string/common.c
+++ b/src/lib/string/common.c
@@ -58,7 +58,7 @@ bool string_has_suffix(const char* str, const char* suffix)
         return false;
 
     const char* search = str + (strlen(str) - strlen(suffix));
-    assert(strlen(search) == strlen(suffix));
+    rassert(strlen(search) == strlen(suffix));
 
     return string_eq(search, suffix);
 }
@@ -67,8 +67,8 @@ bool string_has_suffix(const char* str, const char* suffix)
 int string_extract_index(
         const char* path, const char* prefix, int digits, const char* after)
 {
-    assert(path != NULL);
-    assert(digits > 0);
+    rassert(path != NULL);
+    rassert(digits > 0);
 
     if (!string_has_prefix(path, prefix))
         return -1;

--- a/src/lib/string/key_pattern.c
+++ b/src/lib/string/key_pattern.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2014-2015
+ * Author: Tomi Jylhä-Ollila, Finland 2014-2016
  *
  * This file is part of Kunquat.
  *
@@ -25,8 +25,8 @@
 static int32_t extract_num(
         const char* section, size_t section_length, size_t* digit_count)
 {
-    assert(section != NULL);
-    assert(digit_count != NULL);
+    rassert(section != NULL);
+    rassert(digit_count != NULL);
 
     int32_t num = 0;
     int mul = 1;
@@ -55,10 +55,10 @@ static int32_t extract_num(
 
 bool extract_key_pattern(const char* key, char* key_pattern, Key_indices indices)
 {
-    assert(key != NULL);
-    assert(strlen(key) < KQT_KEY_LENGTH_MAX);
-    assert(key_pattern != NULL);
-    assert(indices != NULL);
+    rassert(key != NULL);
+    rassert(strlen(key) < KQT_KEY_LENGTH_MAX);
+    rassert(key_pattern != NULL);
+    rassert(indices != NULL);
 
     int next_index_pos = 0;
     char* keyp_write_pos = key_pattern;
@@ -86,8 +86,8 @@ bool extract_key_pattern(const char* key, char* key_pattern, Key_indices indices
             ++next_index_pos;
 
             // Create a key pattern section of format "blabla_XXX/"
-            assert(digit_count > 0);
-            assert(digit_count <= section_length);
+            rassert(digit_count > 0);
+            rassert(digit_count <= section_length);
             const size_t prefix_length = section_length - digit_count;
             strncpy(keyp_write_pos, section, prefix_length);
             memset(keyp_write_pos + prefix_length, 'X', digit_count);
@@ -108,7 +108,7 @@ bool extract_key_pattern(const char* key, char* key_pattern, Key_indices indices
     // Copy the last part of the key
     strncpy(keyp_write_pos, section, section_length);
     keyp_write_pos[section_length] = '\0';
-    assert((int)strlen(key) == (keyp_write_pos + strlen(keyp_write_pos) - key_pattern));
+    rassert((int)strlen(key) == (keyp_write_pos + strlen(keyp_write_pos) - key_pattern));
 
     return true;
 }

--- a/src/lib/string/serialise.c
+++ b/src/lib/string/serialise.c
@@ -29,8 +29,8 @@
 
 int serialise_bool(char* dest, int size, bool value)
 {
-    assert(dest != NULL);
-    assert(size > 0);
+    rassert(dest != NULL);
+    rassert(size > 0);
 
     int printed = snprintf(dest, (size_t)size, "%s", value ? "true" : "false");
 
@@ -40,8 +40,8 @@ int serialise_bool(char* dest, int size, bool value)
 
 int serialise_int(char* dest, int size, int64_t value)
 {
-    assert(dest != NULL);
-    assert(size > 0);
+    rassert(dest != NULL);
+    rassert(size > 0);
 
     char result[INT_BUF_SIZE] = "";
     int length = 0;
@@ -64,7 +64,7 @@ int serialise_int(char* dest, int size, int64_t value)
         int64_t left = abs_value;
         while (left != 0)
         {
-            assert(length < INT_BUF_SIZE);
+            rassert(length < INT_BUF_SIZE);
 
             const int64_t digit = left % 10;
             result[length] = (char)(digit + '0');
@@ -75,7 +75,7 @@ int serialise_int(char* dest, int size, int64_t value)
 
         if (is_negative)
         {
-            assert(length < INT_BUF_SIZE);
+            rassert(length < INT_BUF_SIZE);
             result[length] = '-';
             ++length;
         }
@@ -83,7 +83,7 @@ int serialise_int(char* dest, int size, int64_t value)
         // Fix smallest value
         if (is_smallest)
         {
-            assert(result[0] != '9'); // magnitude is a power of 2
+            rassert(result[0] != '9'); // magnitude is a power of 2
             ++result[0];
         }
 
@@ -107,9 +107,9 @@ int serialise_int(char* dest, int size, int64_t value)
 
 int serialise_float(char* dest, int size, double value)
 {
-    assert(dest != NULL);
-    assert(size > 0);
-    assert(isfinite(value));
+    rassert(dest != NULL);
+    rassert(size > 0);
+    rassert(isfinite(value));
 
     // Note: Not the most accurate conversion, this is a temporary solution...
 
@@ -133,7 +133,7 @@ int serialise_float(char* dest, int size, double value)
         // Normalise so that SIGNIFICANT_MAX digits are above the decimal point
         const double scale_factor = pow(10, SIGNIFICANT_MAX - shift - 1);
         int64_t scaled = (int64_t)round(abs_value * scale_factor);
-        assert(scaled >= 0);
+        rassert(scaled >= 0);
 
         bool nonzero_found = false;
         for (int i = SIGNIFICANT_MAX - 1; i >= 0; --i)
@@ -159,13 +159,13 @@ int serialise_float(char* dest, int size, double value)
                 break;
 
             scaled *= 10;
-            assert(scaled < 10);
+            rassert(scaled < 10);
 
             double digit = floor(scaled);
             digits[i] = (char)(digit + '0');
 
             scaled -= digit;
-            assert(scaled >= 0);
+            rassert(scaled >= 0);
         }
 
         // Remove trailing zeros
@@ -178,7 +178,7 @@ int serialise_float(char* dest, int size, double value)
         }
     }
 
-    assert(strlen(digits) > 0);
+    rassert(strlen(digits) > 0);
 
     // buffer size: '-' + significand + '.' + 'e' + exp + '\0' + safety
     char result[1 + SIGNIFICANT_MAX + 1 + 1 + 3 + 1 + 8] = "";
@@ -202,7 +202,7 @@ int serialise_float(char* dest, int size, double value)
         // e<exponent>
         strcat(result, "e");
         const size_t cur_len = strlen(result);
-        assert(cur_len < sizeof(result));
+        rassert(cur_len < sizeof(result));
         serialise_int(&result[cur_len], (int)(sizeof(result) - cur_len - 1), shift);
     }
     else if (shift >= 0)
@@ -244,9 +244,9 @@ int serialise_float(char* dest, int size, double value)
 
 int serialise_Pat_inst_ref(char* dest, int size, const Pat_inst_ref* value)
 {
-    assert(dest != NULL);
-    assert(size > 0);
-    assert(value != NULL);
+    rassert(dest != NULL);
+    rassert(size > 0);
+    rassert(value != NULL);
 
     char pat_buf[INT_BUF_SIZE] = "";
     char inst_buf[INT_BUF_SIZE] = "";
@@ -262,9 +262,9 @@ int serialise_Pat_inst_ref(char* dest, int size, const Pat_inst_ref* value)
 
 int serialise_Tstamp(char* dest, int size, const Tstamp* value)
 {
-    assert(dest != NULL);
-    assert(size > 0);
-    assert(value != NULL);
+    rassert(dest != NULL);
+    rassert(size > 0);
+    rassert(value != NULL);
 
     char beats_buf[INT_BUF_SIZE] = "";
     char rem_buf[INT_BUF_SIZE] = "";

--- a/src/lib/string/var_name.c
+++ b/src/lib/string/var_name.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2016
  *
  * This file is part of Kunquat.
  *
@@ -24,7 +24,7 @@
 
 static bool is_valid_var_name_with_length(const char* str, size_t length)
 {
-    assert(str != NULL);
+    rassert(str != NULL);
 
     return (0 < length) && (length < KQT_VAR_NAME_MAX) &&
         (strspn(str, KQT_VAR_CHARS) == length) &&
@@ -34,7 +34,7 @@ static bool is_valid_var_name_with_length(const char* str, size_t length)
 
 bool is_valid_var_name(const char* str)
 {
-    assert(str != NULL);
+    rassert(str != NULL);
 
     const size_t length = strlen(str);
     return is_valid_var_name_with_length(str, length);
@@ -43,7 +43,7 @@ bool is_valid_var_name(const char* str)
 
 bool is_valid_var_path(const char* str)
 {
-    assert(str != NULL);
+    rassert(str != NULL);
 
     const char* part = str;
     do
@@ -56,7 +56,7 @@ bool is_valid_var_path(const char* str)
         if (*part == '/')
             ++part;
         else
-            assert(*part == '\0');
+            rassert(*part == '\0');
     } while (*part != '\0');
 
     return true;


### PR DESCRIPTION
This branch changes most asserts in libkunquat to release asserts that are compiled even if enable_debug is set to False in options.py. Some asserts in performance-critical areas are converted to debug asserts that are left out when building without debugging.