### PR TITLE
New envelope triggering interface

### DIFF
--- a/kunquat/tracker/ui/model/procparams/envgenparams.py
+++ b/kunquat/tracker/ui/model/procparams/envgenparams.py
@@ -108,4 +108,18 @@ class EnvgenParams(ProcParams):
         assert y_range[0] <= y_range[1]
         self._set_value('p_ln_y_range.json', y_range)
 
+    def get_y_range_min_var(self):
+        return self._get_value('p_f_y_range_min_var.json', 0.0)
+
+    def set_y_range_min_var(self, value):
+        assert value >= 0
+        self._set_value('p_f_y_range_min_var.json', value)
+
+    def get_y_range_max_var(self):
+        return self._get_value('p_f_y_range_max_var.json', 0.0)
+
+    def set_y_range_max_var(self, value):
+        assert value >= 0
+        self._set_value('p_f_y_range_max_var.json', value)
+
 

--- a/kunquat/tracker/ui/model/procparams/envgenparams.py
+++ b/kunquat/tracker/ui/model/procparams/envgenparams.py
@@ -22,7 +22,7 @@ class EnvgenParams(ProcParams):
 
     @staticmethod
     def get_port_info():
-        return { 'in_00': 'stretch', 'out_00': 'env' }
+        return { 'in_00': 'stretch', 'in_01': 'trigger', 'out_00': 'env' }
 
     def __init__(self, proc_id, controller):
         super().__init__(proc_id, controller)
@@ -48,11 +48,45 @@ class EnvgenParams(ProcParams):
     def set_time_env_loop_enabled(self, enabled):
         self._set_value('p_b_env_loop_enabled.json', enabled)
 
-    def get_time_env_is_release(self):
-        return self._get_value('p_b_env_is_release.json', False)
+    def get_trig_immediate(self):
+        return self._get_value('p_b_trig_immediate.json', True)
 
-    def set_time_env_is_release(self, value):
-        self._set_value('p_b_env_is_release.json', value)
+    def set_trig_immediate(self, enabled):
+        self._set_value('p_b_trig_immediate.json', enabled)
+
+    def get_trig_release(self):
+        return self._get_value('p_b_trig_release.json', False)
+
+    def set_trig_release(self, enabled):
+        self._set_value('p_b_trig_release.json', enabled)
+
+    def get_trig_impulse_floor(self):
+        return self._get_value('p_b_trig_impulse_floor.json', False)
+
+    def set_trig_impulse_floor(self, enabled):
+        self._set_value('p_b_trig_impulse_floor.json', enabled)
+
+    def get_trig_impulse_ceil(self):
+        return self._get_value('p_b_trig_impulse_ceil.json', False)
+
+    def set_trig_impulse_ceil(self, enabled):
+        self._set_value('p_b_trig_impulse_ceil.json', enabled)
+
+    def get_trig_impulse_floor_bounds(self):
+        return self._get_value('p_ln_trig_impulse_floor_bounds.json', [-1.0, -0.5])
+
+    def set_trig_impulse_floor_bounds(self, bounds):
+        assert len(bounds) == 2
+        assert bounds[0] <= bounds[1]
+        self._set_value('p_ln_trig_impulse_floor_bounds.json', bounds)
+
+    def get_trig_impulse_ceil_bounds(self):
+        return self._get_value('p_ln_trig_impulse_ceil_bounds.json', [1.0, 0.5])
+
+    def set_trig_impulse_ceil_bounds(self, bounds):
+        assert len(bounds) == 2
+        assert bounds[0] >= bounds[1]
+        self._set_value('p_ln_trig_impulse_ceil_bounds.json', bounds)
 
     def get_linear_force_enabled(self):
         return self._get_value('p_b_linear_force.json', False)

