### PR TITLE
Hide force modifier envelope in the envelope generator processor editor

### DIFF
--- a/kunquat/tracker/ui/views/processor/envgenproc.py
+++ b/kunquat/tracker/ui/views/processor/envgenproc.py
@@ -52,7 +52,7 @@ class EnvgenProc(QWidget, ProcessorUpdater):
         v.addWidget(self._global_adjust)
         v.addLayout(rl)
         v.addWidget(self._time_env)
-        v.addWidget(self._force_env)
+        #v.addWidget(self._force_env)
         self.setLayout(v)
 
         self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)


### PR DESCRIPTION
This branch hides the force modifier envelope of the envelope generator processor, as its purpose in the current design is unclear and can (or will) be replaced by more flexible functionality.