### PR TITLE
Note force shift

### DIFF
--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -103,6 +103,7 @@ class Controller():
 
     def create_sandbox(self):
         transaction = {
+            'p_force_shift.json'                  : -30,
             'album/p_manifest.json'               : {},
             'album/p_tracks.json'                 : [0],
             'song_00/p_manifest.json'             : {},

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -94,6 +94,13 @@ class Module():
     def set_mixing_volume(self, volume):
         self._store['p_mixing_volume.json'] = volume
 
+    def get_force_shift(self):
+        key = 'p_force_shift.json'
+        return self._store.get(key, get_default_value(key))
+
+    def set_force_shift(self, value):
+        self._store['p_force_shift.json'] = value
+
     def get_random_seed(self):
         key = 'p_random_seed.json'
         return self._store.get(key, get_default_value(key))

--- a/kunquat/tracker/ui/views/generalmodeditor.py
+++ b/kunquat/tracker/ui/views/generalmodeditor.py
@@ -14,6 +14,8 @@
 from PySide.QtCore import *
 from PySide.QtGui import *
 
+from .numberslider import NumberSlider
+
 
 class GeneralModEditor(QWidget):
 
@@ -24,6 +26,7 @@ class GeneralModEditor(QWidget):
         self._authors = Authors()
 
         self._mixing_volume = MixingVolume()
+        self._force_shift = ForceShift()
         self._dc_blocker = DCBlocker()
         self._random_seed = RandomSeed()
 
@@ -50,10 +53,12 @@ class GeneralModEditor(QWidget):
         gl.addWidget(QLabel('Mixing volume:'), 0, 0)
         gl.addWidget(self._mixing_volume, 0, 1)
         gl.addWidget(QWidget(), 0, 2)
-        gl.addWidget(QLabel('Block dc:'), 1, 0)
-        gl.addWidget(self._dc_blocker, 1, 1)
-        gl.addWidget(QLabel('Initial random seed:'), 2, 0)
-        gl.addWidget(self._random_seed, 2, 1)
+        gl.addWidget(QLabel('Force shift:'), 1, 0)
+        gl.addWidget(self._force_shift, 1, 1)
+        gl.addWidget(QLabel('Block dc:'), 2, 0)
+        gl.addWidget(self._dc_blocker, 2, 1)
+        gl.addWidget(QLabel('Initial random seed:'), 3, 0)
+        gl.addWidget(self._random_seed, 3, 1)
 
         v = QVBoxLayout()
         v.setContentsMargins(0, 0, 0, 0)
@@ -68,12 +73,14 @@ class GeneralModEditor(QWidget):
         self._title.set_ui_model(ui_model)
         self._authors.set_ui_model(ui_model)
         self._mixing_volume.set_ui_model(ui_model)
+        self._force_shift.set_ui_model(ui_model)
         self._dc_blocker.set_ui_model(ui_model)
         self._random_seed.set_ui_model(ui_model)
 
     def unregister_updaters(self):
         self._random_seed.unregister_updaters()
         self._dc_blocker.unregister_updaters()
+        self._force_shift.unregister_updaters()
         self._mixing_volume.unregister_updaters()
         self._authors.unregister_updaters()
         self._title.unregister_updaters()
@@ -304,6 +311,39 @@ class MixingVolume(QDoubleSpinBox):
         module = self._ui_model.get_module()
         module.set_mixing_volume(value)
         self._updater.signal_update(set(['signal_mixing_volume']))
+
+
+class ForceShift(NumberSlider):
+
+    def __init__(self):
+        super().__init__(0, -60, 0)
+        self._ui_model = None
+        self._updater = None
+
+    def set_ui_model(self, ui_model):
+        self._ui_model = ui_model
+        self._updater = ui_model.get_updater()
+        self._updater.register_updater(self._perform_updates)
+
+        QObject.connect(self, SIGNAL('numberChanged(float)'), self._change_shift)
+
+        self._update_shift()
+
+    def unregister_updaters(self):
+        self._updater.unregister_updater(self._perform_updates)
+
+    def _perform_updates(self, signals):
+        if 'signal_force_shift' in signals:
+            self._update_shift()
+
+    def _update_shift(self):
+        module = self._ui_model.get_module()
+        self.set_number(module.get_force_shift())
+
+    def _change_shift(self, value):
+        module = self._ui_model.get_module()
+        module.set_force_shift(value)
+        self._updater.signal_update(set(['signal_force_shift']))
 
 
 class DCBlocker(QCheckBox):

--- a/kunquat/tracker/ui/views/generalmodeditor.py
+++ b/kunquat/tracker/ui/views/generalmodeditor.py
@@ -53,7 +53,7 @@ class GeneralModEditor(QWidget):
         gl.addWidget(QLabel('Mixing volume:'), 0, 0)
         gl.addWidget(self._mixing_volume, 0, 1)
         gl.addWidget(QWidget(), 0, 2)
-        gl.addWidget(QLabel('Force shift:'), 1, 0)
+        gl.addWidget(QLabel('Note force shift:'), 1, 0)
         gl.addWidget(self._force_shift, 1, 1)
         gl.addWidget(QLabel('Block dc:'), 2, 0)
         gl.addWidget(self._dc_blocker, 2, 1)

--- a/kunquat/tracker/ui/views/sheet/columngrouprenderer.py
+++ b/kunquat/tracker/ui/views/sheet/columngrouprenderer.py
@@ -577,8 +577,12 @@ class TRCache():
         return self._images.get_memory_usage()
 
     def _create_image(self, triggers):
+        module = self._ui_model.get_module()
+        force_shift = module.get_force_shift()
+
         notation = self._notation_manager.get_selected_notation()
-        rends = [TriggerRenderer(self._config, t, notation) for t in triggers]
+        rends = [TriggerRenderer(self._config, t, notation, force_shift)
+                for t in triggers]
         widths = [r.get_total_width() for r in rends]
 
         if self._inactive:

--- a/kunquat/tracker/ui/views/sheet/config.py
+++ b/kunquat/tracker/ui/views/sheet/config.py
@@ -43,11 +43,13 @@ DEFAULT_CONFIG = {
         'font'            : QFont(QFont().defaultFamily(), 12),
         'disabled_colour' : QColor(0x88, 0x88, 0x88, 0x7f),
         'trigger': {
-            'default_colour' : QColor(0xcc, 0xdd, 0xee),
-            'note_on_colour' : QColor(0xff, 0xdd, 0xbb),
-            'hit_colour'     : QColor(0xbb, 0xee, 0x88),
-            'note_off_colour': QColor(0xcc, 0x99, 0x66),
-            'padding'        : 3,
+            'default_colour'   : QColor(0xcc, 0xdd, 0xee),
+            'note_on_colour'   : QColor(0xff, 0xdd, 0xbb),
+            'hit_colour'       : QColor(0xbb, 0xee, 0x88),
+            'note_off_colour'  : QColor(0xcc, 0x99, 0x66),
+            'warning_bg_colour': QColor(0xee, 0x33, 0x11),
+            'warning_fg_colour': QColor(0xff, 0xff, 0xcc),
+            'padding'          : 3,
             },
         'edit_cursor': {
             'view_line_colour': QColor(0xdd, 0xee, 0xff),

--- a/src/lib/init/Module.h
+++ b/src/lib/init/Module.h
@@ -55,6 +55,7 @@ struct Module
     bool is_dc_blocker_enabled;         ///< Block dc in the final mix.
     double mix_vol_dB;                  ///< Mixing volume in dB.
     double mix_vol;                     ///< Mixing volume.
+    double force_shift;                 ///< Force shift.
     Environment* env;                   ///< Environment variables.
     Bind* bind;
 };
@@ -102,6 +103,17 @@ bool Module_read_dc_blocker_enabled(Module* module, Streader* sr);
  * \return   \c true if successful, otherwise \c false.
  */
 bool Module_read_mixing_volume(Module* module, Streader* sr);
+
+
+/**
+ * Read the force shift of the Module.
+ *
+ * \param module   The Module -- must not be \c NULL.
+ * \param sr       The Streader of the JSON input -- must not be \c NULL.
+ *
+ * \return   \c true if successful, otherwise \c false.
+ */
+bool Module_read_force_shift(Module* module, Streader* sr);
 
 
 /**

--- a/src/lib/init/Parse_manager.c
+++ b/src/lib/init/Parse_manager.c
@@ -305,6 +305,20 @@ static bool read_mixing_volume(Reader_params* params)
 }
 
 
+static bool read_force_shift(Reader_params* params)
+{
+    rassert(params != NULL);
+
+    if (!Module_read_force_shift(Handle_get_module(params->handle), params->sr))
+    {
+        set_error(params);
+        return false;
+    }
+
+    return true;
+}
+
+
 #define acquire_port_index(index, params, depth)            \
     if (true)                                               \
     {                                                       \

--- a/src/lib/init/module_key_patterns.h
+++ b/src/lib/init/module_key_patterns.h
@@ -33,6 +33,7 @@
 
 MODULE_KEYP(dc_blocker_enabled,     "p_dc_blocker_enabled.json",            "true")
 MODULE_KEYP(mixing_volume, "p_mixing_volume.json", MAKE_STRING(COMP_DEFAULT_MIX_VOL))
+MODULE_KEYP(force_shift,            "p_force_shift.json",                   "0")
 MODULE_KEYP(out_port_manifest,      "out_XX/p_manifest.json",               "")
 MODULE_KEYP(connections,            "p_connections.json",                   "[]")
 MODULE_KEYP(control_map,            "p_control_map.json",                   "[]")

--- a/src/lib/player/Param_validator.c
+++ b/src/lib/player/Param_validator.c
@@ -156,7 +156,7 @@ bool v_force(const char* param)
     double force = NAN;
     Streader* sr = init_c_streader(param);
 
-    return Streader_read_float(sr, &force) && (force <= 18);
+    return Streader_read_float(sr, &force);
 }
 
 

--- a/src/lib/player/events/Event_channel_force.c
+++ b/src/lib/player/events/Event_channel_force.c
@@ -15,10 +15,12 @@
 #include <player/events/Event_channel_decl.h>
 
 #include <debug/assert.h>
+#include <init/Module.h>
 #include <player/devices/Voice_state.h>
 #include <player/devices/processors/Force_state.h>
 #include <player/events/Event_common.h>
 #include <player/Force_controls.h>
+#include <player/Master_params.h>
 #include <player/Voice.h>
 #include <Value.h>
 
@@ -48,7 +50,9 @@ bool Event_channel_set_force_process(
     rassert(value != NULL);
     rassert(value->type == VALUE_TYPE_FLOAT);
 
-    const double force = value->value.float_type;
+    const double force_shift = master_params->parent.module->force_shift;
+
+    const double force = value->value.float_type + force_shift;
 
     ch->force_controls.force = force;
     Slider_break(&ch->force_controls.slider);
@@ -82,7 +86,9 @@ bool Event_channel_slide_force_process(
     rassert(value != NULL);
     rassert(value->type == VALUE_TYPE_FLOAT);
 
-    const double slide_target = value->value.float_type;
+    const double force_shift = master_params->parent.module->force_shift;
+
+    const double slide_target = value->value.float_type + force_shift;
     const double start_force =
         isfinite(ch->force_controls.force) ? ch->force_controls.force : slide_target;
 


### PR DESCRIPTION
This branch adds a global force shift that is applied to all force setting and sliding events. The default shift adjusts the force levels so that +30 dB in the notation is translated to 0 dB in the audio unit level. This mostly eliminates the need to use negative force values in the notation side. Additionally, force events with high decibel values (> 0 dB in the shifted range) are displayed with a warning colour.