--- a/src/lib/init/devices/processors/Proc_envgen.c
+++ b/src/lib/init/devices/processors/Proc_envgen.c
@@ -43,6 +43,8 @@ static Set_num_list_func    Proc_envgen_set_trig_impulse_ceil_bounds;
 static Set_bool_func        Proc_envgen_set_linear_force;
 static Set_float_func       Proc_envgen_set_global_adjust;
 static Set_num_list_func    Proc_envgen_set_y_range;
+static Set_float_func       Proc_envgen_set_y_range_min_var;
+static Set_float_func       Proc_envgen_set_y_range_max_var;
 
 static void del_Proc_envgen(Device_impl* dimpl);
 
@@ -74,6 +76,8 @@ Device_impl* new_Proc_envgen(void)
 
     envgen->y_min = 0;
     envgen->y_max = 1;
+    envgen->y_min_var = 0;
+    envgen->y_max_var = 0;
 
     if (!Device_impl_init(&envgen->parent, del_Proc_envgen))
     {
@@ -102,7 +106,9 @@ Device_impl* new_Proc_envgen(void)
                 "p_ln_trig_impulse_ceil_bounds.json", NULL) &&
             REG_KEY_BOOL(linear_force, "p_b_linear_force.json", false) &&
             REG_KEY(float, global_adjust, "p_f_global_adjust.json", 0.0) &&
-            REG_KEY(num_list, y_range, "p_ln_y_range.json", NULL)
+            REG_KEY(num_list, y_range, "p_ln_y_range.json", NULL) &&
+            REG_KEY(float, y_range_min_var, "p_f_y_range_min_var.json", 0.0) &&
+            REG_KEY(float, y_range_max_var, "p_f_y_range_max_var.json", 0.0)
         ))
     {
         del_Device_impl(&envgen->parent);
@@ -347,6 +353,32 @@ static bool Proc_envgen_set_y_range(
         egen->y_min = 0;
         egen->y_max = 1;
     }
+
+    return true;
+}
+
+
+static bool Proc_envgen_set_y_range_min_var(
+        Device_impl* dimpl, const Key_indices indices, double value)
+{
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
+
+    Proc_envgen* egen = (Proc_envgen*)dimpl;
+    egen->y_min_var = (isfinite(value) && value >= 0) ? value : 0;
+
+    return true;
+}
+
+
+static bool Proc_envgen_set_y_range_max_var(
+        Device_impl* dimpl, const Key_indices indices, double value)
+{
+    rassert(dimpl != NULL);
+    rassert(indices != NULL);
+
+    Proc_envgen* egen = (Proc_envgen*)dimpl;
+    egen->y_max_var = (isfinite(value) && value >= 0) ? value : 0;
 
     return true;
 }

--- a/src/lib/init/devices/processors/Proc_envgen.h
+++ b/src/lib/init/devices/processors/Proc_envgen.h
@@ -48,6 +48,8 @@ typedef struct Proc_envgen
 
     double y_min;
     double y_max;
+    double y_min_var;
+    double y_max_var;
 } Proc_envgen;
 
 

--- a/src/lib/init/devices/processors/Proc_envgen.h
+++ b/src/lib/init/devices/processors/Proc_envgen.h
@@ -30,7 +30,17 @@ typedef struct Proc_envgen
     bool is_time_env_enabled;
     const Envelope* time_env;
     bool is_loop_enabled;
-    bool is_release_env;
+
+    bool trig_immediate;
+    bool trig_release;
+
+    bool trig_impulse_floor;
+    float trig_impulse_floor_on;
+    float trig_impulse_floor_off;
+
+    bool trig_impulse_ceil;
+    float trig_impulse_ceil_on;
+    float trig_impulse_ceil_off;
 
     bool is_linear_force;
 


### PR DESCRIPTION
This branch redefines the interface for triggering envelope processing inside the envelope generator processor. First, it is now possible to trigger the envelope at both the start and the release of a note (it has only been possible to select one of the two previously). More significantly, the envelope can also be triggered by changes in an input signal fed to the new input port of the processor. Finally, random changes may now be applied to the output range used for each triggering of the envelope.