### PR TITLE
Freeverb flush to zero

### DIFF
--- a/src/lib/intrinsics.h
+++ b/src/lib/intrinsics.h
@@ -1,0 +1,27 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2017
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#ifndef KQT_INTRINSICS_H
+#define KQT_INTRINSICS_H
+
+
+#ifdef __SSE__
+#include <xmmintrin.h>
+#define KQT_SSE
+#endif // __SSE__
+
+
+#endif // KQT_INTRINSICS_H
+
+

--- a/src/lib/player/devices/processors/Freeverb_allpass.c
+++ b/src/lib/player/devices/processors/Freeverb_allpass.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2016
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2017
  *
  * This file is part of Kunquat.
  *
@@ -21,6 +21,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+
+#ifdef __SSE__
+#include <xmmintrin.h>
+#endif
 
 
 struct Freeverb_allpass
@@ -75,10 +79,16 @@ void Freeverb_allpass_process(
     rassert(buf_start >= 0);
     rassert(buf_stop > buf_start);
 
+#ifdef __SSE__
+    dassert(_MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON);
+#endif
+
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
         float bufout = allpass->buffer[allpass->buffer_pos];
+#ifndef __SSE__
         bufout = undenormalise(bufout);
+#endif
         allpass->buffer[allpass->buffer_pos] = buffer[i] + (bufout * allpass->feedback);
 
         buffer[i] = -buffer[i] + bufout;

--- a/src/lib/player/devices/processors/Freeverb_allpass.c
+++ b/src/lib/player/devices/processors/Freeverb_allpass.c
@@ -15,16 +15,13 @@
 #include <player/devices/processors/Freeverb_allpass.h>
 
 #include <debug/assert.h>
+#include <intrinsics.h>
 #include <mathnum/common.h>
 #include <memory.h>
 
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-
-#ifdef __SSE__
-#include <xmmintrin.h>
-#endif
 
 
 struct Freeverb_allpass
@@ -79,14 +76,14 @@ void Freeverb_allpass_process(
     rassert(buf_start >= 0);
     rassert(buf_stop > buf_start);
 
-#ifdef __SSE__
+#ifdef KQT_SSE
     dassert(_MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON);
 #endif
 
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
         float bufout = allpass->buffer[allpass->buffer_pos];
-#ifndef __SSE__
+#ifndef KQT_SSE
         bufout = undenormalise(bufout);
 #endif
         allpass->buffer[allpass->buffer_pos] = buffer[i] + (bufout * allpass->feedback);

--- a/src/lib/player/devices/processors/Freeverb_comb.c
+++ b/src/lib/player/devices/processors/Freeverb_comb.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2016
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2017
  *
  * This file is part of Kunquat.
  *
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifdef __SSE__
+#include <xmmintrin.h>
+#endif
 
 
 struct Freeverb_comb
@@ -75,14 +79,22 @@ void Freeverb_comb_process(
     rassert(buf_start >= 0);
     rassert(buf_stop > buf_start);
 
+#ifdef __SSE__
+    dassert(_MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON);
+#endif
+
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
         float output = comb->buffer[comb->buffer_pos];
+#ifndef __SSE__
         output = undenormalise(output);
+#endif
         const float damp1 = damps[i];
         const float damp2 = 1 - damp1;
         comb->filter_store = (output * damp2) + (comb->filter_store * damp1);
+#ifndef __SSE__
         comb->filter_store = undenormalise(comb->filter_store);
+#endif
         comb->buffer[comb->buffer_pos] = in_buf[i] + (comb->filter_store * refls[i]);
 
         out_buf[i] += output;

--- a/src/lib/player/devices/processors/Freeverb_comb.c
+++ b/src/lib/player/devices/processors/Freeverb_comb.c
@@ -15,16 +15,13 @@
 #include <player/devices/processors/Freeverb_comb.h>
 
 #include <debug/assert.h>
+#include <intrinsics.h>
 #include <mathnum/common.h>
 #include <memory.h>
 
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#ifdef __SSE__
-#include <xmmintrin.h>
-#endif
 
 
 struct Freeverb_comb
@@ -79,20 +76,20 @@ void Freeverb_comb_process(
     rassert(buf_start >= 0);
     rassert(buf_stop > buf_start);
 
-#ifdef __SSE__
+#ifdef KQT_SSE
     dassert(_MM_GET_FLUSH_ZERO_MODE() == _MM_FLUSH_ZERO_ON);
 #endif
 
     for (int32_t i = buf_start; i < buf_stop; ++i)
     {
         float output = comb->buffer[comb->buffer_pos];
-#ifndef __SSE__
+#ifndef KQT_SSE
         output = undenormalise(output);
 #endif
         const float damp1 = damps[i];
         const float damp2 = 1 - damp1;
         comb->filter_store = (output * damp2) + (comb->filter_store * damp1);
-#ifndef __SSE__
+#ifndef KQT_SSE
         comb->filter_store = undenormalise(comb->filter_store);
 #endif
         comb->buffer[comb->buffer_pos] = in_buf[i] + (comb->filter_store * refls[i]);

--- a/src/lib/player/devices/processors/Freeverb_state.c
+++ b/src/lib/player/devices/processors/Freeverb_state.c
@@ -16,6 +16,7 @@
 
 #include <debug/assert.h>
 #include <init/devices/processors/Proc_freeverb.h>
+#include <intrinsics.h>
 #include <mathnum/common.h>
 #include <mathnum/fast_exp2.h>
 #include <memory.h>
@@ -321,7 +322,7 @@ static void Freeverb_pstate_render_mixed(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             comb_input[i] = (float)((ws[0][i] + ws[1][i]) * freeverb->gain);
 
-#ifdef __SSE__
+#ifdef KQT_SSE
         const unsigned int old_ftoz = _MM_GET_FLUSH_ZERO_MODE();
         _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 #endif
@@ -347,7 +348,7 @@ static void Freeverb_pstate_render_mixed(
                         fstate->allpasses[ch][allpass], ws_buf, buf_start, buf_stop);
         }
 
-#ifdef __SSE__
+#ifdef KQT_SSE
         _MM_SET_FLUSH_ZERO_MODE(old_ftoz);
 #endif
 

--- a/src/lib/player/devices/processors/Freeverb_state.c
+++ b/src/lib/player/devices/processors/Freeverb_state.c
@@ -25,6 +25,10 @@
 #include <player/devices/processors/Proc_state_utils.h>
 #include <player/Work_buffers.h>
 
+#ifdef __SSE__
+#include <xmmintrin.h>
+#endif
+
 
 #define FREEVERB_COMBS 8
 #define FREEVERB_ALLPASSES 4
@@ -317,6 +321,11 @@ static void Freeverb_pstate_render_mixed(
         for (int32_t i = buf_start; i < buf_stop; ++i)
             comb_input[i] = (float)((ws[0][i] + ws[1][i]) * freeverb->gain);
 
+#ifdef __SSE__
+        const unsigned int old_ftoz = _MM_GET_FLUSH_ZERO_MODE();
+        _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+#endif
+
         for (int ch = 0; ch < 2; ++ch)
         {
             float* ws_buf = ws[ch];
@@ -337,6 +346,10 @@ static void Freeverb_pstate_render_mixed(
                 Freeverb_allpass_process(
                         fstate->allpasses[ch][allpass], ws_buf, buf_start, buf_stop);
         }
+
+#ifdef __SSE__
+        _MM_SET_FLUSH_ZERO_MODE(old_ftoz);
+#endif
 
         for (int32_t i = buf_start; i < buf_stop; ++i)
         {

--- a/src/lib/player/devices/processors/Freeverb_state.c
+++ b/src/lib/player/devices/processors/Freeverb_state.c
@@ -26,10 +26,6 @@
 #include <player/devices/processors/Proc_state_utils.h>
 #include <player/Work_buffers.h>
 
-#ifdef __SSE__
-#include <xmmintrin.h>
-#endif
-
 
 #define FREEVERB_COMBS 8
 #define FREEVERB_ALLPASSES 4


### PR DESCRIPTION
This branch replaces slow runtime checks for subnormal floats with flush to zero on platforms with SSE support.