### PR TITLE
Fix inconsistency in randomness

### DIFF
--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -621,9 +621,6 @@ void Player_reset(Player* player, int track_num)
         player->master_params.cur_pos.track = track_num;
     }
 
-    for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
-        Channel_set_random_seed(player->channels[i], player->module->random_seed);
-
     Player_update_sliders_and_lfos_audio_rate(player);
     Player_update_sliders_and_lfos_tempo(player);
 

--- a/src/lib/player/Player_seq.c
+++ b/src/lib/player/Player_seq.c
@@ -356,6 +356,9 @@ void Player_reset_channels(Player* player)
     // Reset channels
     const Channel_defaults_list* ch_defs = Module_get_ch_defaults_list(player->module);
 
+    for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
+        Channel_set_random_seed(player->channels[i], player->module->random_seed);
+
     if (ch_defs != NULL)
     {
         for (int i = 0; i < KQT_CHANNELS_MAX; ++i)


### PR DESCRIPTION
This branch fixes application of composition random seed when starting playback without explicit player resetting.