### PR TITLE
Debug assertion configuration

### DIFF
--- a/make.py
+++ b/make.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2014-2016
+# Author: Tomi Jylhä-Ollila, Finland 2014-2017
 #
 # This file is part of Kunquat.
 #
@@ -156,6 +156,9 @@ def build():
     cc = get_cc(options.cc)
 
     cc.set_debug(options.enable_debug)
+
+    if options.enable_debug_asserts:
+        cc.add_define('ENABLE_DEBUG_ASSERTS')
 
     #if options.enable_profiling:
     #    compile_flags.append('-pg')

--- a/options.py
+++ b/options.py
@@ -6,6 +6,9 @@ prefix = '/usr/local'
 # build in debug mode
 enable_debug = True
 
+# enable debug asserts
+enable_debug_asserts = False
+
 # enable libkunquat
 enable_libkunquat = True
 

--- a/src/lib/containers/AAtree.c
+++ b/src/lib/containers/AAtree.c
@@ -50,7 +50,7 @@ static AAnode* aasplit(AAnode* root);
 
 static void aafree(AAnode* node, void (*destroy)(void*));
 
-#ifndef NDEBUG
+#ifdef ENABLE_DEBUG_ASSERTS
 #define aavalidate(node, msg) (dassert(aavalidate_(node, msg)))
 static bool aavalidate_(const AAnode* node, const char* msg);
 #else
@@ -686,7 +686,7 @@ static void aafree(AAnode* node, void (*destroy)(void*))
 }
 
 
-#ifndef NDEBUG
+#ifdef ENABLE_DEBUG_ASSERTS
 static bool aavalidate_(const AAnode* node, const char* msg)
 {
     if (node == NULL

--- a/src/lib/containers/AAtree.c
+++ b/src/lib/containers/AAtree.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2016
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2017
  *
  * This file is part of Kunquat.
  *
@@ -51,7 +51,7 @@ static AAnode* aasplit(AAnode* root);
 static void aafree(AAnode* node, void (*destroy)(void*));
 
 #ifndef NDEBUG
-#define aavalidate(node, msg) (rassert(aavalidate_(node, msg)))
+#define aavalidate(node, msg) (dassert(aavalidate_(node, msg)))
 static bool aavalidate_(const AAnode* node, const char* msg);
 #else
 #define aavalidate(node, msg) ignore(0)

--- a/src/lib/debug/assert.h
+++ b/src/lib/debug/assert.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2016
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2017
  *
  * This file is part of Kunquat.
  *
@@ -89,7 +89,7 @@ void assert_print_msg(
 
 
 // Debug assert that should only be used in performance-critical code.
-#ifndef NDEBUG
+#ifdef ENABLE_DEBUG_ASSERTS
 #define dassert rassert
 #else
 #define dassert(expr) ignore(expr)


### PR DESCRIPTION
This branch adds a separate build configuration option for toggling debug assertions (disabled by default), adding more flexibility for controlling performance and debugability of libkunquat. Also, AA tree validation code now uses debug assertion.