### PR TITLE
Fix mixed-signal streams at different audio rates

### DIFF
--- a/src/lib/player/devices/processors/Stream_state.c
+++ b/src/lib/player/devices/processors/Stream_state.c
@@ -88,6 +88,8 @@ static void Stream_pstate_reset(Device_state* dstate)
     Stream_pstate* spstate = (Stream_pstate*)dstate;
 
     Linear_controls_init(&spstate->controls);
+    Linear_controls_set_audio_rate(&spstate->controls, dstate->audio_rate);
+    Linear_controls_set_tempo(&spstate->controls, 120);
     Linear_controls_set_value(&spstate->controls, spstate->init_value);
     Linear_controls_set_osc_speed_init_value(
             &spstate->controls, spstate->init_osc_speed);


### PR DESCRIPTION
This branch fixes incorrect oscillation speed in the output of mixed-signal stream processors at different audio rates.