### PR TITLE
Fix force carrying behaviour with previously undefined force

### DIFF
--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -48,7 +48,7 @@ static void init_force_controls(Channel* ch, const Master_params* master_params)
     rassert(ch != NULL);
     rassert(master_params != NULL);
 
-    if (!ch->carry_force)
+    if (!ch->carry_force || isnan(ch->force_controls.force))
     {
         Force_controls_reset(&ch->force_controls);
         ch->force_controls.force = 0;


### PR DESCRIPTION
This branch fixes force handling when force carrying is enabled before the first note on in a channel.