### PR TITLE
Fix sample normalisation logic with loud floating-point data

### DIFF
--- a/kunquat/tracker/ui/model/procparams/sampleparams.py
+++ b/kunquat/tracker/ui/model/procparams/sampleparams.py
@@ -375,7 +375,7 @@ class SampleParams(ProcParams):
                     max_abs = max(max_abs, abs(item))
 
             norm_mult = from_max / max_abs
-            if (norm_mult >= 1.01) or (norm_mult <= 0.99):
+            if (norm_mult >= 1.01) or (norm_mult <= 0.99999):
                 mult *= norm_mult
 
                 # Adjust sample volume levels in note and hit maps

--- a/kunquat/tracker/ui/model/procparams/sampleparams.py
+++ b/kunquat/tracker/ui/model/procparams/sampleparams.py
@@ -375,7 +375,7 @@ class SampleParams(ProcParams):
                     max_abs = max(max_abs, abs(item))
 
             norm_mult = from_max / max_abs
-            if norm_mult >= 1.01:
+            if (norm_mult >= 1.01) or (norm_mult <= 0.99):
                 mult *= norm_mult
 
                 # Adjust sample volume levels in note and hit maps


### PR DESCRIPTION
This branch fixes sample normalisation when converting floating-point data that exceeds the [-1.0, 1.0] range.