### PR TITLE
Store grid visibility setting in the module

### DIFF
--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -173,6 +173,10 @@ class Controller():
         self._store.put(values, transaction_notifier=notifier)
         self._store.clear_modified_flag()
 
+        sheet_manager = self._ui_model.get_sheet_manager()
+        if not sheet_manager.is_grid_default_enabled():
+            sheet_manager.set_grid_enabled(False)
+
         self._updater.signal_update('signal_controls')
 
         self._reset_expressions()

--- a/kunquat/tracker/ui/model/sheetmanager.py
+++ b/kunquat/tracker/ui/model/sheetmanager.py
@@ -728,9 +728,14 @@ class SheetManager():
 
     def set_grid_enabled(self, enabled):
         self._session.set_grid_enabled(enabled)
+        value = None if enabled else False
+        self._store.put({ 'i_grid_enabled.json': value }, mark_modified=False)
 
     def is_grid_enabled(self):
         return self._session.is_grid_enabled()
+
+    def is_grid_default_enabled(self):
+        return self._store.get('i_grid_enabled.json', True)
 
     def get_grid(self):
         grid = Grid()

--- a/kunquat/tracker/ui/views/sheet/toolbar.py
+++ b/kunquat/tracker/ui/views/sheet/toolbar.py
@@ -649,6 +649,7 @@ class GridToggle(QCheckBox, Updater):
         self.setText('Grid')
 
     def _on_setup(self):
+        self.register_action('signal_module', self._update_state)
         self.register_action('signal_grid', self._update_state)
 
         self.clicked.connect(self._set_grid_enabled)
@@ -678,6 +679,7 @@ class GridEditorButton(QPushButton, Updater):
         self.setText('Edit grids')
 
     def _on_setup(self):
+        self.register_action('signal_module', self._update_enabled)
         self.register_action('signal_grid', self._update_enabled)
 
         self.clicked.connect(self._open_grid_editor)


### PR DESCRIPTION
This branch adds persistent setting for grid visibility in saved modules. Changing the grid visibility alone will not mark the project as modified.