### PR TITLE
Audio quality groundwork in additive synthesis processor

### DIFF
--- a/scripts/test_libkunquat.py
+++ b/scripts/test_libkunquat.py
@@ -57,6 +57,7 @@ def test_libkunquat(builder, options, cc):
             'handle': ['streader', 'tstamp'],
             'player': ['handle', 'streader', 'fast_sin', 'fast_exp2', 'fast_log2'],
             'memory': ['handle'],
+            'fft': ['memory'],
             'connections': ['handle', 'player'],
             'generator': ['connections'],
             'instrument': ['connections'],

--- a/src/lib/mathnum/common.h
+++ b/src/lib/mathnum/common.h
@@ -24,7 +24,11 @@
 
 
 #undef PI
-#define PI (3.14159265358979323846)
+#define PI 3.14159265358979323846
+
+
+#undef PI2
+#define PI2 6.28318530717958647692
 
 
 #undef min

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -157,7 +157,7 @@ static void drfti1(int32_t n, float* wa, int* ifac)
     ifac[0] = n;
     ifac[1] = nf;
 
-    // Fill complex roots of unity
+    // Fill in complex roots of unity
     const int nfm1 = nf - 1;
 
     if (nfm1 == 0)
@@ -199,14 +199,12 @@ static void drfti1(int32_t n, float* wa, int* ifac)
 
 static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
 {
-    int i = 0, k = 0;
-    float ti2 = 0, tr2 = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t1 = 0;
     t0 = (t2 = l1 * ido);
     t3 = ido << 1;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         ch[t1 << 1] = cc[t1] + cc[t2];
         ch[(t1 << 1) + t3 - 1] = cc[t1] - cc[t2];
@@ -221,20 +219,20 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
     {
         t1 = 0;
         t2 = t0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t3 = t2;
             t4 = (t1 << 1) + (ido << 1);
             t5 = t1;
             t6 = t1 + t1;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 t3 += 2;
                 t4 -= 2;
                 t5 += 2;
                 t6 += 2;
-                tr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
-                ti2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+                const float tr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+                const float ti2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
                 ch[t6] = cc[t5] + ti2;
                 ch[t4] = ti2 - cc[t5];
                 ch[t6 - 1] = cc[t5 - 1] + tr2;
@@ -250,7 +248,7 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     t3 = (t2 = (t1 = ido) - 1);
     t2 += t0;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         ch[t1] = -cc[t2];
         ch[t1 - 1] = cc[t3];
@@ -267,10 +265,7 @@ static void dradf4(
         int ido, int l1, float* cc, float* ch,
         const float* wa1, const float* wa2, const float* wa3)
 {
-    const float hsqt2 = 0.70710678118654752440084436210485f;
-    int i = 0, k = 0, t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
-    float ci2 = 0, ci3 = 0, ci4 = 0, cr2 = 0, cr3 = 0, cr4 = 0;
-    float ti1 = 0, ti2 = 0, ti3 = 0, ti4 = 0, tr1 = 0, tr2 = 0, tr3 = 0, tr4 = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t0 = l1 * ido;
 
@@ -279,10 +274,10 @@ static void dradf4(
     t2 = t1 + (t1 << 1);
     t3 = 0;
 
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
-        tr1 = cc[t1] + cc[t2];
-        tr2 = cc[t3] + cc[t4];
+        const float tr1 = cc[t1] + cc[t2];
+        const float tr2 = cc[t3] + cc[t4];
         ch[t5 = t3 << 2] = tr1 + tr2;
         ch[(ido << 2) + t5 - 1] = tr2 - tr1;
         ch[(t5 += (ido << 1)) - 1] = cc[t3] - cc[t4];
@@ -300,35 +295,35 @@ static void dradf4(
     if (ido != 2)
     {
         t1 = 0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t2 = t1;
             t4 = t1 << 2;
             t5 = (t6 = ido << 1) + t4;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 t3 = (t2 += 2);
                 t4 += 2;
                 t5 -= 2;
 
                 t3 += t0;
-                cr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
-                ci2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+                const float cr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+                const float ci2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
                 t3 += t0;
-                cr3 = wa2[i - 2] * cc[t3 - 1] + wa2[i - 1] * cc[t3];
-                ci3 = wa2[i - 2] * cc[t3] - wa2[i - 1] * cc[t3 - 1];
+                const float cr3 = wa2[i - 2] * cc[t3 - 1] + wa2[i - 1] * cc[t3];
+                const float ci3 = wa2[i - 2] * cc[t3] - wa2[i - 1] * cc[t3 - 1];
                 t3 += t0;
-                cr4 = wa3[i - 2] * cc[t3 - 1] + wa3[i - 1] * cc[t3];
-                ci4 = wa3[i - 2] * cc[t3] - wa3[i - 1] * cc[t3 - 1];
+                const float cr4 = wa3[i - 2] * cc[t3 - 1] + wa3[i - 1] * cc[t3];
+                const float ci4 = wa3[i - 2] * cc[t3] - wa3[i - 1] * cc[t3 - 1];
 
-                tr1 = cr2 + cr4;
-                tr4 = cr4 - cr2;
-                ti1 = ci2 + ci4;
-                ti4 = ci2 - ci4;
-                ti2 = cc[t2] + ci3;
-                ti3 = cc[t2] - ci3;
-                tr2 = cc[t2 - 1] + cr3;
-                tr3 = cc[t2 - 1] - cr3;
+                const float tr1 = cr2 + cr4;
+                const float tr4 = cr4 - cr2;
+                const float ti1 = ci2 + ci4;
+                const float ti4 = ci2 - ci4;
+                const float ti2 = cc[t2] + ci3;
+                const float ti3 = cc[t2] - ci3;
+                const float tr2 = cc[t2 - 1] + cr3;
+                const float tr3 = cc[t2 - 1] - cr3;
 
                 ch[t4 - 1] = tr1 + tr2;
                 ch[t4] = ti1 + ti2;
@@ -354,10 +349,12 @@ static void dradf4(
     t5 = ido << 1;
     t6 = ido;
 
-    for (k = 0; k < l1; k++)
+    const float hsqt2 = 0.70710678118654752440084436210485f;
+
+    for (int k = 0; k < l1; k++)
     {
-        ti1 = -hsqt2 * (cc[t1] + cc[t2]);
-        tr1 = hsqt2 * (cc[t1] - cc[t2]);
+        const float ti1 = -hsqt2 * (cc[t1] + cc[t2]);
+        const float tr1 = hsqt2 * (cc[t1] - cc[t2]);
         ch[t4 - 1] = tr1 + cc[t6 - 1];
         ch[t4 + t5 - 1] = cc[t6 - 1] - tr1;
         ch[t4] = ti1 - cc[t1 + t0];
@@ -376,56 +373,51 @@ static void dradfg(
         int ido, int ip, int l1, int idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, float* wa)
 {
-    int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ic = 0, ik = 0, is = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
     int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
-    float dc2 = 0, ai1 = 0, ai2 = 0, ar1 = 0, ar2 = 0, ds2 = 0;
-    int nbd = 0;
-    float dcp = 0, arg = 0, dsp = 0, ar1h = 0, ar2h = 0;
-    int idp2 = 0, ipp2 = 0;
 
-    arg = (float)(PI2 / ip);
-    dcp = cosf(arg);
-    dsp = sinf(arg);
-    ipph = (ip + 1) >> 1;
-    ipp2 = ip;
-    idp2 = ido;
-    nbd = (ido - 1) >> 1;
+    const float arg = (float)(PI2 / ip);
+    const float dcp = cosf(arg);
+    const float dsp = sinf(arg);
+    const int ipph = (ip + 1) >> 1;
+    const int ipp2 = ip;
+    const int idp2 = ido;
+    const int nbd = (ido - 1) >> 1;
     t0 = l1 * ido;
     t10 = ip * ido;
 
     if (ido != 1)
     {
-        for (ik = 0; ik < idl1; ik++)
+        for (int ik = 0; ik < idl1; ik++)
             ch2[ik] = c2[ik];
 
         t1 = 0;
-        for (j = 1; j < ip; j++)
+        for (int j = 1; j < ip; j++)
         {
             t1 += t0;
             t2 = t1;
-            for (k = 0; k < l1; k++)
+            for (int k = 0; k < l1; k++)
             {
                 ch[t2] = c1[t2];
                 t2 += ido;
             }
         }
 
-        is = -ido;
+        int is = -ido;
         t1 = 0;
         if (nbd > l1)
         {
-            for (j = 1; j < ip; j++)
+            for (int j = 1; j < ip; j++)
             {
                 t1 += t0;
                 is += ido;
                 t2 = -ido + t1;
-                for (k = 0; k < l1; k++)
+                for (int k = 0; k < l1; k++)
                 {
-                    idij = is - 1;
+                    int idij = is - 1;
                     t2 += ido;
                     t3 = t2;
-                    for (i = 2; i < ido; i += 2)
+                    for (int i = 2; i < ido; i += 2)
                     {
                         idij += 2;
                         t3 += 2;
@@ -437,18 +429,18 @@ static void dradfg(
         }
         else
         {
-            for (j = 1; j < ip; j++)
+            for (int j = 1; j < ip; j++)
             {
                 is += ido;
-                idij = is - 1;
+                int idij = is - 1;
                 t1 += t0;
                 t2 = t1;
-                for (i = 2; i < ido; i += 2)
+                for (int i = 2; i < ido; i += 2)
                 {
                     idij += 2;
                     t2 += 2;
                     t3 = t2;
-                    for (k = 0; k < l1; k++)
+                    for (int k = 0; k < l1; k++)
                     {
                         ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
                         ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
@@ -462,19 +454,19 @@ static void dradfg(
         t2 = ipp2 * t0;
         if (nbd < l1)
         {
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (i = 2; i < ido; i += 2)
+                for (int i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
                     t5 = t3 - ido;
                     t6 = t4 - ido;
-                    for (k = 0; k < l1; k++)
+                    for (int k = 0; k < l1; k++)
                     {
                         t5 += ido;
                         t6 += ido;
@@ -488,17 +480,17 @@ static void dradfg(
         }
         else
         {
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (k = 0; k < l1; k++)
+                for (int k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
-                    for (i = 2; i < ido; i += 2)
+                    for (int i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -514,18 +506,18 @@ static void dradfg(
         }
     }
 
-    for (ik = 0; ik < idl1; ik++)
+    for (int ik = 0; ik < idl1; ik++)
         c2[ik] = ch2[ik];
 
     t1 = 0;
     t2 = ipp2 * idl1;
-    for(j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1 - ido;
         t4 = t2 - ido;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t3 += ido;
             t4 += ido;
@@ -534,16 +526,16 @@ static void dradfg(
         }
     }
 
-    ar1 = 1.0f;
-    ai1 = 0.0f;
+    float ar1 = 1.0f;
+    float ai1 = 0.0f;
     t1 = 0;
     t2 = ipp2 * idl1;
     t3 = (ip - 1) * idl1;
-    for (l = 1; l < ipph; l++)
+    for (int l = 1; l < ipph; l++)
     {
         t1 += idl1;
         t2 -= idl1;
-        ar1h = dcp * ar1 - dsp * ai1;
+        const float ar1h = dcp * ar1 - dsp * ai1;
         ai1 = dcp * ai1 + dsp * ar1;
         ar1 = ar1h;
         t4 = t1;
@@ -551,25 +543,25 @@ static void dradfg(
         t6 = t3;
         t7 = idl1;
 
-        for (ik = 0; ik < idl1; ik++)
+        for (int ik = 0; ik < idl1; ik++)
         {
             ch2[t4++] = c2[ik] + ar1 * c2[t7++];
             ch2[t5++] = ai1 * c2[t6++];
         }
 
-        dc2 = ar1;
-        ds2 = ai1;
-        ar2 = ar1;
-        ai2 = ai1;
+        const float dc2 = ar1;
+        const float ds2 = ai1;
+        float ar2 = ar1;
+        float ai2 = ai1;
 
         t4 = idl1;
         t5 = (ipp2 - 1) * idl1;
-        for (j = 2; j < ipph; j++)
+        for (int j = 2; j < ipph; j++)
         {
             t4 += idl1;
             t5 -= idl1;
 
-            ar2h = dc2 * ar2 - ds2 * ai2;
+            const float ar2h = dc2 * ar2 - ds2 * ai2;
             ai2 = dc2 * ai2 + ds2 * ar2;
             ar2 = ar2h;
 
@@ -577,7 +569,7 @@ static void dradfg(
             t7 = t2;
             t8 = t4;
             t9 = t5;
-            for (ik = 0; ik < idl1; ik++)
+            for (int ik = 0; ik < idl1; ik++)
             {
                 ch2[t6++] += ar2 * c2[t8++];
                 ch2[t7++] += ai2 * c2[t9++];
@@ -586,21 +578,21 @@ static void dradfg(
     }
 
     t1 = 0;
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += idl1;
         t2 = t1;
-        for (ik = 0; ik < idl1; ik++)
+        for (int ik = 0; ik < idl1; ik++)
             ch2[ik] += c2[t2++];
     }
 
     if (ido >= l1)
     {
-        for (i = 0; i < ido; i++)
+        for (int i = 0; i < ido; i++)
         {
             t1 = i;
             t2 = i;
-            for (k = 0; k < l1; k++)
+            for (int k = 0; k < l1; k++)
             {
                 cc[t2] = ch[t1];
                 t1 += ido;
@@ -612,11 +604,11 @@ static void dradfg(
     {
         t1 = 0;
         t2 = 0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t3 = t1;
             t4 = t2;
-            for (i = 0; i < ido; i++)
+            for (int i = 0; i < ido; i++)
                 cc[t4++] = ch[t3++];
             t1 += ido;
             t2 += t10;
@@ -627,7 +619,7 @@ static void dradfg(
     t2 = ido << 1;
     t3 = 0;
     t4 = ipp2 * t0;
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += t2;
         t3 += t0;
@@ -637,7 +629,7 @@ static void dradfg(
         t6 = t3;
         t7 = t4;
 
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             cc[t5 - 1] = ch[t6];
             cc[t5] = ch[t7];
@@ -655,8 +647,8 @@ static void dradfg(
         t1 = -ido;
         t3 = 0;
         t4 = 0;
-        t5 = ipp2*t0;
-        for (j = 1; j < ipph; j++)
+        t5 = ipp2 * t0;
+        for (int j = 1; j < ipph; j++)
         {
             t1 += t2;
             t3 += t2;
@@ -666,11 +658,11 @@ static void dradfg(
             t7 = t3;
             t8 = t4;
             t9 = t5;
-            for (k = 0; k < l1; k++)
+            for (int k = 0; k < l1; k++)
             {
-                for (i = 2; i < ido; i += 2)
+                for (int i = 2; i < ido; i += 2)
                 {
-                    ic = idp2 - i;
+                    const int ic = idp2 - i;
                     cc[i + t7 - 1] = ch[i + t8 - 1] + ch[i + t9 - 1];
                     cc[ic + t6 - 1] = ch[i + t8 - 1] - ch[i + t9 - 1];
                     cc[i + t7] = ch[i + t8] + ch[i + t9];
@@ -689,19 +681,19 @@ static void dradfg(
     t3 = 0;
     t4 = 0;
     t5 = ipp2 * t0;
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += t2;
         t3 += t2;
         t4 += t0;
         t5 -= t0;
-        for (i = 2; i < ido; i += 2)
+        for (int i = 2; i < ido; i += 2)
         {
             t6 = idp2 + t1 - i;
             t7 = i + t3;
             t8 = i + t4;
             t9 = i + t5;
-            for (k = 0; k < l1; k++)
+            for (int k = 0; k < l1; k++)
             {
                 cc[t7 - 1] = ch[t8 - 1] + ch[t9 - 1];
                 cc[t6 - 1] = ch[t8 - 1] - ch[t9 - 1];

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -1413,50 +1413,44 @@ static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* i
         l2 = ip * l1;
         ido = n / l2;
         idl1 = ido * l1;
-        if (ip != 4)
-            goto L103;
-        ix2 = iw + ido;
-        ix3 = ix2 + ido;
+        if (ip == 4)
+        {
+            ix2 = iw + ido;
+            ix3 = ix2 + ido;
 
-        if (na != 0)
-            dradb4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
-        else
-            dradb4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
-        na = 1 - na;
-        goto L115;
-
-      L103:
-        if (ip != 2)
-            goto L106;
-
-        if (na != 0)
-            dradb2(ido, l1, ch, c, wa + iw - 1);
-        else
-            dradb2(ido, l1, c, ch, wa + iw - 1);
-        na = 1 - na;
-        goto L115;
-
-      L106:
-        if (ip != 3)
-            goto L109;
-
-        ix2 = iw + ido;
-        if (na != 0)
-            dradb3(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1);
-        else
-            dradb3(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1);
-        na = 1 - na;
-        goto L115;
-
-      L109:
-        if (na != 0)
-            dradbg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
-        else
-            dradbg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
-        if (ido == 1)
+            if (na != 0)
+                dradb4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+            else
+                dradb4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
             na = 1 - na;
+        }
+        else if (ip == 2)
+        {
+            if (na != 0)
+                dradb2(ido, l1, ch, c, wa + iw - 1);
+            else
+                dradb2(ido, l1, c, ch, wa + iw - 1);
+            na = 1 - na;
+        }
+        else if (ip == 3)
+        {
+            ix2 = iw + ido;
+            if (na != 0)
+                dradb3(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1);
+            else
+                dradb3(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1);
+            na = 1 - na;
+        }
+        else
+        {
+            if (na != 0)
+                dradbg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
+            else
+                dradbg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
+            if (ido == 1)
+                na = 1 - na;
+        }
 
-      L115:
         l1 = l2;
         iw += (ip - 1) * ido;
     }

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -121,10 +121,6 @@ void FFT_worker_deinit(FFT_worker* worker)
 static void drfti1(int32_t n, float* wa, int* ifac)
 {
     const int ntryh[4] = { 4, 2, 3, 5 };
-    float arg = 0, argh = 0, argld = 0, fi = 0;
-    int l1 = 0, l2 = 0;
-    int ld = 0, ip = 0, nq = 0, nr = 0;
-    int ido = 0, ipm = 0, nfm1 = 0;
     int nf = 0;
 
     // Divide n into preferred set of factors
@@ -135,8 +131,8 @@ static void drfti1(int32_t n, float* wa, int* ifac)
         // Try dividing by numbers in ntryh followed by 7, 9, 11,...
         const int ntry = (test_index < 4) ? ntryh[test_index] : test_index * 2 - 1;
 
-        nq = left / ntry;
-        nr = left - ntry * nq;
+        const int nq = left / ntry;
+        const int nr = left - ntry * nq;
         if (nr != 0)
         {
             ++test_index;
@@ -161,32 +157,34 @@ static void drfti1(int32_t n, float* wa, int* ifac)
     ifac[0] = n;
     ifac[1] = nf;
 
-    argh = (float)(PI2 / n);
-    int is = 0;
-    nfm1 = nf - 1;
-    l1 = 1;
+    // Fill complex roots of unity
+    const int nfm1 = nf - 1;
 
     if (nfm1 == 0)
         return;
 
+    const float argh = (float)(PI2 / n);
+    int is = 0;
+    int l1 = 1;
+
     for (int k1 = 0; k1 < nfm1; k1++)
     {
-        ip = ifac[k1 + 2];
-        ld = 0;
-        l2 = l1 * ip;
-        ido = n / l2;
-        ipm = ip - 1;
+        const int ip = ifac[k1 + 2];
+        int ld = 0;
+        const int l2 = l1 * ip;
+        const int ido = n / l2;
+        const int ipm = ip - 1;
 
         for (int j = 0; j < ipm; j++)
         {
             ld += l1;
             int i = is;
-            argld = (float)ld * argh;
-            fi = 0.0f;
+            const float argld = (float)ld * argh;
+            float fi = 0.0f;
             for (int ii = 2; ii < ido; ii += 2)
             {
                 fi += 1.0f;
-                arg = fi * argld;
+                const float arg = fi * argld;
                 wa[i++] = cosf(arg);
                 wa[i++] = sinf(arg);
             }

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -1015,32 +1015,27 @@ static void dradbg(
         int ido, int ip, int l1, int idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, const float* wa)
 {
-    int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ik = 0, is = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
     int t7 = 0, t8 = 0, t9 = 0, t10 = 0, t11 = 0, t12 = 0;
-    float dc2 = 0, ai1 = 0, ai2 = 0, ar1 = 0, ar2 = 0, ds2 = 0;
-    int nbd = 0;
-    float dcp = 0, arg = 0, dsp = 0, ar1h = 0, ar2h = 0;
-    int ipp2 = 0;
 
     t10 = ip * ido;
     t0 = l1 * ido;
-    arg = (float)(PI2 / ip);
-    dcp = cosf(arg);
-    dsp = sinf(arg);
-    nbd = (ido - 1) >> 1;
-    ipp2 = ip;
-    ipph = (ip + 1) >> 1;
+    const float arg = (float)(PI2 / ip);
+    const float dcp = cosf(arg);
+    const float dsp = sinf(arg);
+    const int nbd = (ido - 1) >> 1;
+    const int ipp2 = ip;
+    const int ipph = (ip + 1) >> 1;
 
     if (ido >= l1)
     {
         t1 = 0;
         t2 = 0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t3 = t1;
             t4 = t2;
-            for (i = 0; i < ido; i++)
+            for (int i = 0; i < ido; i++)
             {
                 ch[t3] = cc[t4];
                 t3++;
@@ -1053,11 +1048,11 @@ static void dradbg(
     else
     {
         t1 = 0;
-        for (i = 0; i < ido; i++)
+        for (int i = 0; i < ido; i++)
         {
             t2 = t1;
             t3 = t1;
-            for (k = 0; k < l1; k++)
+            for (int k = 0; k < l1; k++)
             {
                 ch[t2] = cc[t3];
                 t2 += ido;
@@ -1070,14 +1065,14 @@ static void dradbg(
     t1 = 0;
     t2 = ipp2 * t0;
     t7 = (t5 = ido << 1);
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
         t6 = t5;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             ch[t3] = cc[t6 - 1] + cc[t6 - 1];
             ch[t4] = cc[t6] + cc[t6];
@@ -1095,7 +1090,7 @@ static void dradbg(
             t1 = 0;
             t2 = ipp2 * t0;
             t7 = 0;
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
@@ -1104,13 +1099,13 @@ static void dradbg(
 
                 t7 += (ido << 1);
                 t8 = t7;
-                for (k = 0; k < l1; k++)
+                for (int k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
                     t9 = t8;
                     t11 = t8;
-                    for (i = 2; i < ido; i += 2)
+                    for (int i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -1132,7 +1127,7 @@ static void dradbg(
             t1 = 0;
             t2 = ipp2 * t0;
             t7 = 0;
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
@@ -1141,7 +1136,7 @@ static void dradbg(
                 t7 += (ido << 1);
                 t8 = t7;
                 t9 = t7;
-                for (i = 2; i < ido; i += 2)
+                for (int i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
@@ -1151,7 +1146,7 @@ static void dradbg(
                     t6 = t4;
                     t11 = t8;
                     t12 = t9;
-                    for (k = 0; k < l1; k++)
+                    for (int k = 0; k < l1; k++)
                     {
                         ch[t5 - 1] = cc[t11 - 1] + cc[t12 - 1];
                         ch[t6 - 1] = cc[t11 - 1] - cc[t12 - 1];
@@ -1167,17 +1162,17 @@ static void dradbg(
         }
     }
 
-    ar1 = 1.0f;
-    ai1 = 0.0f;
+    float ar1 = 1.0f;
+    float ai1 = 0.0f;
     t1 = 0;
     t9 = (t2 = ipp2 * idl1);
     t3 = (ip - 1) * idl1;
-    for (l = 1; l < ipph; l++)
+    for (int l = 1; l < ipph; l++)
     {
         t1 += idl1;
         t2 -= idl1;
 
-        ar1h = dcp * ar1 - dsp * ai1;
+        const float ar1h = dcp * ar1 - dsp * ai1;
         ai1 = dcp * ai1 + dsp * ar1;
         ar1 = ar1h;
         t4 = t1;
@@ -1185,30 +1180,30 @@ static void dradbg(
         t6 = 0;
         t7 = idl1;
         t8 = t3;
-        for (ik = 0; ik < idl1; ik++)
+        for (int ik = 0; ik < idl1; ik++)
         {
             c2[t4++] = ch2[t6++] + ar1 * ch2[t7++];
             c2[t5++] = ai1 * ch2[t8++];
         }
-        dc2 = ar1;
-        ds2 = ai1;
-        ar2 = ar1;
-        ai2 = ai1;
+        const float dc2 = ar1;
+        const float ds2 = ai1;
+        float ar2 = ar1;
+        float ai2 = ai1;
 
         t6 = idl1;
         t7 = t9 - idl1;
-        for (j = 2; j < ipph; j++)
+        for (int j = 2; j < ipph; j++)
         {
             t6 += idl1;
             t7 -= idl1;
-            ar2h = dc2 * ar2 - ds2 * ai2;
+            const float ar2h = dc2 * ar2 - ds2 * ai2;
             ai2 = dc2 * ai2 + ds2 * ar2;
             ar2 = ar2h;
             t4 = t1;
             t5 = t2;
             t11 = t6;
             t12 = t7;
-            for (ik = 0; ik < idl1; ik++)
+            for (int ik = 0; ik < idl1; ik++)
             {
                 c2[t4++] += ar2 * ch2[t11++];
                 c2[t5++] += ai2 * ch2[t12++];
@@ -1217,23 +1212,23 @@ static void dradbg(
     }
 
     t1 = 0;
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += idl1;
         t2 = t1;
-        for (ik = 0; ik < idl1; ik++)
+        for (int ik = 0; ik < idl1; ik++)
             ch2[ik] += ch2[t2++];
     }
 
     t1 = 0;
     t2 = ipp2 * t0;
-    for (j = 1; j < ipph; j++)
+    for (int j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             ch[t3] = c1[t3] - c1[t4];
             ch[t4] = c1[t3] + c1[t4];
@@ -1248,17 +1243,17 @@ static void dradbg(
         {
             t1 = 0;
             t2 = ipp2 * t0;
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (k = 0; k < l1; k++)
+                for (int k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
-                    for (i = 2; i < ido; i += 2)
+                    for (int i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -1276,19 +1271,19 @@ static void dradbg(
         {
             t1 = 0;
             t2 = ipp2 * t0;
-            for (j = 1; j < ipph; j++)
+            for (int j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (i = 2; i < ido; i += 2)
+                for (int i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
                     t5 = t3;
                     t6 = t4;
-                    for (k = 0; k < l1; k++)
+                    for (int k = 0; k < l1; k++)
                     {
                         ch[t5 - 1] = c1[t5 - 1] - c1[t6];
                         ch[t6 - 1] = c1[t5 - 1] + c1[t6];
@@ -1305,36 +1300,37 @@ static void dradbg(
     if (ido == 1)
         return;
 
-    for (ik = 0; ik < idl1; ik++)
+    for (int ik = 0; ik < idl1; ik++)
         c2[ik] = ch2[ik];
 
     t1 = 0;
-    for (j = 1; j < ip; j++)
+    for (int j = 1; j < ip; j++)
     {
         t2 = (t1 += t0);
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             c1[t2] = ch[t2];
             t2 += ido;
         }
     }
 
+    int is = -ido - 1;
+
     if (nbd <= l1)
     {
-        is = -ido - 1;
         t1 = 0;
-        for (j = 1; j < ip; j++)
+        for (int j = 1; j < ip; j++)
         {
             is += ido;
             t1 += t0;
-            idij = is;
+            int idij = is;
             t2 = t1;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 t2 += 2;
                 idij += 2;
                 t3 = t2;
-                for (k = 0; k < l1; k++)
+                for (int k = 0; k < l1; k++)
                 {
                     c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
                     c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
@@ -1345,18 +1341,17 @@ static void dradbg(
         return;
     }
 
-    is = -ido - 1;
     t1 = 0;
-    for (j = 1; j < ip; j++)
+    for (int j = 1; j < ip; j++)
     {
         is += ido;
         t1 += t0;
         t2 = t1;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
-            idij = is;
+            int idij = is;
             t3 = t2;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 idij += 2;
                 t3 += 2;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -1368,25 +1368,21 @@ static void dradbg(
 
 static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* ifac)
 {
-    int i = 0, k1 = 0, l1 = 0, l2 = 0;
+    const int nf = ifac[1];
     int na = 0;
-    int nf = 0, ip = 0, iw = 0, ix2 = 0, ix3 = 0, ido = 0, idl1 = 0;
+    int l1 = 1;
+    int iw = 1;
 
-    nf = ifac[1];
-    na = 0;
-    l1 = 1;
-    iw = 1;
-
-    for (k1 = 0; k1 < nf; k1++)
+    for (int k1 = 0; k1 < nf; k1++)
     {
-        ip = ifac[k1 + 2];
-        l2 = ip * l1;
-        ido = n / l2;
-        idl1 = ido * l1;
+        const int ip = ifac[k1 + 2];
+        const int l2 = ip * l1;
+        const int ido = n / l2;
+        const int idl1 = ido * l1;
         if (ip == 4)
         {
-            ix2 = iw + ido;
-            ix3 = ix2 + ido;
+            const int ix2 = iw + ido;
+            const int ix3 = ix2 + ido;
 
             if (na != 0)
                 dradb4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
@@ -1404,7 +1400,7 @@ static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* i
         }
         else if (ip == 3)
         {
-            ix2 = iw + ido;
+            const int ix2 = iw + ido;
             if (na != 0)
                 dradb3(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1);
             else
@@ -1428,7 +1424,7 @@ static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* i
     if (na == 0)
         return;
 
-    for (i = 0; i < n; i++)
+    for (int i = 0; i < n; i++)
         c[i] = ch[i];
 
     return;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -24,9 +24,9 @@
 #include <stdlib.h>
 
 
-static void drfti1(int32_t n, float* wa, int* ifac);
-static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac);
-static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* ifac);
+static void drfti1(int32_t n, float* wa, int32_t* ifac);
+static void drftf1(int32_t n, float* c, float* ch, float* wa, const int32_t* ifac);
+static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int32_t* ifac);
 
 
 FFT_worker* FFT_worker_init(FFT_worker* worker, int32_t max_tlength)
@@ -48,7 +48,7 @@ FFT_worker* FFT_worker_init(FFT_worker* worker, int32_t max_tlength)
 }
 
 
-static void rfft_init(int32_t n, float* wsave, int* ifac)
+static void rfft_init(int32_t n, float* wsave, int32_t* ifac)
 {
     rassert(n >= 1);
     rassert(wsave != NULL);
@@ -118,21 +118,21 @@ void FFT_worker_deinit(FFT_worker* worker)
 }
 
 
-static void drfti1(int32_t n, float* wa, int* ifac)
+static void drfti1(int32_t n, float* wa, int32_t* ifac)
 {
     const int ntryh[4] = { 4, 2, 3, 5 };
     int nf = 0;
 
     // Divide n into preferred set of factors
-    int test_index = 0;
-    int left = n;
+    int32_t test_index = 0;
+    int32_t left = n;
     while (left > 1)
     {
         // Try dividing by numbers in ntryh followed by 7, 9, 11,...
-        const int ntry = (test_index < 4) ? ntryh[test_index] : test_index * 2 - 1;
+        const int32_t ntry = (test_index < 4) ? ntryh[test_index] : test_index * 2 - 1;
 
-        const int nq = left / ntry;
-        const int nr = left - ntry * nq;
+        const int32_t nq = left / ntry;
+        const int32_t nr = left - ntry * nq;
         if (nr != 0)
         {
             ++test_index;
@@ -163,25 +163,25 @@ static void drfti1(int32_t n, float* wa, int* ifac)
     if (nfm1 == 0)
         return;
 
-    const float argh = (float)(PI2 / n);
-    int is = 0;
-    int l1 = 1;
+    const float argh = (float)(PI2 / (double)n);
+    int32_t is = 0;
+    int32_t l1 = 1;
 
     for (int k1 = 0; k1 < nfm1; k1++)
     {
-        const int ip = ifac[k1 + 2];
-        int ld = 0;
-        const int l2 = l1 * ip;
-        const int ido = n / l2;
-        const int ipm = ip - 1;
+        const int32_t ip = ifac[k1 + 2];
+        int32_t ld = 0;
+        const int32_t l2 = l1 * ip;
+        const int32_t ido = n / l2;
+        const int32_t ipm = ip - 1;
 
-        for (int j = 0; j < ipm; j++)
+        for (int32_t j = 0; j < ipm; j++)
         {
             ld += l1;
-            int i = is;
+            int32_t i = is;
             const float argld = (float)ld * argh;
             float fi = 0.0f;
-            for (int ii = 2; ii < ido; ii += 2)
+            for (int32_t ii = 2; ii < ido; ii += 2)
             {
                 fi += 1.0f;
                 const float arg = fi * argld;
@@ -197,14 +197,14 @@ static void drfti1(int32_t n, float* wa, int* ifac)
 }
 
 
-static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
+static void dradf2(int32_t ido, int32_t l1, float* cc, float* ch, const float* wa1)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t1 = 0;
     t0 = (t2 = l1 * ido);
     t3 = ido << 1;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         ch[t1 << 1] = cc[t1] + cc[t2];
         ch[(t1 << 1) + t3 - 1] = cc[t1] - cc[t2];
@@ -219,13 +219,13 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
     {
         t1 = 0;
         t2 = t0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t3 = t2;
             t4 = (t1 << 1) + (ido << 1);
             t5 = t1;
             t6 = t1 + t1;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 t3 += 2;
                 t4 -= 2;
@@ -248,7 +248,7 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     t3 = (t2 = (t1 = ido) - 1);
     t2 += t0;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         ch[t1] = -cc[t2];
         ch[t1 - 1] = cc[t3];
@@ -262,10 +262,10 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
 
 static void dradf4(
-        int ido, int l1, float* cc, float* ch,
+        int32_t ido, int32_t l1, float* cc, float* ch,
         const float* wa1, const float* wa2, const float* wa3)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t0 = l1 * ido;
 
@@ -274,7 +274,7 @@ static void dradf4(
     t2 = t1 + (t1 << 1);
     t3 = 0;
 
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         const float tr1 = cc[t1] + cc[t2];
         const float tr2 = cc[t3] + cc[t4];
@@ -295,12 +295,12 @@ static void dradf4(
     if (ido != 2)
     {
         t1 = 0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t2 = t1;
             t4 = t1 << 2;
             t5 = (t6 = ido << 1) + t4;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 t3 = (t2 += 2);
                 t4 += 2;
@@ -351,7 +351,7 @@ static void dradf4(
 
     const float hsqt2 = 0.70710678118654752440084436210485f;
 
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         const float ti1 = -hsqt2 * (cc[t1] + cc[t2]);
         const float tr1 = hsqt2 * (cc[t1] - cc[t2]);
@@ -370,54 +370,54 @@ static void dradf4(
 
 
 static void dradfg(
-        int ido, int ip, int l1, int idl1, float* cc, float* c1,
+        int32_t ido, int32_t ip, int32_t l1, int32_t idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, float* wa)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
-    int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
+    int32_t t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
 
-    const float arg = (float)(PI2 / ip);
+    const float arg = (float)(PI2 / (double)ip);
     const float dcp = cosf(arg);
     const float dsp = sinf(arg);
-    const int ipph = (ip + 1) >> 1;
-    const int ipp2 = ip;
-    const int idp2 = ido;
-    const int nbd = (ido - 1) >> 1;
+    const int32_t ipph = (ip + 1) >> 1;
+    const int32_t ipp2 = ip;
+    const int32_t idp2 = ido;
+    const int32_t nbd = (ido - 1) >> 1;
     t0 = l1 * ido;
     t10 = ip * ido;
 
     if (ido != 1)
     {
-        for (int ik = 0; ik < idl1; ik++)
+        for (int32_t ik = 0; ik < idl1; ik++)
             ch2[ik] = c2[ik];
 
         t1 = 0;
-        for (int j = 1; j < ip; j++)
+        for (int32_t j = 1; j < ip; j++)
         {
             t1 += t0;
             t2 = t1;
-            for (int k = 0; k < l1; k++)
+            for (int32_t k = 0; k < l1; k++)
             {
                 ch[t2] = c1[t2];
                 t2 += ido;
             }
         }
 
-        int is = -ido;
+        int32_t is = -ido;
         t1 = 0;
         if (nbd > l1)
         {
-            for (int j = 1; j < ip; j++)
+            for (int32_t j = 1; j < ip; j++)
             {
                 t1 += t0;
                 is += ido;
                 t2 = -ido + t1;
-                for (int k = 0; k < l1; k++)
+                for (int32_t k = 0; k < l1; k++)
                 {
-                    int idij = is - 1;
+                    int32_t idij = is - 1;
                     t2 += ido;
                     t3 = t2;
-                    for (int i = 2; i < ido; i += 2)
+                    for (int32_t i = 2; i < ido; i += 2)
                     {
                         idij += 2;
                         t3 += 2;
@@ -429,18 +429,18 @@ static void dradfg(
         }
         else
         {
-            for (int j = 1; j < ip; j++)
+            for (int32_t j = 1; j < ip; j++)
             {
                 is += ido;
-                int idij = is - 1;
+                int32_t idij = is - 1;
                 t1 += t0;
                 t2 = t1;
-                for (int i = 2; i < ido; i += 2)
+                for (int32_t i = 2; i < ido; i += 2)
                 {
                     idij += 2;
                     t2 += 2;
                     t3 = t2;
-                    for (int k = 0; k < l1; k++)
+                    for (int32_t k = 0; k < l1; k++)
                     {
                         ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
                         ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
@@ -454,19 +454,19 @@ static void dradfg(
         t2 = ipp2 * t0;
         if (nbd < l1)
         {
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (int i = 2; i < ido; i += 2)
+                for (int32_t i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
                     t5 = t3 - ido;
                     t6 = t4 - ido;
-                    for (int k = 0; k < l1; k++)
+                    for (int32_t k = 0; k < l1; k++)
                     {
                         t5 += ido;
                         t6 += ido;
@@ -480,17 +480,17 @@ static void dradfg(
         }
         else
         {
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (int k = 0; k < l1; k++)
+                for (int32_t k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
-                    for (int i = 2; i < ido; i += 2)
+                    for (int32_t i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -506,18 +506,18 @@ static void dradfg(
         }
     }
 
-    for (int ik = 0; ik < idl1; ik++)
+    for (int32_t ik = 0; ik < idl1; ik++)
         c2[ik] = ch2[ik];
 
     t1 = 0;
     t2 = ipp2 * idl1;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1 - ido;
         t4 = t2 - ido;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t3 += ido;
             t4 += ido;
@@ -531,7 +531,7 @@ static void dradfg(
     t1 = 0;
     t2 = ipp2 * idl1;
     t3 = (ip - 1) * idl1;
-    for (int l = 1; l < ipph; l++)
+    for (int32_t l = 1; l < ipph; l++)
     {
         t1 += idl1;
         t2 -= idl1;
@@ -543,7 +543,7 @@ static void dradfg(
         t6 = t3;
         t7 = idl1;
 
-        for (int ik = 0; ik < idl1; ik++)
+        for (int32_t ik = 0; ik < idl1; ik++)
         {
             ch2[t4++] = c2[ik] + ar1 * c2[t7++];
             ch2[t5++] = ai1 * c2[t6++];
@@ -556,7 +556,7 @@ static void dradfg(
 
         t4 = idl1;
         t5 = (ipp2 - 1) * idl1;
-        for (int j = 2; j < ipph; j++)
+        for (int32_t j = 2; j < ipph; j++)
         {
             t4 += idl1;
             t5 -= idl1;
@@ -569,7 +569,7 @@ static void dradfg(
             t7 = t2;
             t8 = t4;
             t9 = t5;
-            for (int ik = 0; ik < idl1; ik++)
+            for (int32_t ik = 0; ik < idl1; ik++)
             {
                 ch2[t6++] += ar2 * c2[t8++];
                 ch2[t7++] += ai2 * c2[t9++];
@@ -578,21 +578,21 @@ static void dradfg(
     }
 
     t1 = 0;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += idl1;
         t2 = t1;
-        for (int ik = 0; ik < idl1; ik++)
+        for (int32_t ik = 0; ik < idl1; ik++)
             ch2[ik] += c2[t2++];
     }
 
     if (ido >= l1)
     {
-        for (int i = 0; i < ido; i++)
+        for (int32_t i = 0; i < ido; i++)
         {
             t1 = i;
             t2 = i;
-            for (int k = 0; k < l1; k++)
+            for (int32_t k = 0; k < l1; k++)
             {
                 cc[t2] = ch[t1];
                 t1 += ido;
@@ -604,11 +604,11 @@ static void dradfg(
     {
         t1 = 0;
         t2 = 0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t3 = t1;
             t4 = t2;
-            for (int i = 0; i < ido; i++)
+            for (int32_t i = 0; i < ido; i++)
                 cc[t4++] = ch[t3++];
             t1 += ido;
             t2 += t10;
@@ -619,7 +619,7 @@ static void dradfg(
     t2 = ido << 1;
     t3 = 0;
     t4 = ipp2 * t0;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += t2;
         t3 += t0;
@@ -629,7 +629,7 @@ static void dradfg(
         t6 = t3;
         t7 = t4;
 
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             cc[t5 - 1] = ch[t6];
             cc[t5] = ch[t7];
@@ -648,7 +648,7 @@ static void dradfg(
         t3 = 0;
         t4 = 0;
         t5 = ipp2 * t0;
-        for (int j = 1; j < ipph; j++)
+        for (int32_t j = 1; j < ipph; j++)
         {
             t1 += t2;
             t3 += t2;
@@ -658,11 +658,11 @@ static void dradfg(
             t7 = t3;
             t8 = t4;
             t9 = t5;
-            for (int k = 0; k < l1; k++)
+            for (int32_t k = 0; k < l1; k++)
             {
-                for (int i = 2; i < ido; i += 2)
+                for (int32_t i = 2; i < ido; i += 2)
                 {
-                    const int ic = idp2 - i;
+                    const int32_t ic = idp2 - i;
                     cc[i + t7 - 1] = ch[i + t8 - 1] + ch[i + t9 - 1];
                     cc[ic + t6 - 1] = ch[i + t8 - 1] - ch[i + t9 - 1];
                     cc[i + t7] = ch[i + t8] + ch[i + t9];
@@ -681,19 +681,19 @@ static void dradfg(
     t3 = 0;
     t4 = 0;
     t5 = ipp2 * t0;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += t2;
         t3 += t2;
         t4 += t0;
         t5 -= t0;
-        for (int i = 2; i < ido; i += 2)
+        for (int32_t i = 2; i < ido; i += 2)
         {
             t6 = idp2 + t1 - i;
             t7 = i + t3;
             t8 = i + t4;
             t9 = i + t5;
-            for (int k = 0; k < l1; k++)
+            for (int32_t k = 0; k < l1; k++)
             {
                 cc[t7 - 1] = ch[t8 - 1] + ch[t9 - 1];
                 cc[t6 - 1] = ch[t8 - 1] - ch[t9 - 1];
@@ -711,27 +711,27 @@ static void dradfg(
 }
 
 
-static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
+static void drftf1(int32_t n, float* c, float* ch, float* wa, const int32_t* ifac)
 {
-    const int nf = ifac[1];
+    const int32_t nf = ifac[1];
     int na = 1;
-    int l2 = n;
-    int iw = n;
+    int32_t l2 = n;
+    int32_t iw = n;
 
-    for (int k1 = 0; k1 < nf; k1++)
+    for (int32_t k1 = 0; k1 < nf; k1++)
     {
-        const int kh = nf - k1;
-        const int ip = ifac[kh + 1];
-        const int l1 = l2 / ip;
-        const int ido = n / l2;
-        const int idl1 = ido * l1;
+        const int32_t kh = nf - k1;
+        const int32_t ip = ifac[kh + 1];
+        const int32_t l1 = l2 / ip;
+        const int32_t ido = n / l2;
+        const int32_t idl1 = ido * l1;
         iw -= (ip - 1) * ido;
         na = 1 - na;
 
         if (ip == 4)
         {
-            const int ix2 = iw + ido;
-            const int ix3 = ix2 + ido;
+            const int32_t ix2 = iw + ido;
+            const int32_t ix3 = ix2 + ido;
             if (na != 0)
                 dradf4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
             else
@@ -767,23 +767,23 @@ static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
     if (na == 1)
         return;
 
-    for (int i = 0; i < n; i++)
+    for (int32_t i = 0; i < n; i++)
         c[i] = ch[i];
 
     return;
 }
 
 
-static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
+static void dradb2(int32_t ido, int32_t l1, float* cc, float* ch, const float* wa1)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t0 = l1 * ido;
 
     t1 = 0;
     t2 = 0;
     t3 = (ido << 1) - 1;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         ch[t1] = cc[t2] + cc[t3 + t2];
         ch[t1 + t0] = cc[t2] - cc[t3 + t2];
@@ -797,12 +797,12 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
     {
         t1 = 0;
         t2 = 0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t3 = t1;
             t5 = (t4 = t2) + (ido << 1);
             t6 = t0 + t1;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 t3 += 2;
                 t4 += 2;
@@ -824,7 +824,7 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     t1 = ido - 1;
     t2 = ido - 1;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         ch[t1] = cc[t2] + cc[t2];
         ch[t1 + t0] = -(cc[t2 + 1] + cc[t2 + 1]);
@@ -837,12 +837,12 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
 
 static void dradb3(
-        int ido, int l1, float* cc, float* ch, const float* wa1, const float *wa2)
+        int32_t ido, int32_t l1, float* cc, float* ch, const float* wa1, const float *wa2)
 {
     const float taur = -0.5f;
     const float taui = 0.86602540378443864676372317075293618f;
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
-    int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
+    int32_t t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
 
     t0 = l1 * ido;
 
@@ -851,7 +851,7 @@ static void dradb3(
     t3 = ido << 1;
     t4 = ido + (ido << 1);
     t5 = 0;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         const float tr2 = cc[t3 - 1] + cc[t3 - 1];
         const float cr2 = cc[t5] + (taur * tr2);
@@ -869,14 +869,14 @@ static void dradb3(
 
     t1 = 0;
     t3 = ido << 1;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         t7 = t1 + (t1 << 1);
         t6 = (t5 = t7 + t3);
         t8 = t1;
         t10 = (t9 = t1 + t0) + t0;
 
-        for (int i = 2; i < ido; i += 2)
+        for (int32_t i = 2; i < ido; i += 2)
         {
             t5 += 2;
             t6 -= 2;
@@ -909,10 +909,10 @@ static void dradb3(
 
 
 static void dradb4(
-        int ido, int l1, float* cc, float* ch,
+        int32_t ido, int32_t l1, float* cc, float* ch,
         const float* wa1, const float* wa2, const float* wa3)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0, t7 = 0, t8 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0, t7 = 0, t8 = 0;
 
     t0 = l1 * ido;
 
@@ -920,7 +920,7 @@ static void dradb4(
     t2 = ido << 2;
     t3 = 0;
     t6 = ido << 1;
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         t4 = t3 + t6;
         t5 = t1;
@@ -942,11 +942,11 @@ static void dradb4(
     if (ido != 2)
     {
         t1 = 0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t5 = (t4 = (t3 = (t2 = t1 << 2) + t6)) + t6;
             t7 = t1;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 t2 += 2;
                 t3 += 2;
@@ -990,7 +990,7 @@ static void dradb4(
     t2 = ido << 2;
     t3 = ido - 1;
     t4 = ido + (ido << 1);
-    for (int k = 0; k < l1; k++)
+    for (int32_t k = 0; k < l1; k++)
     {
         t5 = t3;
         const float ti1 = cc[t1] + cc[t4];
@@ -1012,30 +1012,30 @@ static void dradb4(
 
 
 static void dradbg(
-        int ido, int ip, int l1, int idl1, float* cc, float* c1,
+        int32_t ido, int32_t ip, int32_t l1, int32_t idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, const float* wa)
 {
-    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
-    int t7 = 0, t8 = 0, t9 = 0, t10 = 0, t11 = 0, t12 = 0;
+    int32_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    int32_t t7 = 0, t8 = 0, t9 = 0, t10 = 0, t11 = 0, t12 = 0;
 
     t10 = ip * ido;
     t0 = l1 * ido;
-    const float arg = (float)(PI2 / ip);
+    const float arg = (float)(PI2 / (double)ip);
     const float dcp = cosf(arg);
     const float dsp = sinf(arg);
-    const int nbd = (ido - 1) >> 1;
-    const int ipp2 = ip;
-    const int ipph = (ip + 1) >> 1;
+    const int32_t nbd = (ido - 1) >> 1;
+    const int32_t ipp2 = ip;
+    const int32_t ipph = (ip + 1) >> 1;
 
     if (ido >= l1)
     {
         t1 = 0;
         t2 = 0;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             t3 = t1;
             t4 = t2;
-            for (int i = 0; i < ido; i++)
+            for (int32_t i = 0; i < ido; i++)
             {
                 ch[t3] = cc[t4];
                 t3++;
@@ -1048,11 +1048,11 @@ static void dradbg(
     else
     {
         t1 = 0;
-        for (int i = 0; i < ido; i++)
+        for (int32_t i = 0; i < ido; i++)
         {
             t2 = t1;
             t3 = t1;
-            for (int k = 0; k < l1; k++)
+            for (int32_t k = 0; k < l1; k++)
             {
                 ch[t2] = cc[t3];
                 t2 += ido;
@@ -1065,14 +1065,14 @@ static void dradbg(
     t1 = 0;
     t2 = ipp2 * t0;
     t7 = (t5 = ido << 1);
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
         t6 = t5;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             ch[t3] = cc[t6 - 1] + cc[t6 - 1];
             ch[t4] = cc[t6] + cc[t6];
@@ -1090,7 +1090,7 @@ static void dradbg(
             t1 = 0;
             t2 = ipp2 * t0;
             t7 = 0;
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
@@ -1099,13 +1099,13 @@ static void dradbg(
 
                 t7 += (ido << 1);
                 t8 = t7;
-                for (int k = 0; k < l1; k++)
+                for (int32_t k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
                     t9 = t8;
                     t11 = t8;
-                    for (int i = 2; i < ido; i += 2)
+                    for (int32_t i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -1127,7 +1127,7 @@ static void dradbg(
             t1 = 0;
             t2 = ipp2 * t0;
             t7 = 0;
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
@@ -1136,7 +1136,7 @@ static void dradbg(
                 t7 += (ido << 1);
                 t8 = t7;
                 t9 = t7;
-                for (int i = 2; i < ido; i += 2)
+                for (int32_t i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
@@ -1146,7 +1146,7 @@ static void dradbg(
                     t6 = t4;
                     t11 = t8;
                     t12 = t9;
-                    for (int k = 0; k < l1; k++)
+                    for (int32_t k = 0; k < l1; k++)
                     {
                         ch[t5 - 1] = cc[t11 - 1] + cc[t12 - 1];
                         ch[t6 - 1] = cc[t11 - 1] - cc[t12 - 1];
@@ -1167,7 +1167,7 @@ static void dradbg(
     t1 = 0;
     t9 = (t2 = ipp2 * idl1);
     t3 = (ip - 1) * idl1;
-    for (int l = 1; l < ipph; l++)
+    for (int32_t l = 1; l < ipph; l++)
     {
         t1 += idl1;
         t2 -= idl1;
@@ -1180,7 +1180,7 @@ static void dradbg(
         t6 = 0;
         t7 = idl1;
         t8 = t3;
-        for (int ik = 0; ik < idl1; ik++)
+        for (int32_t ik = 0; ik < idl1; ik++)
         {
             c2[t4++] = ch2[t6++] + ar1 * ch2[t7++];
             c2[t5++] = ai1 * ch2[t8++];
@@ -1192,7 +1192,7 @@ static void dradbg(
 
         t6 = idl1;
         t7 = t9 - idl1;
-        for (int j = 2; j < ipph; j++)
+        for (int32_t j = 2; j < ipph; j++)
         {
             t6 += idl1;
             t7 -= idl1;
@@ -1203,7 +1203,7 @@ static void dradbg(
             t5 = t2;
             t11 = t6;
             t12 = t7;
-            for (int ik = 0; ik < idl1; ik++)
+            for (int32_t ik = 0; ik < idl1; ik++)
             {
                 c2[t4++] += ar2 * ch2[t11++];
                 c2[t5++] += ai2 * ch2[t12++];
@@ -1212,23 +1212,23 @@ static void dradbg(
     }
 
     t1 = 0;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += idl1;
         t2 = t1;
-        for (int ik = 0; ik < idl1; ik++)
+        for (int32_t ik = 0; ik < idl1; ik++)
             ch2[ik] += ch2[t2++];
     }
 
     t1 = 0;
     t2 = ipp2 * t0;
-    for (int j = 1; j < ipph; j++)
+    for (int32_t j = 1; j < ipph; j++)
     {
         t1 += t0;
         t2 -= t0;
         t3 = t1;
         t4 = t2;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             ch[t3] = c1[t3] - c1[t4];
             ch[t4] = c1[t3] + c1[t4];
@@ -1243,17 +1243,17 @@ static void dradbg(
         {
             t1 = 0;
             t2 = ipp2 * t0;
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (int k = 0; k < l1; k++)
+                for (int32_t k = 0; k < l1; k++)
                 {
                     t5 = t3;
                     t6 = t4;
-                    for (int i = 2; i < ido; i += 2)
+                    for (int32_t i = 2; i < ido; i += 2)
                     {
                         t5 += 2;
                         t6 += 2;
@@ -1271,19 +1271,19 @@ static void dradbg(
         {
             t1 = 0;
             t2 = ipp2 * t0;
-            for (int j = 1; j < ipph; j++)
+            for (int32_t j = 1; j < ipph; j++)
             {
                 t1 += t0;
                 t2 -= t0;
                 t3 = t1;
                 t4 = t2;
-                for (int i = 2; i < ido; i += 2)
+                for (int32_t i = 2; i < ido; i += 2)
                 {
                     t3 += 2;
                     t4 += 2;
                     t5 = t3;
                     t6 = t4;
-                    for (int k = 0; k < l1; k++)
+                    for (int32_t k = 0; k < l1; k++)
                     {
                         ch[t5 - 1] = c1[t5 - 1] - c1[t6];
                         ch[t6 - 1] = c1[t5 - 1] + c1[t6];
@@ -1300,37 +1300,37 @@ static void dradbg(
     if (ido == 1)
         return;
 
-    for (int ik = 0; ik < idl1; ik++)
+    for (int32_t ik = 0; ik < idl1; ik++)
         c2[ik] = ch2[ik];
 
     t1 = 0;
-    for (int j = 1; j < ip; j++)
+    for (int32_t j = 1; j < ip; j++)
     {
         t2 = (t1 += t0);
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
             c1[t2] = ch[t2];
             t2 += ido;
         }
     }
 
-    int is = -ido - 1;
+    int32_t is = -ido - 1;
 
     if (nbd <= l1)
     {
         t1 = 0;
-        for (int j = 1; j < ip; j++)
+        for (int32_t j = 1; j < ip; j++)
         {
             is += ido;
             t1 += t0;
-            int idij = is;
+            int32_t idij = is;
             t2 = t1;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 t2 += 2;
                 idij += 2;
                 t3 = t2;
-                for (int k = 0; k < l1; k++)
+                for (int32_t k = 0; k < l1; k++)
                 {
                     c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
                     c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
@@ -1342,16 +1342,16 @@ static void dradbg(
     }
 
     t1 = 0;
-    for (int j = 1; j < ip; j++)
+    for (int32_t j = 1; j < ip; j++)
     {
         is += ido;
         t1 += t0;
         t2 = t1;
-        for (int k = 0; k < l1; k++)
+        for (int32_t k = 0; k < l1; k++)
         {
-            int idij = is;
+            int32_t idij = is;
             t3 = t2;
-            for (int i = 2; i < ido; i += 2)
+            for (int32_t i = 2; i < ido; i += 2)
             {
                 idij += 2;
                 t3 += 2;
@@ -1366,23 +1366,23 @@ static void dradbg(
 }
 
 
-static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* ifac)
+static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int32_t* ifac)
 {
-    const int nf = ifac[1];
+    const int32_t nf = ifac[1];
     int na = 0;
-    int l1 = 1;
-    int iw = 1;
+    int32_t l1 = 1;
+    int32_t iw = 1;
 
-    for (int k1 = 0; k1 < nf; k1++)
+    for (int32_t k1 = 0; k1 < nf; k1++)
     {
-        const int ip = ifac[k1 + 2];
-        const int l2 = ip * l1;
-        const int ido = n / l2;
-        const int idl1 = ido * l1;
+        const int32_t ip = ifac[k1 + 2];
+        const int32_t l2 = ip * l1;
+        const int32_t ido = n / l2;
+        const int32_t idl1 = ido * l1;
         if (ip == 4)
         {
-            const int ix2 = iw + ido;
-            const int ix3 = ix2 + ido;
+            const int32_t ix2 = iw + ido;
+            const int32_t ix3 = ix2 + ido;
 
             if (na != 0)
                 dradb4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
@@ -1400,7 +1400,7 @@ static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* i
         }
         else if (ip == 3)
         {
-            const int ix2 = iw + ido;
+            const int32_t ix2 = iw + ido;
             if (na != 0)
                 dradb3(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1);
             else
@@ -1424,7 +1424,7 @@ static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* i
     if (na == 0)
         return;
 
-    for (int i = 0; i < n; i++)
+    for (int32_t i = 0; i < n; i++)
         c[i] = ch[i];
 
     return;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -1,0 +1,1434 @@
+
+
+/*
+ * This is a modified version of the FFTPACK C implementation released
+ * to the public domain, source: http://www.netlib.org/fftpack/fft.c
+ *
+ * Modifications for Kunquat by Tomi Jylhä-Ollila, Finland 2016
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <debug/assert.h>
+#include <mathnum/fft.h>
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+
+static void drfti1(int32_t n, float* wa, int* ifac)
+{
+    const int ntryh[4] = { 4, 2, 3, 5 };
+    const float tpi = 6.28318530717958647692528676655900577f;
+    float arg = 0, argh = 0, argld = 0, fi = 0;
+    int ntry = 0, i = 0, j = -1;
+    int l1 = 0, l2 = 0;
+    int ld = 0, ip = 0, nq = 0, nr = 0;
+    int ido = 0, ipm = 0, nfm1 = 0;
+    int nl = n;
+    int nf = 0;
+
+  L101:
+    j++;
+    if (j < 4)
+        ntry = ntryh[j];
+    else
+        ntry += 2;
+
+  L104:
+    nq = nl / ntry;
+    nr = nl - ntry * nq;
+    if (nr != 0)
+        goto L101;
+
+    nf++;
+    ifac[nf + 1] = ntry;
+    nl = nq;
+    if (ntry != 2)
+        goto L107;
+    if (nf == 1)
+        goto L107;
+
+    for (i = 1; i < nf; i++)
+    {
+        const int ib = nf - i + 1;
+        ifac[ib + 1] = ifac[ib];
+    }
+    ifac[2] = 2;
+
+  L107:
+    if (nl != 1)
+        goto L104;
+    ifac[0] = n;
+    ifac[1] = nf;
+    argh = tpi / (float)n;
+    int is = 0;
+    nfm1 = nf - 1;
+    l1 = 1;
+
+    if (nfm1 == 0)
+        return;
+
+    for (int k1 = 0; k1 < nfm1; k1++)
+    {
+        ip = ifac[k1 + 2];
+        ld = 0;
+        l2 = l1 * ip;
+        ido = n / l2;
+        ipm = ip - 1;
+
+        for (j = 0; j < ipm; j++)
+        {
+            ld += l1;
+            i = is;
+            argld = (float)ld * argh;
+            fi = 0.0f;
+            for (int ii = 2; ii < ido; ii += 2)
+            {
+                fi += 1.0f;
+                arg = fi * argld;
+                wa[i++] = cosf(arg);
+                wa[i++] = sinf(arg);
+            }
+            is += ido;
+        }
+        l1 = l2;
+    }
+
+    return;
+}
+
+
+void rfft_init(int32_t n, float* wsave, int* ifac)
+{
+    rassert(n >= 1);
+    rassert(wsave != NULL);
+    rassert(ifac != NULL);
+
+    if (n == 1)
+        return;
+
+    drfti1(n, wsave + n, ifac);
+
+    return;
+}
+
+
+static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
+{
+    int i = 0, k = 0;
+    float ti2 = 0, tr2 = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+
+    t1 = 0;
+    t0 = (t2 = l1 * ido);
+    t3 = ido << 1;
+    for (k = 0; k < l1; k++)
+    {
+        ch[t1 << 1] = cc[t1] + cc[t2];
+        ch[(t1 << 1) + t3 - 1] = cc[t1] - cc[t2];
+        t1 += ido;
+        t2 += ido;
+    }
+
+    if (ido < 2)
+        return;
+    if (ido == 2)
+        goto L105;
+
+    t1 = 0;
+    t2 = t0;
+    for (k = 0; k < l1; k++)
+    {
+        t3 = t2;
+        t4 = (t1 << 1) + (ido << 1);
+        t5 = t1;
+        t6 = t1 + t1;
+        for (i = 2; i < ido; i += 2)
+        {
+            t3 += 2;
+            t4 -= 2;
+            t5 += 2;
+            t6 += 2;
+            tr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+            ti2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+            ch[t6] = cc[t5] + ti2;
+            ch[t4] = ti2 - cc[t5];
+            ch[t6 - 1] = cc[t5 - 1] + tr2;
+            ch[t4 - 1] = cc[t5 - 1] - tr2;
+        }
+        t1 += ido;
+        t2 += ido;
+    }
+
+    if (ido % 2 == 1)
+        return;
+
+  L105:
+    t3 = (t2 = (t1 = ido) - 1);
+    t2 += t0;
+    for (k = 0; k < l1; k++)
+    {
+        ch[t1] = -cc[t2];
+        ch[t1 - 1] = cc[t3];
+        t1 += ido << 1;
+        t2 += ido;
+        t3 += ido;
+    }
+
+    return;
+}
+
+
+static void dradf4(
+        int ido, int l1, float* cc, float* ch,
+        const float* wa1, const float* wa2, const float* wa3)
+{
+    const float hsqt2 = 0.70710678118654752440084436210485f;
+    int i = 0, k = 0, t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    float ci2 = 0, ci3 = 0, ci4 = 0, cr2 = 0, cr3 = 0, cr4 = 0;
+    float ti1 = 0, ti2 = 0, ti3 = 0, ti4 = 0, tr1 = 0, tr2 = 0, tr3 = 0, tr4 = 0;
+
+    t0 = l1 * ido;
+
+    t1=t0;
+    t4=t1<<1;
+    t2=t1+(t1<<1);
+    t3=0;
+
+    for (k = 0; k < l1; k++)
+    {
+        tr1 = cc[t1] + cc[t2];
+        tr2 = cc[t3] + cc[t4];
+        ch[t5 = t3 << 2] = tr1 + tr2;
+        ch[(ido << 2) + t5 - 1] = tr2 - tr1;
+        ch[(t5 += (ido << 1)) - 1] = cc[t3] - cc[t4];
+        ch[t5] = cc[t2] - cc[t1];
+
+        t1 += ido;
+        t2 += ido;
+        t3 += ido;
+        t4 += ido;
+    }
+
+    if (ido < 2)
+        return;
+    if (ido == 2)
+        goto L105;
+
+    t1=0;
+    for (k = 0; k < l1; k++)
+    {
+        t2 = t1;
+        t4 = t1 << 2;
+        t5 = (t6 = ido << 1) + t4;
+        for (i = 2; i < ido; i += 2)
+        {
+            t3 = (t2 += 2);
+            t4 += 2;
+            t5 -= 2;
+
+            t3 += t0;
+            cr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+            ci2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+            t3 += t0;
+            cr3 = wa2[i - 2] * cc[t3 - 1] + wa2[i - 1] * cc[t3];
+            ci3 = wa2[i - 2] * cc[t3] - wa2[i - 1] * cc[t3 - 1];
+            t3 += t0;
+            cr4 = wa3[i - 2] * cc[t3 - 1] + wa3[i - 1] * cc[t3];
+            ci4 = wa3[i - 2] * cc[t3] - wa3[i - 1] * cc[t3 - 1];
+
+            tr1 = cr2 + cr4;
+            tr4 = cr4 - cr2;
+            ti1 = ci2 + ci4;
+            ti4 = ci2 - ci4;
+            ti2 = cc[t2] + ci3;
+            ti3 = cc[t2] - ci3;
+            tr2 = cc[t2 - 1] + cr3;
+            tr3 = cc[t2 - 1] - cr3;
+
+            ch[t4 - 1] = tr1 + tr2;
+            ch[t4] = ti1 + ti2;
+
+            ch[t5 - 1] = tr3 - ti4;
+            ch[t5] = tr4 - ti3;
+
+            ch[t4 + t6 - 1] = ti4 + tr3;
+            ch[t4 + t6] = tr4 + ti3;
+
+            ch[t5 + t6 - 1] = tr2 - tr1;
+            ch[t5 + t6] = ti1 - ti2;
+        }
+        t1 += ido;
+    }
+    if (ido % 2 == 1)
+        return;
+
+  L105:
+
+    t2 = (t1 = t0 + ido - 1) + (t0 << 1);
+    t3 = ido << 2;
+    t4 = ido;
+    t5 = ido << 1;
+    t6 = ido;
+
+    for (k = 0; k < l1; k++)
+    {
+        ti1 = -hsqt2 * (cc[t1] + cc[t2]);
+        tr1 = hsqt2 * (cc[t1] - cc[t2]);
+        ch[t4 - 1] = tr1 + cc[t6 - 1];
+        ch[t4 + t5 - 1] = cc[t6 - 1] - tr1;
+        ch[t4] = ti1 - cc[t1 + t0];
+        ch[t4 + t5] = ti1 + cc[t1 + t0];
+        t1 += ido;
+        t2 += ido;
+        t4 += t3;
+        t6 += ido;
+    }
+
+    return;
+}
+
+
+static void dradfg(
+        int ido, int ip, int l1, int idl1, float* cc, float* c1,
+        float* c2, float* ch, float* ch2, float* wa)
+{
+    const float tpi = 6.28318530717958647692528676655900577f;
+    int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ic = 0, ik = 0, is = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
+    int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
+    float dc2 = 0, ai1 = 0, ai2 = 0, ar1 = 0, ar2 = 0, ds2 = 0;
+    int nbd = 0;
+    float dcp = 0, arg = 0, dsp = 0, ar1h = 0, ar2h = 0;
+    int idp2 = 0, ipp2 = 0;
+
+    arg = tpi / (float)ip;
+    dcp = cosf(arg);
+    dsp = sinf(arg);
+    ipph = (ip + 1) >> 1;
+    ipp2 = ip;
+    idp2 = ido;
+    nbd = (ido - 1) >> 1;
+    t0 = l1 * ido;
+    t10 = ip * ido;
+
+    if (ido == 1)
+        goto L119;
+    for (ik = 0; ik < idl1; ik++)
+        ch2[ik] = c2[ik];
+
+    t1 = 0;
+    for (j = 1; j < ip; j++)
+    {
+        t1 += t0;
+        t2 = t1;
+        for (k = 0; k < l1; k++)
+        {
+            ch[t2] = c1[t2];
+            t2 += ido;
+        }
+    }
+
+    is=-ido;
+    t1=0;
+    if (nbd > l1)
+    {
+        for (j = 1; j < ip; j++)
+        {
+            t1 += t0;
+            is += ido;
+            t2 = -ido + t1;
+            for (k = 0; k < l1; k++)
+            {
+                idij = is - 1;
+                t2 += ido;
+                t3 = t2;
+                for (i = 2; i < ido; i += 2)
+                {
+                    idij += 2;
+                    t3 += 2;
+                    ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
+                    ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
+                }
+            }
+        }
+    }
+    else
+    {
+        for (j = 1; j < ip; j++)
+        {
+            is += ido;
+            idij = is - 1;
+            t1 += t0;
+            t2 = t1;
+            for (i = 2; i < ido; i += 2)
+            {
+                idij += 2;
+                t2 += 2;
+                t3 = t2;
+                for (k = 0; k < l1; k++)
+                {
+                    ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
+                    ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
+                    t3 += ido;
+                }
+            }
+        }
+    }
+
+    t1 = 0;
+    t2 = ipp2 * t0;
+    if (nbd < l1)
+    {
+        for (j = 1; j < ipph; j++)
+        {
+            t1 += t0;
+            t2 -= t0;
+            t3 = t1;
+            t4 = t2;
+            for (i = 2; i < ido; i += 2)
+            {
+                t3 += 2;
+                t4 += 2;
+                t5 = t3 - ido;
+                t6 = t4 - ido;
+                for (k = 0; k < l1; k++)
+                {
+                    t5 += ido;
+                    t6 += ido;
+                    c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
+                    c1[t6 - 1] = ch[t5] - ch[t6];
+                    c1[t5] = ch[t5] + ch[t6];
+                    c1[t6] = ch[t6 - 1] - ch[t5 - 1];
+                }
+            }
+        }
+    }
+    else
+    {
+        for (j = 1; j < ipph; j++)
+        {
+            t1 += t0;
+            t2 -= t0;
+            t3 = t1;
+            t4 = t2;
+            for (k = 0; k < l1; k++)
+            {
+                t5 = t3;
+                t6 = t4;
+                for (i = 2; i < ido; i += 2)
+                {
+                    t5 += 2;
+                    t6 += 2;
+                    c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
+                    c1[t6 - 1] = ch[t5] - ch[t6];
+                    c1[t5] = ch[t5] + ch[t6];
+                    c1[t6] = ch[t6 - 1] - ch[t5 - 1];
+                }
+                t3 += ido;
+                t4 += ido;
+            }
+        }
+    }
+
+  L119:
+    for (ik = 0; ik < idl1; ik++)
+        c2[ik] = ch2[ik];
+
+    t1 = 0;
+    t2 = ipp2 * idl1;
+    for(j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1 - ido;
+        t4 = t2 - ido;
+        for (k = 0; k < l1; k++)
+        {
+            t3 += ido;
+            t4 += ido;
+            c1[t3] = ch[t3] + ch[t4];
+            c1[t4] = ch[t4] - ch[t3];
+        }
+    }
+
+    ar1 = 1.0f;
+    ai1 = 0.0f;
+    t1 = 0;
+    t2 = ipp2 * idl1;
+    t3 = (ip - 1) * idl1;
+    for (l = 1; l < ipph; l++)
+    {
+        t1 += idl1;
+        t2 -= idl1;
+        ar1h = dcp * ar1 - dsp * ai1;
+        ai1 = dcp * ai1 + dsp * ar1;
+        ar1 = ar1h;
+        t4 = t1;
+        t5 = t2;
+        t6 = t3;
+        t7 = idl1;
+
+        for (ik = 0; ik < idl1; ik++)
+        {
+            ch2[t4++] = c2[ik] + ar1 * c2[t7++];
+            ch2[t5++] = ai1 * c2[t6++];
+        }
+
+        dc2 = ar1;
+        ds2 = ai1;
+        ar2 = ar1;
+        ai2 = ai1;
+
+        t4 = idl1;
+        t5 = (ipp2 - 1) * idl1;
+        for (j = 2; j < ipph; j++)
+        {
+            t4 += idl1;
+            t5 -= idl1;
+
+            ar2h = dc2 * ar2 - ds2 * ai2;
+            ai2 = dc2 * ai2 + ds2 * ar2;
+            ar2 = ar2h;
+
+            t6 = t1;
+            t7 = t2;
+            t8 = t4;
+            t9 = t5;
+            for (ik = 0; ik < idl1; ik++)
+            {
+                ch2[t6++] += ar2 * c2[t8++];
+                ch2[t7++] += ai2 * c2[t9++];
+            }
+        }
+    }
+
+    t1 = 0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += idl1;
+        t2 = t1;
+        for (ik = 0; ik < idl1; ik++)
+            ch2[ik] += c2[t2++];
+    }
+
+    if (ido < l1)
+        goto L132;
+
+    t1 = 0;
+    t2 = 0;
+    for (k = 0; k < l1; k++)
+    {
+        t3 = t1;
+        t4 = t2;
+        for (i = 0; i < ido; i++)
+            cc[t4++] = ch[t3++];
+        t1 += ido;
+        t2 += t10;
+    }
+
+    goto L135;
+
+  L132:
+    for (i = 0; i < ido; i++)
+    {
+        t1 = i;
+        t2 = i;
+        for (k = 0; k < l1; k++)
+        {
+            cc[t2] = ch[t1];
+            t1 += ido;
+            t2 += t10;
+        }
+    }
+
+  L135:
+    t1 = 0;
+    t2 = ido << 1;
+    t3 = 0;
+    t4 = ipp2 * t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t2;
+        t3 += t0;
+        t4 -= t0;
+
+        t5 = t1;
+        t6 = t3;
+        t7 = t4;
+
+        for (k = 0; k < l1; k++)
+        {
+            cc[t5 - 1] = ch[t6];
+            cc[t5] = ch[t7];
+            t5 += t10;
+            t6 += ido;
+            t7 += ido;
+        }
+    }
+
+    if (ido == 1)
+        return;
+    if (nbd < l1)
+        goto L141;
+
+    t1 = -ido;
+    t3 = 0;
+    t4 = 0;
+    t5 = ipp2*t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t2;
+        t3 += t2;
+        t4 += t0;
+        t5 -= t0;
+        t6 = t1;
+        t7 = t3;
+        t8 = t4;
+        t9 = t5;
+        for (k = 0; k < l1; k++)
+        {
+            for (i = 2; i < ido; i += 2)
+            {
+                ic = idp2 - i;
+                cc[i + t7 - 1] = ch[i + t8 - 1] + ch[i + t9 - 1];
+                cc[ic + t6 - 1] = ch[i + t8 - 1] - ch[i + t9 - 1];
+                cc[i + t7] = ch[i + t8] + ch[i + t9];
+                cc[ic + t6] = ch[i + t9] - ch[i + t8];
+            }
+            t6 += t10;
+            t7 += t10;
+            t8 += ido;
+            t9 += ido;
+        }
+    }
+    return;
+
+  L141:
+
+    t1 = -ido;
+    t3 = 0;
+    t4 = 0;
+    t5 = ipp2 * t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t2;
+        t3 += t2;
+        t4 += t0;
+        t5 -= t0;
+        for (i = 2; i < ido; i += 2)
+        {
+            t6 = idp2 + t1 - i;
+            t7 = i + t3;
+            t8 = i + t4;
+            t9 = i + t5;
+            for (k = 0; k < l1; k++)
+            {
+                cc[t7-1] = ch[t8 - 1] + ch[t9 - 1];
+                cc[t6-1] = ch[t8 - 1] - ch[t9 - 1];
+                cc[t7] = ch[t8] + ch[t9];
+                cc[t6] = ch[t9] - ch[t8];
+                t6 += t10;
+                t7 += t10;
+                t8 += ido;
+                t9 += ido;
+            }
+        }
+    }
+
+    return;
+}
+
+
+static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
+{
+    int i = 0, k1 = 0, l1 = 0, l2 = 0;
+    int na = 0, kh = 0, nf = 0;
+    int ip = 0, iw = 0, ido = 0, idl1 = 0, ix2 = 0, ix3 = 0;
+
+    nf = ifac[1];
+    na = 1;
+    l2 = n;
+    iw = n;
+
+    for (k1 = 0; k1 < nf; k1++)
+    {
+        kh = nf - k1;
+        ip = ifac[kh + 1];
+        l1 = l2 / ip;
+        ido = n / l2;
+        idl1 = ido * l1;
+        iw -= (ip - 1) * ido;
+        na = 1 - na;
+
+        if (ip != 4)
+            goto L102;
+
+        ix2 = iw + ido;
+        ix3 = ix2 + ido;
+        if (na != 0)
+            dradf4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+        else
+            dradf4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+        goto L110;
+
+      L102:
+        if (ip != 2)
+            goto L104;
+        if (na != 0)
+            goto L103;
+
+        dradf2(ido, l1, c, ch, wa + iw - 1);
+        goto L110;
+
+      L103:
+        dradf2(ido, l1, ch, c, wa + iw - 1);
+        goto L110;
+
+      L104:
+        if (ido == 1)
+            na = 1 - na;
+        if (na != 0)
+            goto L109;
+
+        dradfg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
+        na = 1;
+        goto L110;
+
+      L109:
+        dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
+        na = 0;
+
+      L110:
+        l2 = l1;
+    }
+
+    if (na == 1)
+        return;
+
+    for (i = 0; i < n; i++)
+        c[i] = ch[i];
+
+    return;
+}
+
+
+void rfft_forward(int32_t n, float* r, float* wsave, const int* ifac)
+{
+    rassert(n >= 1);
+    rassert(r != NULL);
+    rassert(wsave != NULL);
+    rassert(ifac != NULL);
+
+    if (n == 1)
+        return;
+
+    drftf1(n, r, wsave, wsave + n, ifac);
+
+    return;
+}
+
+
+static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
+{
+    int i = 0, k = 0, t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    float ti2 = 0, tr2 = 0;
+
+    t0 = l1 * ido;
+
+    t1 = 0;
+    t2 = 0;
+    t3 = (ido << 1) - 1;
+    for (k = 0; k < l1; k++)
+    {
+        ch[t1] = cc[t2] + cc[t3 + t2];
+        ch[t1 + t0] = cc[t2] - cc[t3 + t2];
+        t2 = (t1 += ido) << 1;
+    }
+
+    if (ido < 2)
+        return;
+    if (ido == 2)
+        goto L105;
+
+    t1 = 0;
+    t2 = 0;
+    for (k = 0; k < l1; k++)
+    {
+        t3 = t1;
+        t5 = (t4 = t2) + (ido << 1);
+        t6 = t0 + t1;
+        for (i = 2; i < ido; i += 2)
+        {
+            t3 += 2;
+            t4 += 2;
+            t5 -= 2;
+            t6 += 2;
+            ch[t3 - 1] = cc[t4 - 1] + cc[t5 - 1];
+            tr2 = cc[t4 - 1] - cc[t5 - 1];
+            ch[t3] = cc[t4] - cc[t5];
+            ti2 = cc[t4] + cc[t5];
+            ch[t6 - 1] = wa1[i - 2] * tr2 - wa1[i - 1] * ti2;
+            ch[t6] = wa1[i - 2] * ti2 + wa1[i - 1] * tr2;
+        }
+        t2 = (t1 += ido) << 1;
+    }
+
+    if (ido % 2 == 1)
+        return;
+
+  L105:
+    t1 = ido - 1;
+    t2 = ido - 1;
+    for (k = 0; k < l1; k++)
+    {
+        ch[t1] = cc[t2] + cc[t2];
+        ch[t1 + t0] = -(cc[t2 + 1] + cc[t2 + 1]);
+        t1 += ido;
+        t2 += ido << 1;
+    }
+
+    return;
+}
+
+
+static void dradb3(
+        int ido, int l1, float* cc, float* ch, const float* wa1, const float *wa2)
+{
+    const float taur = -0.5f;
+    const float taui = 0.86602540378443864676372317075293618f;
+    int i = 0, k = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
+    int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
+    float ci2 = 0, ci3 = 0, di2 = 0, di3 = 0, cr2 = 0, cr3 = 0;
+    float dr2 = 0, dr3 = 0, ti2 = 0, tr2 = 0;
+
+    t0 = l1 * ido;
+
+    t1 = 0;
+    t2 = t0 << 1;
+    t3 = ido << 1;
+    t4 = ido + (ido << 1);
+    t5 = 0;
+    for (k = 0; k < l1; k++)
+    {
+        tr2 = cc[t3 - 1] + cc[t3 - 1];
+        cr2 = cc[t5] + (taur * tr2);
+        ch[t1] = cc[t5] + tr2;
+        ci3 = taui * (cc[t3] + cc[t3]);
+        ch[t1 + t0] = cr2 - ci3;
+        ch[t1 + t2] = cr2 + ci3;
+        t1 += ido;
+        t3 += t4;
+        t5 += t4;
+    }
+
+    if (ido == 1)
+        return;
+
+    t1 = 0;
+    t3 = ido << 1;
+    for (k = 0; k < l1; k++)
+    {
+        t7 = t1 + (t1 << 1);
+        t6 = (t5 = t7 + t3);
+        t8 = t1;
+        t10 = (t9 = t1 + t0) + t0;
+
+        for (i = 2; i < ido; i += 2)
+        {
+            t5 += 2;
+            t6 -= 2;
+            t7 += 2;
+            t8 += 2;
+            t9 += 2;
+            t10 += 2;
+            tr2 = cc[t5 - 1] + cc[t6 - 1];
+            cr2 = cc[t7 - 1] + (taur * tr2);
+            ch[t8 - 1] = cc[t7 - 1] + tr2;
+            ti2 =cc[t5] - cc[t6];
+            ci2 =cc[t7] + (taur * ti2);
+            ch[t8] = cc[t7] + ti2;
+            cr3 = taui * (cc[t5 - 1] - cc[t6 - 1]);
+            ci3 = taui * (cc[t5] + cc[t6]);
+            dr2 = cr2 - ci3;
+            dr3 = cr2 + ci3;
+            di2 = ci2 + cr3;
+            di3 = ci2 - cr3;
+            ch[t9 - 1] = wa1[i - 2] * dr2 - wa1[i - 1] * di2;
+            ch[t9] = wa1[i - 2] * di2 + wa1[i - 1] * dr2;
+            ch[t10 - 1] = wa2[i - 2] * dr3 - wa2[i - 1] * di3;
+            ch[t10] = wa2[i - 2] * di3 + wa2[i - 1] * dr3;
+        }
+        t1 += ido;
+    }
+
+    return;
+}
+
+
+static void dradb4(
+        int ido, int l1, float* cc, float* ch,
+        const float* wa1, const float* wa2, const float* wa3)
+{
+    const float sqrt2 = 1.4142135623730950488016887242097f;
+    int i = 0, k = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0, t7 = 0, t8 = 0;
+    float ci2 = 0, ci3 = 0, ci4 = 0, cr2 = 0, cr3 = 0, cr4 = 0;
+    float ti1 = 0, ti2 = 0, ti3 = 0, ti4 = 0, tr1 = 0, tr2 = 0, tr3 = 0, tr4 = 0;
+
+    t0 = l1 * ido;
+
+    t1 = 0;
+    t2 = ido << 2;
+    t3 = 0;
+    t6 = ido << 1;
+    for (k = 0; k < l1; k++)
+    {
+        t4 = t3 + t6;
+        t5 = t1;
+        tr3 = cc[t4 - 1] + cc[t4 - 1];
+        tr4 = cc[t4] + cc[t4];
+        tr1 = cc[t3] - cc[(t4 += t6) - 1];
+        tr2 = cc[t3] + cc[t4 - 1];
+        ch[t5] = tr2 + tr3;
+        ch[t5 += t0] = tr1 - tr4;
+        ch[t5 += t0] = tr2 - tr3;
+        ch[t5 += t0] = tr1 + tr4;
+        t1 += ido;
+        t3 += t2;
+    }
+
+    if (ido < 2)
+        return;
+    if (ido == 2)
+        goto L105;
+
+    t1 = 0;
+    for (k = 0; k < l1; k++)
+    {
+        t5 = (t4 = (t3 = (t2 = t1 << 2) + t6)) + t6;
+        t7 = t1;
+        for (i = 2; i < ido; i += 2)
+        {
+            t2 += 2;
+            t3 += 2;
+            t4 -= 2;
+            t5 -= 2;
+            t7 += 2;
+            ti1 = cc[t2] + cc[t5];
+            ti2 = cc[t2] - cc[t5];
+            ti3 = cc[t3] - cc[t4];
+            tr4 = cc[t3] + cc[t4];
+            tr1 = cc[t2 - 1] - cc[t5 - 1];
+            tr2 = cc[t2 - 1] + cc[t5 - 1];
+            ti4 = cc[t3 - 1] - cc[t4 - 1];
+            tr3 = cc[t3 - 1] + cc[t4 - 1];
+            ch[t7 - 1] = tr2 + tr3;
+            cr3 = tr2 - tr3;
+            ch[t7] = ti2 + ti3;
+            ci3 = ti2 - ti3;
+            cr2 = tr1 - tr4;
+            cr4 = tr1 + tr4;
+            ci2 = ti1 + ti4;
+            ci4 = ti1 - ti4;
+
+            ch[(t8 = t7 + t0) - 1] = wa1[i - 2] * cr2 - wa1[i - 1]*ci2;
+            ch[t8] = wa1[i - 2] * ci2 + wa1[i - 1] * cr2;
+            ch[(t8 += t0) - 1] = wa2[i - 2] * cr3 - wa2[i - 1] * ci3;
+            ch[t8] = wa2[i - 2] * ci3 + wa2[i - 1] * cr3;
+            ch[(t8 += t0) - 1] = wa3[i - 2] * cr4 - wa3[i - 1] * ci4;
+            ch[t8] = wa3[i - 2] * ci4 + wa3[i - 1] * cr4;
+        }
+        t1 += ido;
+    }
+
+    if (ido % 2 == 1)
+        return;
+
+  L105:
+
+    t1 = ido;
+    t2 = ido << 2;
+    t3 = ido - 1;
+    t4 = ido + (ido << 1);
+    for (k = 0; k < l1; k++)
+    {
+        t5 = t3;
+        ti1 = cc[t1] + cc[t4];
+        ti2 = cc[t4] - cc[t1];
+        tr1 = cc[t1 - 1] - cc[t4 - 1];
+        tr2 = cc[t1 - 1] + cc[t4 - 1];
+        ch[t5] = tr2 + tr2;
+        ch[t5 += t0] = sqrt2 * (tr1 - ti1);
+        ch[t5 += t0] = ti2 + ti2;
+        ch[t5 += t0] = -sqrt2 * (tr1 + ti1);
+
+        t3 += ido;
+        t1 += t2;
+        t4 += t2;
+    }
+
+    return;
+}
+
+
+static void dradbg(
+        int ido, int ip, int l1, int idl1, float* cc, float* c1,
+        float* c2, float* ch, float* ch2, const float* wa)
+{
+    const float tpi = 6.28318530717958647692528676655900577f;
+    int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ik = 0, is = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
+    int t7 = 0, t8 = 0, t9 = 0, t10 = 0, t11 = 0, t12 = 0;
+    float dc2 = 0, ai1 = 0, ai2 = 0, ar1 = 0, ar2 = 0, ds2 = 0;
+    int nbd = 0;
+    float dcp = 0, arg = 0, dsp = 0, ar1h = 0, ar2h = 0;
+    int ipp2 = 0;
+
+    t10 = ip * ido;
+    t0 = l1 * ido;
+    arg = tpi / (float)ip;
+    dcp = cosf(arg);
+    dsp = sinf(arg);
+    nbd = (ido - 1) >> 1;
+    ipp2 = ip;
+    ipph = (ip + 1) >> 1;
+    if (ido < l1)
+        goto L103;
+
+    t1 = 0;
+    t2 = 0;
+    for (k = 0; k < l1; k++)
+    {
+        t3 = t1;
+        t4 = t2;
+        for (i = 0; i < ido; i++)
+        {
+            ch[t3] = cc[t4];
+            t3++;
+            t4++;
+        }
+        t1 += ido;
+        t2 += t10;
+    }
+    goto L106;
+
+  L103:
+    t1 = 0;
+    for (i = 0; i < ido; i++)
+    {
+        t2 = t1;
+        t3 = t1;
+        for (k = 0; k < l1; k++)
+        {
+            ch[t2] = cc[t3];
+            t2 += ido;
+            t3 += t10;
+        }
+        t1++;
+    }
+
+  L106:
+    t1 = 0;
+    t2 = ipp2 * t0;
+    t7 = (t5 = ido << 1);
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+        t6 = t5;
+        for (k = 0; k < l1; k++)
+        {
+            ch[t3] = cc[t6 - 1] + cc[t6 - 1];
+            ch[t4] = cc[t6] + cc[t6];
+            t3 += ido;
+            t4 += ido;
+            t6 += t10;
+        }
+        t5 += t7;
+    }
+
+    if (ido == 1)
+        goto L116;
+    if (nbd < l1)
+        goto L112;
+
+    t1 = 0;
+    t2 = ipp2 * t0;
+    t7 = 0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+
+        t7+=(ido<<1);
+        t8=t7;
+        for (k = 0; k < l1; k++)
+        {
+            t5 = t3;
+            t6 = t4;
+            t9 = t8;
+            t11 = t8;
+            for (i = 2; i < ido; i += 2)
+            {
+                t5 += 2;
+                t6 += 2;
+                t9 += 2;
+                t11 -= 2;
+                ch[t5 - 1] = cc[t9 - 1] + cc[t11 - 1];
+                ch[t6 - 1] = cc[t9 - 1] - cc[t11 - 1];
+                ch[t5] = cc[t9] - cc[t11];
+                ch[t6] = cc[t9] + cc[t11];
+            }
+            t3 += ido;
+            t4 += ido;
+            t8 += t10;
+        }
+    }
+    goto L116;
+
+  L112:
+    t1 = 0;
+    t2 = ipp2 * t0;
+    t7 = 0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+        t7 += (ido << 1);
+        t8 = t7;
+        t9 = t7;
+        for (i = 2; i < ido; i += 2)
+        {
+            t3 += 2;
+            t4 += 2;
+            t8 += 2;
+            t9 -= 2;
+            t5 = t3;
+            t6 = t4;
+            t11 = t8;
+            t12 = t9;
+            for (k = 0; k < l1; k++)
+            {
+                ch[t5 - 1] = cc[t11 - 1] + cc[t12 - 1];
+                ch[t6 - 1] = cc[t11 - 1] - cc[t12 - 1];
+                ch[t5] = cc[t11] - cc[t12];
+                ch[t6] = cc[t11] + cc[t12];
+                t5 += ido;
+                t6 += ido;
+                t11 += t10;
+                t12 += t10;
+            }
+        }
+    }
+
+  L116:
+    ar1 = 1.0f;
+    ai1 = 0.0f;
+    t1 = 0;
+    t9 = (t2 = ipp2 * idl1);
+    t3 = (ip - 1) * idl1;
+    for (l = 1; l < ipph; l++)
+    {
+        t1 += idl1;
+        t2 -= idl1;
+
+        ar1h = dcp * ar1 - dsp * ai1;
+        ai1 = dcp * ai1 + dsp * ar1;
+        ar1 = ar1h;
+        t4 = t1;
+        t5 = t2;
+        t6 = 0;
+        t7 = idl1;
+        t8 = t3;
+        for (ik = 0; ik < idl1; ik++)
+        {
+            c2[t4++] = ch2[t6++] + ar1 * ch2[t7++];
+            c2[t5++] = ai1 * ch2[t8++];
+        }
+        dc2 = ar1;
+        ds2 = ai1;
+        ar2 = ar1;
+        ai2 = ai1;
+
+        t6 = idl1;
+        t7 = t9 - idl1;
+        for (j = 2; j < ipph; j++)
+        {
+            t6 += idl1;
+            t7 -= idl1;
+            ar2h = dc2 * ar2 - ds2 * ai2;
+            ai2 = dc2 * ai2 + ds2 * ar2;
+            ar2 = ar2h;
+            t4 = t1;
+            t5 = t2;
+            t11 = t6;
+            t12 = t7;
+            for (ik = 0; ik < idl1; ik++)
+            {
+                c2[t4++] += ar2 * ch2[t11++];
+                c2[t5++] += ai2 * ch2[t12++];
+            }
+        }
+    }
+
+    t1 = 0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += idl1;
+        t2 = t1;
+        for (ik = 0; ik < idl1; ik++)
+            ch2[ik] += ch2[t2++];
+    }
+
+    t1 = 0;
+    t2 = ipp2 * t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+        for (k = 0; k < l1; k++)
+        {
+            ch[t3] = c1[t3] - c1[t4];
+            ch[t4] = c1[t3] + c1[t4];
+            t3 += ido;
+            t4 += ido;
+        }
+    }
+
+    if (ido == 1)
+        goto L132;
+    if (nbd < l1)
+        goto L128;
+
+    t1 = 0;
+    t2 = ipp2 * t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+        for (k = 0; k < l1; k++)
+        {
+            t5 = t3;
+            t6 = t4;
+            for (i = 2; i < ido; i += 2)
+            {
+                t5 += 2;
+                t6 += 2;
+                ch[t5 - 1] = c1[t5 - 1] - c1[t6];
+                ch[t6 - 1] = c1[t5 - 1] + c1[t6];
+                ch[t5] = c1[t5] + c1[t6 - 1];
+                ch[t6] = c1[t5] - c1[t6 - 1];
+            }
+            t3 += ido;
+            t4 += ido;
+        }
+    }
+    goto L132;
+
+  L128:
+    t1 = 0;
+    t2 = ipp2 * t0;
+    for (j = 1; j < ipph; j++)
+    {
+        t1 += t0;
+        t2 -= t0;
+        t3 = t1;
+        t4 = t2;
+        for (i = 2; i < ido; i += 2)
+        {
+            t3 += 2;
+            t4 += 2;
+            t5 = t3;
+            t6 = t4;
+            for (k = 0; k < l1; k++)
+            {
+                ch[t5 - 1] = c1[t5 - 1] - c1[t6];
+                ch[t6 - 1] = c1[t5 - 1] + c1[t6];
+                ch[t5] = c1[t5] + c1[t6 - 1];
+                ch[t6] = c1[t5] - c1[t6 - 1];
+                t5 += ido;
+                t6 += ido;
+            }
+        }
+    }
+
+  L132:
+    if (ido == 1)
+        return;
+
+    for (ik = 0; ik < idl1; ik++)
+        c2[ik] = ch2[ik];
+
+    t1 = 0;
+    for (j = 1; j < ip; j++)
+    {
+        t2 = (t1 += t0);
+        for (k = 0; k < l1; k++)
+        {
+            c1[t2] = ch[t2];
+            t2 += ido;
+        }
+    }
+
+    if (nbd > l1)
+        goto L139;
+
+    is = -ido - 1;
+    t1 = 0;
+    for (j = 1; j < ip; j++)
+    {
+        is += ido;
+        t1 += t0;
+        idij = is;
+        t2 = t1;
+        for (i = 2; i < ido; i += 2)
+        {
+            t2 += 2;
+            idij += 2;
+            t3 = t2;
+            for (k = 0; k < l1; k++)
+            {
+                c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
+                c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
+                t3 += ido;
+            }
+        }
+    }
+    return;
+
+  L139:
+    is = -ido - 1;
+    t1 = 0;
+    for (j = 1; j < ip; j++)
+    {
+        is += ido;
+        t1 += t0;
+        t2 = t1;
+        for (k = 0; k < l1; k++)
+        {
+            idij = is;
+            t3 = t2;
+            for (i = 2; i < ido; i += 2)
+            {
+                idij += 2;
+                t3 += 2;
+                c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
+                c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
+            }
+            t2 += ido;
+        }
+    }
+
+    return;
+}
+
+
+static void drftb1(int32_t n, float* c, float* ch, const float* wa, const int* ifac)
+{
+    int i = 0, k1 = 0, l1 = 0, l2 = 0;
+    int na = 0;
+    int nf = 0, ip = 0, iw = 0, ix2 = 0, ix3 = 0, ido = 0, idl1 = 0;
+
+    nf = ifac[1];
+    na = 0;
+    l1 = 1;
+    iw = 1;
+
+    for (k1 = 0; k1 < nf; k1++)
+    {
+        ip = ifac[k1 + 2];
+        l2 = ip * l1;
+        ido = n / l2;
+        idl1 = ido * l1;
+        if (ip != 4)
+            goto L103;
+        ix2 = iw + ido;
+        ix3 = ix2 + ido;
+
+        if (na != 0)
+            dradb4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+        else
+            dradb4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+        na = 1 - na;
+        goto L115;
+
+      L103:
+        if (ip != 2)
+            goto L106;
+
+        if (na != 0)
+            dradb2(ido, l1, ch, c, wa + iw - 1);
+        else
+            dradb2(ido, l1, c, ch, wa + iw - 1);
+        na = 1 - na;
+        goto L115;
+
+      L106:
+        if (ip != 3)
+            goto L109;
+
+        ix2 = iw + ido;
+        if (na != 0)
+            dradb3(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1);
+        else
+            dradb3(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1);
+        na = 1 - na;
+        goto L115;
+
+      L109:
+        if (na != 0)
+            dradbg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
+        else
+            dradbg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
+        if (ido == 1)
+            na = 1 - na;
+
+      L115:
+        l1 = l2;
+        iw += (ip - 1) * ido;
+    }
+
+    if (na == 0)
+        return;
+
+    for (i = 0; i < n; i++)
+        c[i] = ch[i];
+
+    return;
+}
+
+
+void rfft_backward(int32_t n, float* r, float* wsave, const int* ifac)
+{
+    rassert(n >= 1);
+    rassert(r != NULL);
+    rassert(wsave != NULL);
+    rassert(ifac != NULL);
+
+    if (n == 1)
+        return;
+
+    drftb1(n, r, wsave, wsave + n, ifac);
+
+    return;
+}
+
+

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -742,45 +742,44 @@ static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
         iw -= (ip - 1) * ido;
         na = 1 - na;
 
-        if (ip != 4)
-            goto L102;
+        if (ip == 4)
+        {
+            ix2 = iw + ido;
+            ix3 = ix2 + ido;
+            if (na != 0)
+                dradf4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
+            else
+                dradf4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
 
-        ix2 = iw + ido;
-        ix3 = ix2 + ido;
-        if (na != 0)
-            dradf4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
-        else
-            dradf4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
-        goto L110;
+            l2 = l1;
+            continue;
+        }
 
-      L102:
-        if (ip != 2)
-            goto L104;
-        if (na != 0)
-            goto L103;
+        if (ip == 2)
+        {
+            if (na == 0)
+                dradf2(ido, l1, c, ch, wa + iw - 1);
+            else
+                dradf2(ido, l1, ch, c, wa + iw - 1);
 
-        dradf2(ido, l1, c, ch, wa + iw - 1);
-        goto L110;
+            l2 = l1;
+            continue;
+        }
 
-      L103:
-        dradf2(ido, l1, ch, c, wa + iw - 1);
-        goto L110;
-
-      L104:
         if (ido == 1)
             na = 1 - na;
-        if (na != 0)
-            goto L109;
 
-        dradfg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
-        na = 1;
-        goto L110;
+        if (na == 0)
+        {
+            dradfg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
+            na = 1;
+        }
+        else
+        {
+            dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
+            na = 0;
+        }
 
-      L109:
-        dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
-        na = 0;
-
-      L110:
         l2 = l1;
     }
 

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -122,46 +122,45 @@ static void drfti1(int32_t n, float* wa, int* ifac)
 {
     const int ntryh[4] = { 4, 2, 3, 5 };
     float arg = 0, argh = 0, argld = 0, fi = 0;
-    int ntry = 0, i = 0, j = -1;
     int l1 = 0, l2 = 0;
     int ld = 0, ip = 0, nq = 0, nr = 0;
     int ido = 0, ipm = 0, nfm1 = 0;
-    int nl = n;
     int nf = 0;
 
-  L101:
-    j++;
-    if (j < 4)
-        ntry = ntryh[j];
-    else
-        ntry += 2;
-
-  L104:
-    nq = nl / ntry;
-    nr = nl - ntry * nq;
-    if (nr != 0)
-        goto L101;
-
-    nf++;
-    ifac[nf + 1] = ntry;
-    nl = nq;
-    if (ntry != 2)
-        goto L107;
-    if (nf == 1)
-        goto L107;
-
-    for (i = 1; i < nf; i++)
+    // Divide n into preferred set of factors
+    int test_index = 0;
+    int left = n;
+    while (left > 1)
     {
-        const int ib = nf - i + 1;
-        ifac[ib + 1] = ifac[ib];
-    }
-    ifac[2] = 2;
+        // Try dividing by numbers in ntryh followed by 7, 9, 11,...
+        const int ntry = (test_index < 4) ? ntryh[test_index] : test_index * 2 - 1;
 
-  L107:
-    if (nl != 1)
-        goto L104;
+        nq = left / ntry;
+        nr = left - ntry * nq;
+        if (nr != 0)
+        {
+            ++test_index;
+            continue;
+        }
+
+        nf++;
+        ifac[nf + 1] = ntry;
+        left = nq;
+
+        if ((ntry == 2) && (nf != 1))
+        {
+            for (int i = 1; i < nf; ++i)
+            {
+                const int ib = nf - i + 1;
+                ifac[ib + 1] = ifac[ib];
+            }
+            ifac[2] = 2;
+        }
+    }
+
     ifac[0] = n;
     ifac[1] = nf;
+
     argh = (float)(PI2 / n);
     int is = 0;
     nfm1 = nf - 1;
@@ -178,10 +177,10 @@ static void drfti1(int32_t n, float* wa, int* ifac)
         ido = n / l2;
         ipm = ip - 1;
 
-        for (j = 0; j < ipm; j++)
+        for (int j = 0; j < ipm; j++)
         {
             ld += l1;
-            i = is;
+            int i = is;
             argld = (float)ld * argh;
             fi = 0.0f;
             for (int ii = 2; ii < ido; ii += 2)

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -713,61 +713,52 @@ static void dradfg(
 
 static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
 {
-    int i = 0, k1 = 0, l1 = 0, l2 = 0;
-    int na = 0, kh = 0, nf = 0;
-    int ip = 0, iw = 0, ido = 0, idl1 = 0, ix2 = 0, ix3 = 0;
+    const int nf = ifac[1];
+    int na = 1;
+    int l2 = n;
+    int iw = n;
 
-    nf = ifac[1];
-    na = 1;
-    l2 = n;
-    iw = n;
-
-    for (k1 = 0; k1 < nf; k1++)
+    for (int k1 = 0; k1 < nf; k1++)
     {
-        kh = nf - k1;
-        ip = ifac[kh + 1];
-        l1 = l2 / ip;
-        ido = n / l2;
-        idl1 = ido * l1;
+        const int kh = nf - k1;
+        const int ip = ifac[kh + 1];
+        const int l1 = l2 / ip;
+        const int ido = n / l2;
+        const int idl1 = ido * l1;
         iw -= (ip - 1) * ido;
         na = 1 - na;
 
         if (ip == 4)
         {
-            ix2 = iw + ido;
-            ix3 = ix2 + ido;
+            const int ix2 = iw + ido;
+            const int ix3 = ix2 + ido;
             if (na != 0)
                 dradf4(ido, l1, ch, c, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
             else
                 dradf4(ido, l1, c, ch, wa + iw - 1, wa + ix2 - 1, wa + ix3 - 1);
-
-            l2 = l1;
-            continue;
         }
-
-        if (ip == 2)
+        else if (ip == 2)
         {
             if (na == 0)
                 dradf2(ido, l1, c, ch, wa + iw - 1);
             else
                 dradf2(ido, l1, ch, c, wa + iw - 1);
-
-            l2 = l1;
-            continue;
-        }
-
-        if (ido == 1)
-            na = 1 - na;
-
-        if (na == 0)
-        {
-            dradfg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
-            na = 1;
         }
         else
         {
-            dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
-            na = 0;
+            if (ido == 1)
+                na = 1 - na;
+
+            if (na == 0)
+            {
+                dradfg(ido, ip, l1, idl1, c, c, c, ch, ch, wa + iw - 1);
+                na = 1;
+            }
+            else
+            {
+                dradfg(ido, ip, l1, idl1, ch, ch, ch, c, c, wa + iw - 1);
+                na = 0;
+            }
         }
 
         l2 = l1;
@@ -776,7 +767,7 @@ static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
     if (na == 1)
         return;
 
-    for (i = 0; i < n; i++)
+    for (int i = 0; i < n; i++)
         c[i] = ch[i];
 
     return;
@@ -785,15 +776,14 @@ static void drftf1(int32_t n, float* c, float* ch, float* wa, const int* ifac)
 
 static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
 {
-    int i = 0, k = 0, t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
-    float ti2 = 0, tr2 = 0;
+    int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
 
     t0 = l1 * ido;
 
     t1 = 0;
     t2 = 0;
     t3 = (ido << 1) - 1;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         ch[t1] = cc[t2] + cc[t3 + t2];
         ch[t1 + t0] = cc[t2] - cc[t3 + t2];
@@ -807,21 +797,21 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
     {
         t1 = 0;
         t2 = 0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t3 = t1;
             t5 = (t4 = t2) + (ido << 1);
             t6 = t0 + t1;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 t3 += 2;
                 t4 += 2;
                 t5 -= 2;
                 t6 += 2;
                 ch[t3 - 1] = cc[t4 - 1] + cc[t5 - 1];
-                tr2 = cc[t4 - 1] - cc[t5 - 1];
+                const float tr2 = cc[t4 - 1] - cc[t5 - 1];
                 ch[t3] = cc[t4] - cc[t5];
-                ti2 = cc[t4] + cc[t5];
+                const float ti2 = cc[t4] + cc[t5];
                 ch[t6 - 1] = wa1[i - 2] * tr2 - wa1[i - 1] * ti2;
                 ch[t6] = wa1[i - 2] * ti2 + wa1[i - 1] * tr2;
             }
@@ -834,7 +824,7 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     t1 = ido - 1;
     t2 = ido - 1;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         ch[t1] = cc[t2] + cc[t2];
         ch[t1 + t0] = -(cc[t2 + 1] + cc[t2 + 1]);
@@ -851,11 +841,8 @@ static void dradb3(
 {
     const float taur = -0.5f;
     const float taui = 0.86602540378443864676372317075293618f;
-    int i = 0, k = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
     int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
-    float ci2 = 0, ci3 = 0, di2 = 0, di3 = 0, cr2 = 0, cr3 = 0;
-    float dr2 = 0, dr3 = 0, ti2 = 0, tr2 = 0;
 
     t0 = l1 * ido;
 
@@ -864,12 +851,12 @@ static void dradb3(
     t3 = ido << 1;
     t4 = ido + (ido << 1);
     t5 = 0;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
-        tr2 = cc[t3 - 1] + cc[t3 - 1];
-        cr2 = cc[t5] + (taur * tr2);
+        const float tr2 = cc[t3 - 1] + cc[t3 - 1];
+        const float cr2 = cc[t5] + (taur * tr2);
         ch[t1] = cc[t5] + tr2;
-        ci3 = taui * (cc[t3] + cc[t3]);
+        const float ci3 = taui * (cc[t3] + cc[t3]);
         ch[t1 + t0] = cr2 - ci3;
         ch[t1 + t2] = cr2 + ci3;
         t1 += ido;
@@ -882,14 +869,14 @@ static void dradb3(
 
     t1 = 0;
     t3 = ido << 1;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         t7 = t1 + (t1 << 1);
         t6 = (t5 = t7 + t3);
         t8 = t1;
         t10 = (t9 = t1 + t0) + t0;
 
-        for (i = 2; i < ido; i += 2)
+        for (int i = 2; i < ido; i += 2)
         {
             t5 += 2;
             t6 -= 2;
@@ -897,18 +884,18 @@ static void dradb3(
             t8 += 2;
             t9 += 2;
             t10 += 2;
-            tr2 = cc[t5 - 1] + cc[t6 - 1];
-            cr2 = cc[t7 - 1] + (taur * tr2);
+            const float tr2 = cc[t5 - 1] + cc[t6 - 1];
+            const float cr2 = cc[t7 - 1] + (taur * tr2);
             ch[t8 - 1] = cc[t7 - 1] + tr2;
-            ti2 =cc[t5] - cc[t6];
-            ci2 =cc[t7] + (taur * ti2);
+            const float ti2 = cc[t5] - cc[t6];
+            const float ci2 = cc[t7] + (taur * ti2);
             ch[t8] = cc[t7] + ti2;
-            cr3 = taui * (cc[t5 - 1] - cc[t6 - 1]);
-            ci3 = taui * (cc[t5] + cc[t6]);
-            dr2 = cr2 - ci3;
-            dr3 = cr2 + ci3;
-            di2 = ci2 + cr3;
-            di3 = ci2 - cr3;
+            const float cr3 = taui * (cc[t5 - 1] - cc[t6 - 1]);
+            const float ci3 = taui * (cc[t5] + cc[t6]);
+            const float dr2 = cr2 - ci3;
+            const float dr3 = cr2 + ci3;
+            const float di2 = ci2 + cr3;
+            const float di3 = ci2 - cr3;
             ch[t9 - 1] = wa1[i - 2] * dr2 - wa1[i - 1] * di2;
             ch[t9] = wa1[i - 2] * di2 + wa1[i - 1] * dr2;
             ch[t10 - 1] = wa2[i - 2] * dr3 - wa2[i - 1] * di3;
@@ -925,11 +912,7 @@ static void dradb4(
         int ido, int l1, float* cc, float* ch,
         const float* wa1, const float* wa2, const float* wa3)
 {
-    const float sqrt2 = 1.4142135623730950488016887242097f;
-    int i = 0, k = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0, t7 = 0, t8 = 0;
-    float ci2 = 0, ci3 = 0, ci4 = 0, cr2 = 0, cr3 = 0, cr4 = 0;
-    float ti1 = 0, ti2 = 0, ti3 = 0, ti4 = 0, tr1 = 0, tr2 = 0, tr3 = 0, tr4 = 0;
 
     t0 = l1 * ido;
 
@@ -937,14 +920,14 @@ static void dradb4(
     t2 = ido << 2;
     t3 = 0;
     t6 = ido << 1;
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         t4 = t3 + t6;
         t5 = t1;
-        tr3 = cc[t4 - 1] + cc[t4 - 1];
-        tr4 = cc[t4] + cc[t4];
-        tr1 = cc[t3] - cc[(t4 += t6) - 1];
-        tr2 = cc[t3] + cc[t4 - 1];
+        const float tr3 = cc[t4 - 1] + cc[t4 - 1];
+        const float tr4 = cc[t4] + cc[t4];
+        const float tr1 = cc[t3] - cc[(t4 += t6) - 1];
+        const float tr2 = cc[t3] + cc[t4 - 1];
         ch[t5] = tr2 + tr3;
         ch[t5 += t0] = tr1 - tr4;
         ch[t5 += t0] = tr2 - tr3;
@@ -959,35 +942,35 @@ static void dradb4(
     if (ido != 2)
     {
         t1 = 0;
-        for (k = 0; k < l1; k++)
+        for (int k = 0; k < l1; k++)
         {
             t5 = (t4 = (t3 = (t2 = t1 << 2) + t6)) + t6;
             t7 = t1;
-            for (i = 2; i < ido; i += 2)
+            for (int i = 2; i < ido; i += 2)
             {
                 t2 += 2;
                 t3 += 2;
                 t4 -= 2;
                 t5 -= 2;
                 t7 += 2;
-                ti1 = cc[t2] + cc[t5];
-                ti2 = cc[t2] - cc[t5];
-                ti3 = cc[t3] - cc[t4];
-                tr4 = cc[t3] + cc[t4];
-                tr1 = cc[t2 - 1] - cc[t5 - 1];
-                tr2 = cc[t2 - 1] + cc[t5 - 1];
-                ti4 = cc[t3 - 1] - cc[t4 - 1];
-                tr3 = cc[t3 - 1] + cc[t4 - 1];
+                const float ti1 = cc[t2] + cc[t5];
+                const float ti2 = cc[t2] - cc[t5];
+                const float ti3 = cc[t3] - cc[t4];
+                const float tr4 = cc[t3] + cc[t4];
+                const float tr1 = cc[t2 - 1] - cc[t5 - 1];
+                const float tr2 = cc[t2 - 1] + cc[t5 - 1];
+                const float ti4 = cc[t3 - 1] - cc[t4 - 1];
+                const float tr3 = cc[t3 - 1] + cc[t4 - 1];
                 ch[t7 - 1] = tr2 + tr3;
-                cr3 = tr2 - tr3;
+                const float cr3 = tr2 - tr3;
                 ch[t7] = ti2 + ti3;
-                ci3 = ti2 - ti3;
-                cr2 = tr1 - tr4;
-                cr4 = tr1 + tr4;
-                ci2 = ti1 + ti4;
-                ci4 = ti1 - ti4;
+                const float ci3 = ti2 - ti3;
+                const float cr2 = tr1 - tr4;
+                const float cr4 = tr1 + tr4;
+                const float ci2 = ti1 + ti4;
+                const float ci4 = ti1 - ti4;
 
-                ch[(t8 = t7 + t0) - 1] = wa1[i - 2] * cr2 - wa1[i - 1]*ci2;
+                ch[(t8 = t7 + t0) - 1] = wa1[i - 2] * cr2 - wa1[i - 1] * ci2;
                 ch[t8] = wa1[i - 2] * ci2 + wa1[i - 1] * cr2;
                 ch[(t8 += t0) - 1] = wa2[i - 2] * cr3 - wa2[i - 1] * ci3;
                 ch[t8] = wa2[i - 2] * ci3 + wa2[i - 1] * cr3;
@@ -1001,17 +984,19 @@ static void dradb4(
             return;
     }
 
+    const float sqrt2 = 1.4142135623730950488016887242097f;
+
     t1 = ido;
     t2 = ido << 2;
     t3 = ido - 1;
     t4 = ido + (ido << 1);
-    for (k = 0; k < l1; k++)
+    for (int k = 0; k < l1; k++)
     {
         t5 = t3;
-        ti1 = cc[t1] + cc[t4];
-        ti2 = cc[t4] - cc[t1];
-        tr1 = cc[t1 - 1] - cc[t4 - 1];
-        tr2 = cc[t1 - 1] + cc[t4 - 1];
+        const float ti1 = cc[t1] + cc[t4];
+        const float ti2 = cc[t4] - cc[t1];
+        const float tr1 = cc[t1 - 1] - cc[t4 - 1];
+        const float tr2 = cc[t1 - 1] + cc[t4 - 1];
         ch[t5] = tr2 + tr2;
         ch[t5 += t0] = sqrt2 * (tr1 - ti1);
         ch[t5 += t0] = ti2 + ti2;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -812,36 +812,36 @@ static void dradb2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     if (ido < 2)
         return;
-    if (ido == 2)
-        goto L105;
 
-    t1 = 0;
-    t2 = 0;
-    for (k = 0; k < l1; k++)
+    if (ido != 2)
     {
-        t3 = t1;
-        t5 = (t4 = t2) + (ido << 1);
-        t6 = t0 + t1;
-        for (i = 2; i < ido; i += 2)
+        t1 = 0;
+        t2 = 0;
+        for (k = 0; k < l1; k++)
         {
-            t3 += 2;
-            t4 += 2;
-            t5 -= 2;
-            t6 += 2;
-            ch[t3 - 1] = cc[t4 - 1] + cc[t5 - 1];
-            tr2 = cc[t4 - 1] - cc[t5 - 1];
-            ch[t3] = cc[t4] - cc[t5];
-            ti2 = cc[t4] + cc[t5];
-            ch[t6 - 1] = wa1[i - 2] * tr2 - wa1[i - 1] * ti2;
-            ch[t6] = wa1[i - 2] * ti2 + wa1[i - 1] * tr2;
+            t3 = t1;
+            t5 = (t4 = t2) + (ido << 1);
+            t6 = t0 + t1;
+            for (i = 2; i < ido; i += 2)
+            {
+                t3 += 2;
+                t4 += 2;
+                t5 -= 2;
+                t6 += 2;
+                ch[t3 - 1] = cc[t4 - 1] + cc[t5 - 1];
+                tr2 = cc[t4 - 1] - cc[t5 - 1];
+                ch[t3] = cc[t4] - cc[t5];
+                ti2 = cc[t4] + cc[t5];
+                ch[t6 - 1] = wa1[i - 2] * tr2 - wa1[i - 1] * ti2;
+                ch[t6] = wa1[i - 2] * ti2 + wa1[i - 1] * tr2;
+            }
+            t2 = (t1 += ido) << 1;
         }
-        t2 = (t1 += ido) << 1;
+
+        if (ido % 2 == 1)
+            return;
     }
 
-    if (ido % 2 == 1)
-        return;
-
-  L105:
     t1 = ido - 1;
     t2 = ido - 1;
     for (k = 0; k < l1; k++)
@@ -965,52 +965,51 @@ static void dradb4(
 
     if (ido < 2)
         return;
-    if (ido == 2)
-        goto L105;
 
-    t1 = 0;
-    for (k = 0; k < l1; k++)
+    if (ido != 2)
     {
-        t5 = (t4 = (t3 = (t2 = t1 << 2) + t6)) + t6;
-        t7 = t1;
-        for (i = 2; i < ido; i += 2)
+        t1 = 0;
+        for (k = 0; k < l1; k++)
         {
-            t2 += 2;
-            t3 += 2;
-            t4 -= 2;
-            t5 -= 2;
-            t7 += 2;
-            ti1 = cc[t2] + cc[t5];
-            ti2 = cc[t2] - cc[t5];
-            ti3 = cc[t3] - cc[t4];
-            tr4 = cc[t3] + cc[t4];
-            tr1 = cc[t2 - 1] - cc[t5 - 1];
-            tr2 = cc[t2 - 1] + cc[t5 - 1];
-            ti4 = cc[t3 - 1] - cc[t4 - 1];
-            tr3 = cc[t3 - 1] + cc[t4 - 1];
-            ch[t7 - 1] = tr2 + tr3;
-            cr3 = tr2 - tr3;
-            ch[t7] = ti2 + ti3;
-            ci3 = ti2 - ti3;
-            cr2 = tr1 - tr4;
-            cr4 = tr1 + tr4;
-            ci2 = ti1 + ti4;
-            ci4 = ti1 - ti4;
+            t5 = (t4 = (t3 = (t2 = t1 << 2) + t6)) + t6;
+            t7 = t1;
+            for (i = 2; i < ido; i += 2)
+            {
+                t2 += 2;
+                t3 += 2;
+                t4 -= 2;
+                t5 -= 2;
+                t7 += 2;
+                ti1 = cc[t2] + cc[t5];
+                ti2 = cc[t2] - cc[t5];
+                ti3 = cc[t3] - cc[t4];
+                tr4 = cc[t3] + cc[t4];
+                tr1 = cc[t2 - 1] - cc[t5 - 1];
+                tr2 = cc[t2 - 1] + cc[t5 - 1];
+                ti4 = cc[t3 - 1] - cc[t4 - 1];
+                tr3 = cc[t3 - 1] + cc[t4 - 1];
+                ch[t7 - 1] = tr2 + tr3;
+                cr3 = tr2 - tr3;
+                ch[t7] = ti2 + ti3;
+                ci3 = ti2 - ti3;
+                cr2 = tr1 - tr4;
+                cr4 = tr1 + tr4;
+                ci2 = ti1 + ti4;
+                ci4 = ti1 - ti4;
 
-            ch[(t8 = t7 + t0) - 1] = wa1[i - 2] * cr2 - wa1[i - 1]*ci2;
-            ch[t8] = wa1[i - 2] * ci2 + wa1[i - 1] * cr2;
-            ch[(t8 += t0) - 1] = wa2[i - 2] * cr3 - wa2[i - 1] * ci3;
-            ch[t8] = wa2[i - 2] * ci3 + wa2[i - 1] * cr3;
-            ch[(t8 += t0) - 1] = wa3[i - 2] * cr4 - wa3[i - 1] * ci4;
-            ch[t8] = wa3[i - 2] * ci4 + wa3[i - 1] * cr4;
+                ch[(t8 = t7 + t0) - 1] = wa1[i - 2] * cr2 - wa1[i - 1]*ci2;
+                ch[t8] = wa1[i - 2] * ci2 + wa1[i - 1] * cr2;
+                ch[(t8 += t0) - 1] = wa2[i - 2] * cr3 - wa2[i - 1] * ci3;
+                ch[t8] = wa2[i - 2] * ci3 + wa2[i - 1] * cr3;
+                ch[(t8 += t0) - 1] = wa3[i - 2] * cr4 - wa3[i - 1] * ci4;
+                ch[t8] = wa3[i - 2] * ci4 + wa3[i - 1] * cr4;
+            }
+            t1 += ido;
         }
-        t1 += ido;
+
+        if (ido % 2 == 1)
+            return;
     }
-
-    if (ido % 2 == 1)
-        return;
-
-  L105:
 
     t1 = ido;
     t2 = ido << 2;
@@ -1057,42 +1056,42 @@ static void dradbg(
     nbd = (ido - 1) >> 1;
     ipp2 = ip;
     ipph = (ip + 1) >> 1;
-    if (ido < l1)
-        goto L103;
 
-    t1 = 0;
-    t2 = 0;
-    for (k = 0; k < l1; k++)
+    if (ido >= l1)
     {
-        t3 = t1;
-        t4 = t2;
-        for (i = 0; i < ido; i++)
-        {
-            ch[t3] = cc[t4];
-            t3++;
-            t4++;
-        }
-        t1 += ido;
-        t2 += t10;
-    }
-    goto L106;
-
-  L103:
-    t1 = 0;
-    for (i = 0; i < ido; i++)
-    {
-        t2 = t1;
-        t3 = t1;
+        t1 = 0;
+        t2 = 0;
         for (k = 0; k < l1; k++)
         {
-            ch[t2] = cc[t3];
-            t2 += ido;
-            t3 += t10;
+            t3 = t1;
+            t4 = t2;
+            for (i = 0; i < ido; i++)
+            {
+                ch[t3] = cc[t4];
+                t3++;
+                t4++;
+            }
+            t1 += ido;
+            t2 += t10;
         }
-        t1++;
+    }
+    else
+    {
+        t1 = 0;
+        for (i = 0; i < ido; i++)
+        {
+            t2 = t1;
+            t3 = t1;
+            for (k = 0; k < l1; k++)
+            {
+                ch[t2] = cc[t3];
+                t2 += ido;
+                t3 += t10;
+            }
+            t1++;
+        }
     }
 
-  L106:
     t1 = 0;
     t2 = ipp2 * t0;
     t7 = (t5 = ido << 1);
@@ -1114,85 +1113,85 @@ static void dradbg(
         t5 += t7;
     }
 
-    if (ido == 1)
-        goto L116;
-    if (nbd < l1)
-        goto L112;
-
-    t1 = 0;
-    t2 = ipp2 * t0;
-    t7 = 0;
-    for (j = 1; j < ipph; j++)
+    if (ido != 1)
     {
-        t1 += t0;
-        t2 -= t0;
-        t3 = t1;
-        t4 = t2;
-
-        t7+=(ido<<1);
-        t8=t7;
-        for (k = 0; k < l1; k++)
+        if (nbd >= l1)
         {
-            t5 = t3;
-            t6 = t4;
-            t9 = t8;
-            t11 = t8;
-            for (i = 2; i < ido; i += 2)
+            t1 = 0;
+            t2 = ipp2 * t0;
+            t7 = 0;
+            for (j = 1; j < ipph; j++)
             {
-                t5 += 2;
-                t6 += 2;
-                t9 += 2;
-                t11 -= 2;
-                ch[t5 - 1] = cc[t9 - 1] + cc[t11 - 1];
-                ch[t6 - 1] = cc[t9 - 1] - cc[t11 - 1];
-                ch[t5] = cc[t9] - cc[t11];
-                ch[t6] = cc[t9] + cc[t11];
-            }
-            t3 += ido;
-            t4 += ido;
-            t8 += t10;
-        }
-    }
-    goto L116;
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
 
-  L112:
-    t1 = 0;
-    t2 = ipp2 * t0;
-    t7 = 0;
-    for (j = 1; j < ipph; j++)
-    {
-        t1 += t0;
-        t2 -= t0;
-        t3 = t1;
-        t4 = t2;
-        t7 += (ido << 1);
-        t8 = t7;
-        t9 = t7;
-        for (i = 2; i < ido; i += 2)
-        {
-            t3 += 2;
-            t4 += 2;
-            t8 += 2;
-            t9 -= 2;
-            t5 = t3;
-            t6 = t4;
-            t11 = t8;
-            t12 = t9;
-            for (k = 0; k < l1; k++)
-            {
-                ch[t5 - 1] = cc[t11 - 1] + cc[t12 - 1];
-                ch[t6 - 1] = cc[t11 - 1] - cc[t12 - 1];
-                ch[t5] = cc[t11] - cc[t12];
-                ch[t6] = cc[t11] + cc[t12];
-                t5 += ido;
-                t6 += ido;
-                t11 += t10;
-                t12 += t10;
+                t7 += (ido << 1);
+                t8 = t7;
+                for (k = 0; k < l1; k++)
+                {
+                    t5 = t3;
+                    t6 = t4;
+                    t9 = t8;
+                    t11 = t8;
+                    for (i = 2; i < ido; i += 2)
+                    {
+                        t5 += 2;
+                        t6 += 2;
+                        t9 += 2;
+                        t11 -= 2;
+                        ch[t5 - 1] = cc[t9 - 1] + cc[t11 - 1];
+                        ch[t6 - 1] = cc[t9 - 1] - cc[t11 - 1];
+                        ch[t5] = cc[t9] - cc[t11];
+                        ch[t6] = cc[t9] + cc[t11];
+                    }
+                    t3 += ido;
+                    t4 += ido;
+                    t8 += t10;
+                }
             }
         }
+        else
+        {
+            t1 = 0;
+            t2 = ipp2 * t0;
+            t7 = 0;
+            for (j = 1; j < ipph; j++)
+            {
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
+                t7 += (ido << 1);
+                t8 = t7;
+                t9 = t7;
+                for (i = 2; i < ido; i += 2)
+                {
+                    t3 += 2;
+                    t4 += 2;
+                    t8 += 2;
+                    t9 -= 2;
+                    t5 = t3;
+                    t6 = t4;
+                    t11 = t8;
+                    t12 = t9;
+                    for (k = 0; k < l1; k++)
+                    {
+                        ch[t5 - 1] = cc[t11 - 1] + cc[t12 - 1];
+                        ch[t6 - 1] = cc[t11 - 1] - cc[t12 - 1];
+                        ch[t5] = cc[t11] - cc[t12];
+                        ch[t6] = cc[t11] + cc[t12];
+                        t5 += ido;
+                        t6 += ido;
+                        t11 += t10;
+                        t12 += t10;
+                    }
+                }
+            }
+        }
     }
 
-  L116:
     ar1 = 1.0f;
     ai1 = 0.0f;
     t1 = 0;
@@ -1268,66 +1267,66 @@ static void dradbg(
         }
     }
 
-    if (ido == 1)
-        goto L132;
-    if (nbd < l1)
-        goto L128;
-
-    t1 = 0;
-    t2 = ipp2 * t0;
-    for (j = 1; j < ipph; j++)
+    if (ido != 1)
     {
-        t1 += t0;
-        t2 -= t0;
-        t3 = t1;
-        t4 = t2;
-        for (k = 0; k < l1; k++)
+        if (nbd >= l1)
         {
-            t5 = t3;
-            t6 = t4;
-            for (i = 2; i < ido; i += 2)
+            t1 = 0;
+            t2 = ipp2 * t0;
+            for (j = 1; j < ipph; j++)
             {
-                t5 += 2;
-                t6 += 2;
-                ch[t5 - 1] = c1[t5 - 1] - c1[t6];
-                ch[t6 - 1] = c1[t5 - 1] + c1[t6];
-                ch[t5] = c1[t5] + c1[t6 - 1];
-                ch[t6] = c1[t5] - c1[t6 - 1];
-            }
-            t3 += ido;
-            t4 += ido;
-        }
-    }
-    goto L132;
-
-  L128:
-    t1 = 0;
-    t2 = ipp2 * t0;
-    for (j = 1; j < ipph; j++)
-    {
-        t1 += t0;
-        t2 -= t0;
-        t3 = t1;
-        t4 = t2;
-        for (i = 2; i < ido; i += 2)
-        {
-            t3 += 2;
-            t4 += 2;
-            t5 = t3;
-            t6 = t4;
-            for (k = 0; k < l1; k++)
-            {
-                ch[t5 - 1] = c1[t5 - 1] - c1[t6];
-                ch[t6 - 1] = c1[t5 - 1] + c1[t6];
-                ch[t5] = c1[t5] + c1[t6 - 1];
-                ch[t6] = c1[t5] - c1[t6 - 1];
-                t5 += ido;
-                t6 += ido;
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
+                for (k = 0; k < l1; k++)
+                {
+                    t5 = t3;
+                    t6 = t4;
+                    for (i = 2; i < ido; i += 2)
+                    {
+                        t5 += 2;
+                        t6 += 2;
+                        ch[t5 - 1] = c1[t5 - 1] - c1[t6];
+                        ch[t6 - 1] = c1[t5 - 1] + c1[t6];
+                        ch[t5] = c1[t5] + c1[t6 - 1];
+                        ch[t6] = c1[t5] - c1[t6 - 1];
+                    }
+                    t3 += ido;
+                    t4 += ido;
+                }
             }
         }
+        else
+        {
+            t1 = 0;
+            t2 = ipp2 * t0;
+            for (j = 1; j < ipph; j++)
+            {
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
+                for (i = 2; i < ido; i += 2)
+                {
+                    t3 += 2;
+                    t4 += 2;
+                    t5 = t3;
+                    t6 = t4;
+                    for (k = 0; k < l1; k++)
+                    {
+                        ch[t5 - 1] = c1[t5 - 1] - c1[t6];
+                        ch[t6 - 1] = c1[t5 - 1] + c1[t6];
+                        ch[t5] = c1[t5] + c1[t6 - 1];
+                        ch[t6] = c1[t5] - c1[t6 - 1];
+                        t5 += ido;
+                        t6 += ido;
+                    }
+                }
+            }
+        }
     }
 
-  L132:
     if (ido == 1)
         return;
 
@@ -1345,33 +1344,32 @@ static void dradbg(
         }
     }
 
-    if (nbd > l1)
-        goto L139;
-
-    is = -ido - 1;
-    t1 = 0;
-    for (j = 1; j < ip; j++)
+    if (nbd <= l1)
     {
-        is += ido;
-        t1 += t0;
-        idij = is;
-        t2 = t1;
-        for (i = 2; i < ido; i += 2)
+        is = -ido - 1;
+        t1 = 0;
+        for (j = 1; j < ip; j++)
         {
-            t2 += 2;
-            idij += 2;
-            t3 = t2;
-            for (k = 0; k < l1; k++)
+            is += ido;
+            t1 += t0;
+            idij = is;
+            t2 = t1;
+            for (i = 2; i < ido; i += 2)
             {
-                c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
-                c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
-                t3 += ido;
+                t2 += 2;
+                idij += 2;
+                t3 = t2;
+                for (k = 0; k < l1; k++)
+                {
+                    c1[t3 - 1] = wa[idij - 1] * ch[t3 - 1] - wa[idij] * ch[t3];
+                    c1[t3] = wa[idij - 1] * ch[t3] + wa[idij] * ch[t3 - 1];
+                    t3 += ido;
+                }
             }
         }
+        return;
     }
-    return;
 
-  L139:
     is = -ido - 1;
     t1 = 0;
     for (j = 1; j < ip; j++)

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -396,126 +396,126 @@ static void dradfg(
     t0 = l1 * ido;
     t10 = ip * ido;
 
-    if (ido == 1)
-        goto L119;
-    for (ik = 0; ik < idl1; ik++)
-        ch2[ik] = c2[ik];
-
-    t1 = 0;
-    for (j = 1; j < ip; j++)
+    if (ido != 1)
     {
-        t1 += t0;
-        t2 = t1;
-        for (k = 0; k < l1; k++)
-        {
-            ch[t2] = c1[t2];
-            t2 += ido;
-        }
-    }
+        for (ik = 0; ik < idl1; ik++)
+            ch2[ik] = c2[ik];
 
-    is = -ido;
-    t1 = 0;
-    if (nbd > l1)
-    {
+        t1 = 0;
         for (j = 1; j < ip; j++)
         {
             t1 += t0;
-            is += ido;
-            t2 = -ido + t1;
+            t2 = t1;
             for (k = 0; k < l1; k++)
             {
-                idij = is - 1;
+                ch[t2] = c1[t2];
                 t2 += ido;
-                t3 = t2;
+            }
+        }
+
+        is = -ido;
+        t1 = 0;
+        if (nbd > l1)
+        {
+            for (j = 1; j < ip; j++)
+            {
+                t1 += t0;
+                is += ido;
+                t2 = -ido + t1;
+                for (k = 0; k < l1; k++)
+                {
+                    idij = is - 1;
+                    t2 += ido;
+                    t3 = t2;
+                    for (i = 2; i < ido; i += 2)
+                    {
+                        idij += 2;
+                        t3 += 2;
+                        ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
+                        ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (j = 1; j < ip; j++)
+            {
+                is += ido;
+                idij = is - 1;
+                t1 += t0;
+                t2 = t1;
                 for (i = 2; i < ido; i += 2)
                 {
                     idij += 2;
-                    t3 += 2;
-                    ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
-                    ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
+                    t2 += 2;
+                    t3 = t2;
+                    for (k = 0; k < l1; k++)
+                    {
+                        ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
+                        ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
+                        t3 += ido;
+                    }
                 }
             }
         }
-    }
-    else
-    {
-        for (j = 1; j < ip; j++)
-        {
-            is += ido;
-            idij = is - 1;
-            t1 += t0;
-            t2 = t1;
-            for (i = 2; i < ido; i += 2)
-            {
-                idij += 2;
-                t2 += 2;
-                t3 = t2;
-                for (k = 0; k < l1; k++)
-                {
-                    ch[t3 - 1] = wa[idij - 1] * c1[t3 - 1] + wa[idij] * c1[t3];
-                    ch[t3] = wa[idij - 1] * c1[t3] - wa[idij] * c1[t3 - 1];
-                    t3 += ido;
-                }
-            }
-        }
-    }
 
-    t1 = 0;
-    t2 = ipp2 * t0;
-    if (nbd < l1)
-    {
-        for (j = 1; j < ipph; j++)
+        t1 = 0;
+        t2 = ipp2 * t0;
+        if (nbd < l1)
         {
-            t1 += t0;
-            t2 -= t0;
-            t3 = t1;
-            t4 = t2;
-            for (i = 2; i < ido; i += 2)
+            for (j = 1; j < ipph; j++)
             {
-                t3 += 2;
-                t4 += 2;
-                t5 = t3 - ido;
-                t6 = t4 - ido;
-                for (k = 0; k < l1; k++)
-                {
-                    t5 += ido;
-                    t6 += ido;
-                    c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
-                    c1[t6 - 1] = ch[t5] - ch[t6];
-                    c1[t5] = ch[t5] + ch[t6];
-                    c1[t6] = ch[t6 - 1] - ch[t5 - 1];
-                }
-            }
-        }
-    }
-    else
-    {
-        for (j = 1; j < ipph; j++)
-        {
-            t1 += t0;
-            t2 -= t0;
-            t3 = t1;
-            t4 = t2;
-            for (k = 0; k < l1; k++)
-            {
-                t5 = t3;
-                t6 = t4;
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
                 for (i = 2; i < ido; i += 2)
                 {
-                    t5 += 2;
-                    t6 += 2;
-                    c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
-                    c1[t6 - 1] = ch[t5] - ch[t6];
-                    c1[t5] = ch[t5] + ch[t6];
-                    c1[t6] = ch[t6 - 1] - ch[t5 - 1];
+                    t3 += 2;
+                    t4 += 2;
+                    t5 = t3 - ido;
+                    t6 = t4 - ido;
+                    for (k = 0; k < l1; k++)
+                    {
+                        t5 += ido;
+                        t6 += ido;
+                        c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
+                        c1[t6 - 1] = ch[t5] - ch[t6];
+                        c1[t5] = ch[t5] + ch[t6];
+                        c1[t6] = ch[t6 - 1] - ch[t5 - 1];
+                    }
                 }
-                t3 += ido;
-                t4 += ido;
+            }
+        }
+        else
+        {
+            for (j = 1; j < ipph; j++)
+            {
+                t1 += t0;
+                t2 -= t0;
+                t3 = t1;
+                t4 = t2;
+                for (k = 0; k < l1; k++)
+                {
+                    t5 = t3;
+                    t6 = t4;
+                    for (i = 2; i < ido; i += 2)
+                    {
+                        t5 += 2;
+                        t6 += 2;
+                        c1[t5 - 1] = ch[t5 - 1] + ch[t6 - 1];
+                        c1[t6 - 1] = ch[t5] - ch[t6];
+                        c1[t5] = ch[t5] + ch[t6];
+                        c1[t6] = ch[t6 - 1] - ch[t5 - 1];
+                    }
+                    t3 += ido;
+                    t4 += ido;
+                }
             }
         }
     }
 
-  L119:
     for (ik = 0; ik < idl1; ik++)
         c2[ik] = ch2[ik];
 
@@ -596,37 +596,35 @@ static void dradfg(
             ch2[ik] += c2[t2++];
     }
 
-    if (ido < l1)
-        goto L132;
-
-    t1 = 0;
-    t2 = 0;
-    for (k = 0; k < l1; k++)
+    if (ido >= l1)
     {
-        t3 = t1;
-        t4 = t2;
         for (i = 0; i < ido; i++)
-            cc[t4++] = ch[t3++];
-        t1 += ido;
-        t2 += t10;
+        {
+            t1 = i;
+            t2 = i;
+            for (k = 0; k < l1; k++)
+            {
+                cc[t2] = ch[t1];
+                t1 += ido;
+                t2 += t10;
+            }
+        }
     }
-
-    goto L135;
-
-  L132:
-    for (i = 0; i < ido; i++)
+    else
     {
-        t1 = i;
-        t2 = i;
+        t1 = 0;
+        t2 = 0;
         for (k = 0; k < l1; k++)
         {
-            cc[t2] = ch[t1];
+            t3 = t1;
+            t4 = t2;
+            for (i = 0; i < ido; i++)
+                cc[t4++] = ch[t3++];
             t1 += ido;
             t2 += t10;
         }
     }
 
-  L135:
     t1 = 0;
     t2 = ido << 1;
     t3 = 0;
@@ -653,42 +651,41 @@ static void dradfg(
 
     if (ido == 1)
         return;
-    if (nbd < l1)
-        goto L141;
 
-    t1 = -ido;
-    t3 = 0;
-    t4 = 0;
-    t5 = ipp2*t0;
-    for (j = 1; j < ipph; j++)
+    if (nbd >= l1)
     {
-        t1 += t2;
-        t3 += t2;
-        t4 += t0;
-        t5 -= t0;
-        t6 = t1;
-        t7 = t3;
-        t8 = t4;
-        t9 = t5;
-        for (k = 0; k < l1; k++)
+        t1 = -ido;
+        t3 = 0;
+        t4 = 0;
+        t5 = ipp2*t0;
+        for (j = 1; j < ipph; j++)
         {
-            for (i = 2; i < ido; i += 2)
+            t1 += t2;
+            t3 += t2;
+            t4 += t0;
+            t5 -= t0;
+            t6 = t1;
+            t7 = t3;
+            t8 = t4;
+            t9 = t5;
+            for (k = 0; k < l1; k++)
             {
-                ic = idp2 - i;
-                cc[i + t7 - 1] = ch[i + t8 - 1] + ch[i + t9 - 1];
-                cc[ic + t6 - 1] = ch[i + t8 - 1] - ch[i + t9 - 1];
-                cc[i + t7] = ch[i + t8] + ch[i + t9];
-                cc[ic + t6] = ch[i + t9] - ch[i + t8];
+                for (i = 2; i < ido; i += 2)
+                {
+                    ic = idp2 - i;
+                    cc[i + t7 - 1] = ch[i + t8 - 1] + ch[i + t9 - 1];
+                    cc[ic + t6 - 1] = ch[i + t8 - 1] - ch[i + t9 - 1];
+                    cc[i + t7] = ch[i + t8] + ch[i + t9];
+                    cc[ic + t6] = ch[i + t9] - ch[i + t8];
+                }
+                t6 += t10;
+                t7 += t10;
+                t8 += ido;
+                t9 += ido;
             }
-            t6 += t10;
-            t7 += t10;
-            t8 += ido;
-            t9 += ido;
         }
+        return;
     }
-    return;
-
-  L141:
 
     t1 = -ido;
     t3 = 0;
@@ -708,8 +705,8 @@ static void dradfg(
             t9 = i + t5;
             for (k = 0; k < l1; k++)
             {
-                cc[t7-1] = ch[t8 - 1] + ch[t9 - 1];
-                cc[t6-1] = ch[t8 - 1] - ch[t9 - 1];
+                cc[t7 - 1] = ch[t8 - 1] + ch[t9 - 1];
+                cc[t6 - 1] = ch[t8 - 1] - ch[t9 - 1];
                 cc[t7] = ch[t8] + ch[t9];
                 cc[t6] = ch[t9] - ch[t8];
                 t6 += t10;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -13,8 +13,10 @@
  */
 
 
-#include <debug/assert.h>
 #include <mathnum/fft.h>
+
+#include <debug/assert.h>
+#include <mathnum/common.h>
 #include <memory.h>
 
 #include <math.h>
@@ -119,7 +121,6 @@ void FFT_worker_deinit(FFT_worker* worker)
 static void drfti1(int32_t n, float* wa, int* ifac)
 {
     const int ntryh[4] = { 4, 2, 3, 5 };
-    const float tpi = 6.28318530717958647692528676655900577f;
     float arg = 0, argh = 0, argld = 0, fi = 0;
     int ntry = 0, i = 0, j = -1;
     int l1 = 0, l2 = 0;
@@ -161,7 +162,7 @@ static void drfti1(int32_t n, float* wa, int* ifac)
         goto L104;
     ifac[0] = n;
     ifac[1] = nf;
-    argh = tpi / (float)n;
+    argh = (float)(PI2 / n);
     int is = 0;
     nfm1 = nf - 1;
     l1 = 1;
@@ -379,7 +380,6 @@ static void dradfg(
         int ido, int ip, int l1, int idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, float* wa)
 {
-    const float tpi = 6.28318530717958647692528676655900577f;
     int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ic = 0, ik = 0, is = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0;
     int t6 = 0, t7 = 0, t8 = 0, t9 = 0, t10 = 0;
@@ -388,7 +388,7 @@ static void dradfg(
     float dcp = 0, arg = 0, dsp = 0, ar1h = 0, ar2h = 0;
     int idp2 = 0, ipp2 = 0;
 
-    arg = tpi / (float)ip;
+    arg = (float)(PI2 / ip);
     dcp = cosf(arg);
     dsp = sinf(arg);
     ipph = (ip + 1) >> 1;
@@ -1047,7 +1047,6 @@ static void dradbg(
         int ido, int ip, int l1, int idl1, float* cc, float* c1,
         float* c2, float* ch, float* ch2, const float* wa)
 {
-    const float tpi = 6.28318530717958647692528676655900577f;
     int idij = 0, ipph = 0, i = 0, j = 0, k = 0, l = 0, ik = 0, is = 0;
     int t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0, t5 = 0, t6 = 0;
     int t7 = 0, t8 = 0, t9 = 0, t10 = 0, t11 = 0, t12 = 0;
@@ -1058,7 +1057,7 @@ static void dradbg(
 
     t10 = ip * ido;
     t0 = l1 * ido;
-    arg = tpi / (float)ip;
+    arg = (float)(PI2 / ip);
     dcp = cosf(arg);
     dsp = sinf(arg);
     nbd = (ido - 1) >> 1;

--- a/src/lib/mathnum/fft.c
+++ b/src/lib/mathnum/fft.c
@@ -218,38 +218,38 @@ static void dradf2(int ido, int l1, float* cc, float* ch, const float* wa1)
 
     if (ido < 2)
         return;
-    if (ido == 2)
-        goto L105;
 
-    t1 = 0;
-    t2 = t0;
-    for (k = 0; k < l1; k++)
+    if (ido != 2)
     {
-        t3 = t2;
-        t4 = (t1 << 1) + (ido << 1);
-        t5 = t1;
-        t6 = t1 + t1;
-        for (i = 2; i < ido; i += 2)
+        t1 = 0;
+        t2 = t0;
+        for (k = 0; k < l1; k++)
         {
-            t3 += 2;
-            t4 -= 2;
-            t5 += 2;
-            t6 += 2;
-            tr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
-            ti2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
-            ch[t6] = cc[t5] + ti2;
-            ch[t4] = ti2 - cc[t5];
-            ch[t6 - 1] = cc[t5 - 1] + tr2;
-            ch[t4 - 1] = cc[t5 - 1] - tr2;
+            t3 = t2;
+            t4 = (t1 << 1) + (ido << 1);
+            t5 = t1;
+            t6 = t1 + t1;
+            for (i = 2; i < ido; i += 2)
+            {
+                t3 += 2;
+                t4 -= 2;
+                t5 += 2;
+                t6 += 2;
+                tr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+                ti2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+                ch[t6] = cc[t5] + ti2;
+                ch[t4] = ti2 - cc[t5];
+                ch[t6 - 1] = cc[t5 - 1] + tr2;
+                ch[t4 - 1] = cc[t5 - 1] - tr2;
+            }
+            t1 += ido;
+            t2 += ido;
         }
-        t1 += ido;
-        t2 += ido;
+
+        if (ido % 2 == 1)
+            return;
     }
 
-    if (ido % 2 == 1)
-        return;
-
-  L105:
     t3 = (t2 = (t1 = ido) - 1);
     t2 += t0;
     for (k = 0; k < l1; k++)
@@ -276,10 +276,10 @@ static void dradf4(
 
     t0 = l1 * ido;
 
-    t1=t0;
-    t4=t1<<1;
-    t2=t1+(t1<<1);
-    t3=0;
+    t1 = t0;
+    t4 = t1 << 1;
+    t2 = t1 + (t1 << 1);
+    t3 = 0;
 
     for (k = 0; k < l1; k++)
     {
@@ -298,58 +298,57 @@ static void dradf4(
 
     if (ido < 2)
         return;
-    if (ido == 2)
-        goto L105;
 
-    t1=0;
-    for (k = 0; k < l1; k++)
+    if (ido != 2)
     {
-        t2 = t1;
-        t4 = t1 << 2;
-        t5 = (t6 = ido << 1) + t4;
-        for (i = 2; i < ido; i += 2)
+        t1 = 0;
+        for (k = 0; k < l1; k++)
         {
-            t3 = (t2 += 2);
-            t4 += 2;
-            t5 -= 2;
+            t2 = t1;
+            t4 = t1 << 2;
+            t5 = (t6 = ido << 1) + t4;
+            for (i = 2; i < ido; i += 2)
+            {
+                t3 = (t2 += 2);
+                t4 += 2;
+                t5 -= 2;
 
-            t3 += t0;
-            cr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
-            ci2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
-            t3 += t0;
-            cr3 = wa2[i - 2] * cc[t3 - 1] + wa2[i - 1] * cc[t3];
-            ci3 = wa2[i - 2] * cc[t3] - wa2[i - 1] * cc[t3 - 1];
-            t3 += t0;
-            cr4 = wa3[i - 2] * cc[t3 - 1] + wa3[i - 1] * cc[t3];
-            ci4 = wa3[i - 2] * cc[t3] - wa3[i - 1] * cc[t3 - 1];
+                t3 += t0;
+                cr2 = wa1[i - 2] * cc[t3 - 1] + wa1[i - 1] * cc[t3];
+                ci2 = wa1[i - 2] * cc[t3] - wa1[i - 1] * cc[t3 - 1];
+                t3 += t0;
+                cr3 = wa2[i - 2] * cc[t3 - 1] + wa2[i - 1] * cc[t3];
+                ci3 = wa2[i - 2] * cc[t3] - wa2[i - 1] * cc[t3 - 1];
+                t3 += t0;
+                cr4 = wa3[i - 2] * cc[t3 - 1] + wa3[i - 1] * cc[t3];
+                ci4 = wa3[i - 2] * cc[t3] - wa3[i - 1] * cc[t3 - 1];
 
-            tr1 = cr2 + cr4;
-            tr4 = cr4 - cr2;
-            ti1 = ci2 + ci4;
-            ti4 = ci2 - ci4;
-            ti2 = cc[t2] + ci3;
-            ti3 = cc[t2] - ci3;
-            tr2 = cc[t2 - 1] + cr3;
-            tr3 = cc[t2 - 1] - cr3;
+                tr1 = cr2 + cr4;
+                tr4 = cr4 - cr2;
+                ti1 = ci2 + ci4;
+                ti4 = ci2 - ci4;
+                ti2 = cc[t2] + ci3;
+                ti3 = cc[t2] - ci3;
+                tr2 = cc[t2 - 1] + cr3;
+                tr3 = cc[t2 - 1] - cr3;
 
-            ch[t4 - 1] = tr1 + tr2;
-            ch[t4] = ti1 + ti2;
+                ch[t4 - 1] = tr1 + tr2;
+                ch[t4] = ti1 + ti2;
 
-            ch[t5 - 1] = tr3 - ti4;
-            ch[t5] = tr4 - ti3;
+                ch[t5 - 1] = tr3 - ti4;
+                ch[t5] = tr4 - ti3;
 
-            ch[t4 + t6 - 1] = ti4 + tr3;
-            ch[t4 + t6] = tr4 + ti3;
+                ch[t4 + t6 - 1] = ti4 + tr3;
+                ch[t4 + t6] = tr4 + ti3;
 
-            ch[t5 + t6 - 1] = tr2 - tr1;
-            ch[t5 + t6] = ti1 - ti2;
+                ch[t5 + t6 - 1] = tr2 - tr1;
+                ch[t5 + t6] = ti1 - ti2;
+            }
+            t1 += ido;
         }
-        t1 += ido;
+        if (ido % 2 == 1)
+            return;
     }
-    if (ido % 2 == 1)
-        return;
-
-  L105:
 
     t2 = (t1 = t0 + ido - 1) + (t0 << 1);
     t3 = ido << 2;
@@ -414,8 +413,8 @@ static void dradfg(
         }
     }
 
-    is=-ido;
-    t1=0;
+    is = -ido;
+    t1 = 0;
     if (nbd > l1)
     {
         for (j = 1; j < ip; j++)

--- a/src/lib/mathnum/fft.h
+++ b/src/lib/mathnum/fft.h
@@ -20,43 +20,58 @@
 #include <stdlib.h>
 
 
+typedef struct FFT_worker
+{
+    int32_t max_length;
+    int32_t cur_length;
+    float* wsave;
+    int ifac[32];
+} FFT_worker;
+
+
+#define FFT_WORKER_AUTO (&(FFT_worker){ .max_length = 0, .cur_length = 0 })
+
+
 /**
- * Initialise work space for real-valued FFT.
+ * Initialise the FFT worker.
  *
- * \param tlength   The length of the transformed array -- must be positive.
- * \param wsave     The array for complex roots of unity -- must not be
- *                  \c NULL and must have space for \a length * 2
- *                  floating-point numbers.
- * \param ifac      The array for factorisation information
- *                  -- must not be \c NULL.
+ * \param worker        The FFT worker -- must not be \c NULL.
+ * \param max_tlength   Maximum length of Fourier Transform performed
+ *                      -- must be positive.
+ *
+ * \return   \a worker if successful, or \c NULL if memory allocation failed.
  */
-void rfft_init(int32_t tlength, float* wsave, int* ifac);
+FFT_worker* FFT_worker_init(FFT_worker* worker, int32_t max_tlength);
 
 
 /**
  * Calculate the Fast Fourier Transform of a periodic signal.
  *
- * \param length   The number of elements to be processed -- must be positive.
+ * \param worker   The FFT worker -- must not be \c NULL.
  * \param data     The input/output array -- must not be \c NULL.
- * \param wsave    The array of complex roots of unity filled by \a rfft_init
- *                 -- must not be \c NULL.
- * \param ifac     The array of factorisation information filled by
- *                 \a rfft_init -- must not be \c NULL.
+ * \param length   The length of the array -- must be positive and not larger
+ *                 than the maximum length supported by \a worker.
  */
-void rfft_forward(int32_t length, float* data, float* wsave, const int* ifac);
+void FFT_worker_rfft(FFT_worker* worker, float* data, int32_t length);
 
 
 /**
  * Calculate the inverse Fast Fourier Transform of a periodic signal.
  *
- * \param length   The number of elements to be processed -- must be positive.
+ * \param worker   The FFT worker -- must not be \c NULL.
  * \param data     The input/output array -- must not be \c NULL.
- * \param wsave    The array of complex roots of unity filled by \a rfft_init
- *                 -- must not be \c NULL.
- * \param ifac     The array of factorisation information filled by
- *                 \a rfft_init -- must not be \c NULL.
+ * \param length   The length of the array -- must be positive and not larger
+ *                 than the maximum length supported by \a worker.
  */
-void rfft_backward(int32_t length, float* data, float* wsave, const int* ifac);
+void FFT_worker_irfft(FFT_worker* worker, float* data, int32_t length);
+
+
+/**
+ * Deinitialise the FFT worker.
+ *
+ * \param worker   The FFT worker -- must not be \c NULL.
+ */
+void FFT_worker_deinit(FFT_worker* worker);
 
 
 #endif // KQT_FFT_H

--- a/src/lib/mathnum/fft.h
+++ b/src/lib/mathnum/fft.h
@@ -1,0 +1,64 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2016
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#ifndef KQT_FFT_H
+#define KQT_FFT_H
+
+
+#include <stdint.h>
+#include <stdlib.h>
+
+
+/**
+ * Initialise work space for real-valued FFT.
+ *
+ * \param tlength   The length of the transformed array -- must be positive.
+ * \param wsave     The array for complex roots of unity -- must not be
+ *                  \c NULL and must have space for \a length * 2
+ *                  floating-point numbers.
+ * \param ifac      The array for factorisation information
+ *                  -- must not be \c NULL.
+ */
+void rfft_init(int32_t tlength, float* wsave, int* ifac);
+
+
+/**
+ * Calculate the Fast Fourier Transform of a periodic signal.
+ *
+ * \param length   The number of elements to be processed -- must be positive.
+ * \param data     The input/output array -- must not be \c NULL.
+ * \param wsave    The array of complex roots of unity filled by \a rfft_init
+ *                 -- must not be \c NULL.
+ * \param ifac     The array of factorisation information filled by
+ *                 \a rfft_init -- must not be \c NULL.
+ */
+void rfft_forward(int32_t length, float* data, float* wsave, const int* ifac);
+
+
+/**
+ * Calculate the inverse Fast Fourier Transform of a periodic signal.
+ *
+ * \param length   The number of elements to be processed -- must be positive.
+ * \param data     The input/output array -- must not be \c NULL.
+ * \param wsave    The array of complex roots of unity filled by \a rfft_init
+ *                 -- must not be \c NULL.
+ * \param ifac     The array of factorisation information filled by
+ *                 \a rfft_init -- must not be \c NULL.
+ */
+void rfft_backward(int32_t length, float* data, float* wsave, const int* ifac);
+
+
+#endif // KQT_FFT_H
+
+

--- a/src/lib/mathnum/fft.h
+++ b/src/lib/mathnum/fft.h
@@ -25,7 +25,7 @@ typedef struct FFT_worker
     int32_t max_length;
     int32_t cur_length;
     float* wsave;
-    int ifac[32];
+    int32_t ifac[32];
 } FFT_worker;
 
 

--- a/src/lib/player/devices/processors/Stream_state.c
+++ b/src/lib/player/devices/processors/Stream_state.c
@@ -147,6 +147,9 @@ Device_state* new_Stream_pstate(
     const Proc_stream* stream = (const Proc_stream*)device->dimpl;
     spstate->init_value = stream->init_value;
 
+    spstate->init_osc_speed = 0;
+    spstate->init_osc_depth = 0;
+
     Linear_controls_init(&spstate->controls);
     Linear_controls_set_audio_rate(&spstate->controls, audio_rate);
     Linear_controls_set_tempo(&spstate->controls, 120);

--- a/src/test/fft.c
+++ b/src/test/fft.c
@@ -1,0 +1,172 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2016
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <test_common.h>
+
+#include <mathnum/common.h>
+#include <mathnum/fft.h>
+#include <mathnum/Random.h>
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+#define max_test_length 256
+static FFT_worker* fw = FFT_WORKER_AUTO;
+
+
+void setup_fft_worker(void)
+{
+    FFT_worker* tfw = FFT_worker_init(fw, max_test_length);
+    fail_if(tfw == NULL, "Could not allocate memory for FFT worker.");
+    return;
+}
+
+
+void fft_worker_teardown(void)
+{
+    FFT_worker_deinit(fw);
+    return;
+}
+
+
+START_TEST(Factorisation_is_valid)
+{
+    float data[max_test_length] = { 0 };
+
+    const int check_val = _i;
+
+    FFT_worker_rfft(fw, data, check_val);
+
+    fail_unless(fw->ifac[0] == check_val,
+            "Calculated length (%d) does not match the given length (%d)",
+            (int)fw->ifac[0], check_val);
+    fail_unless(fw->ifac[1] > 0,
+            "Number of factors (%d) is not positive", fw->ifac[1]);
+
+    int prod = 1;
+    for (int i = 0; i < fw->ifac[1]; ++i)
+        prod *= fw->ifac[2 + i];
+
+    fail_unless(prod == check_val,
+            "Product of calculated factors (%d) does not equal given length (%d)",
+            prod, check_val);
+}
+END_TEST
+
+
+typedef void (*fill_func)(float*, int);
+
+static void fill_data_base_freq(float* data, int length)
+{
+    for (int i = 0; i < length; ++i)
+        data[i] = (float)cos(i * 2 * PI / (float)length);
+
+    return;
+}
+
+static void fill_data_saw(float* data, int length)
+{
+    for (int i = 0; i < length; ++i)
+        data[i] = (float)i / (float)length;
+
+    return;
+}
+
+static void fill_data_noise(float* data, int length)
+{
+    Random* random = Random_init(RANDOM_AUTO, "test");
+
+    for (int i = 0; i < length; ++i)
+        data[i] = (float)Random_get_float_signal(random);
+
+    return;
+}
+
+
+START_TEST(Forward_and_inverse_transform_return_scaled_original)
+{
+    const int test_length = _i;
+
+    float orig_data[max_test_length] = { 0 };
+    float data[max_test_length] = { 0 };
+
+    fill_func funcs[] =
+    {
+        fill_data_base_freq,
+        fill_data_saw,
+        fill_data_noise,
+    };
+    const size_t funcs_count = sizeof(funcs) / sizeof(*funcs);
+
+    for (size_t fi = 0; fi < funcs_count; ++fi)
+    {
+        funcs[fi](orig_data, test_length);
+        memcpy(data, orig_data, sizeof(data));
+
+        FFT_worker_rfft(fw, data, test_length);
+        FFT_worker_irfft(fw, data, test_length);
+
+        for (int i = 0; i < test_length; ++i)
+            data[i] /= (float)test_length;
+
+        for (int i = 0; i < test_length; ++i)
+        {
+            fail_if(fabsf(data[i] - orig_data[i]) > 0.001f,
+                    "Absolute value is too large at index %d:"
+                    " converted %.7g, original %.7g",
+                    i, data[i], orig_data[i]);
+        }
+    }
+}
+END_TEST
+
+
+static Suite* FFT_suite(void)
+{
+    Suite* s = suite_create("FFT");
+
+    static const int timeout = DEFAULT_TIMEOUT;
+
+    TCase* tc_correctness = tcase_create("correctness");
+    suite_add_tcase(s, tc_correctness);
+    tcase_set_timeout(tc_correctness, timeout);
+    tcase_add_checked_fixture(tc_correctness, setup_fft_worker, fft_worker_teardown);
+
+    tcase_add_loop_test(tc_correctness, Factorisation_is_valid, 2, max_test_length + 1);
+    tcase_add_loop_test(
+            tc_correctness,
+            Forward_and_inverse_transform_return_scaled_original,
+            1,
+            max_test_length + 1);
+
+    return s;
+}
+
+
+int main(void)
+{
+    Suite* suite = FFT_suite();
+    SRunner* sr = srunner_create(suite);
+#ifdef K_MEM_DEBUG
+    srunner_set_fork_status(sr, CK_NOFORK);
+#endif
+    srunner_run_all(sr, CK_NORMAL);
+    const int fail_count = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    exit(fail_count > 0);
+}
+
+

--- a/src/test/fft.c
+++ b/src/test/fft.c
@@ -19,6 +19,7 @@
 #include <mathnum/Random.h>
 
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -56,7 +57,7 @@ START_TEST(Factorisation_is_valid)
     fail_unless(fw->ifac[1] > 0,
             "Number of factors (%d) is not positive", fw->ifac[1]);
 
-    int prod = 1;
+    int32_t prod = 1;
     for (int i = 0; i < fw->ifac[1]; ++i)
         prod *= fw->ifac[2 + i];
 


### PR DESCRIPTION
This branch reduces aliasing artifacts produced by the additive synthesis processor. The internal representation of the base waveforms should also be useful later when adding sinc interpolation support. This branch also includes a (hopefully) correct implementation of forward and inverse FFT for real-valued input (however, the PADsynth processor is still using the old inverse FFT implementation).