### PR TITLE
Give unique random seeds for each voice of note

### DIFF
--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -136,9 +136,6 @@ bool Event_channel_note_on_process(
         return true;
 
     // Allocate new Voices
-    bool is_voice_rand_seed_set = false;
-    uint64_t voice_rand_seed = 0;
-
     const uint64_t new_group_id = Voice_pool_new_group_id(ch->pool);
 
     double pitch_param = params->arg->value.float_type;
@@ -200,11 +197,7 @@ bool Event_channel_note_on_process(
         const Proc_state* proc_state = (Proc_state*)Device_states_get_state(
                 dstates, Device_get_id((const Device*)proc));
 
-        if (!is_voice_rand_seed_set)
-        {
-            voice_rand_seed = Random_get_uint64(&ch->rand);
-            is_voice_rand_seed_set = true;
-        }
+        const uint64_t voice_rand_seed = Random_get_uint64(&ch->rand);
 
         const bool voice_allocated = reserve_voice(
                 ch, au, new_group_id, proc_state, i, voice_rand_seed, params->external);
@@ -257,9 +250,6 @@ bool Event_channel_hit_process(
     if (au == NULL)
         return true;
 
-    bool is_voice_rand_seed_set = false;
-    uint64_t voice_rand_seed = 0;
-
     const uint64_t new_group_id = Voice_pool_new_group_id(ch->pool);
 
     init_force_controls(ch, master_params);
@@ -290,11 +280,7 @@ bool Event_channel_hit_process(
         const Proc_state* proc_state = (Proc_state*)Device_states_get_state(
                 dstates, Device_get_id((const Device*)proc));
 
-        if (!is_voice_rand_seed_set)
-        {
-            voice_rand_seed = Random_get_uint64(&ch->rand);
-            is_voice_rand_seed_set = true;
-        }
+        const uint64_t voice_rand_seed = Random_get_uint64(&ch->rand);
 
         const bool voice_allocated = reserve_voice(
                 ch, au, new_group_id, proc_state, i, voice_rand_seed, params->external);


### PR DESCRIPTION
This branch fixes issue #768. A future extension might add support for a user-defined random context, as there might be some use cases where it is useful for voices to share the same random sequence.