### PR TITLE
Fix range editing behaviour

### DIFF
--- a/kunquat/tracker/ui/views/processor/envgenproc.py
+++ b/kunquat/tracker/ui/views/processor/envgenproc.py
@@ -325,8 +325,8 @@ class TriggerImpulseBounds(QWidget, ProcessorUpdater):
     def _on_setup(self):
         self.register_action(self._get_update_signal_type(), self._update_all)
 
-        self._start_value.valueChanged.connect(self._change_start)
-        self._stop_value.valueChanged.connect(self._change_stop)
+        self._start_value.editingFinished.connect(self._change_start)
+        self._stop_value.editingFinished.connect(self._change_stop)
 
         self._update_all()
 
@@ -355,10 +355,10 @@ class TriggerImpulseBounds(QWidget, ProcessorUpdater):
     def _update_bounds(self):
         raise NotImplementedError
 
-    def _change_start(self, new_start):
+    def _change_start(self):
         raise NotImplementedError
 
-    def _change_stop(self, new_stop):
+    def _change_stop(self):
         raise NotImplementedError
 
 
@@ -375,18 +375,20 @@ class TriggerImpulseFloorBounds(TriggerImpulseBounds):
         egen_params = self._get_egen_params()
         self._try_update_bounds(egen_params.get_trig_impulse_floor_bounds())
 
-    def _change_start(self, new_start):
+    def _change_start(self):
         egen_params = self._get_egen_params()
         cur_bounds = egen_params.get_trig_impulse_floor_bounds()
 
+        new_start = self._start_value.value()
         new_stop = max(cur_bounds[1], new_start)
         egen_params.set_trig_impulse_floor_bounds([new_start, new_stop])
         self._updater.signal_update(self._get_update_signal_type())
 
-    def _change_stop(self, new_stop):
+    def _change_stop(self):
         egen_params = self._get_egen_params()
         cur_bounds = egen_params.get_trig_impulse_floor_bounds()
 
+        new_stop = self._stop_value.value()
         new_start = min(cur_bounds[0], new_stop)
         egen_params.set_trig_impulse_floor_bounds([new_start, new_stop])
         self._updater.signal_update(self._get_update_signal_type())
@@ -405,18 +407,20 @@ class TriggerImpulseCeilBounds(TriggerImpulseBounds):
         egen_params = self._get_egen_params()
         self._try_update_bounds(egen_params.get_trig_impulse_ceil_bounds())
 
-    def _change_start(self, new_start):
+    def _change_start(self):
         egen_params = self._get_egen_params()
         cur_bounds = egen_params.get_trig_impulse_ceil_bounds()
 
+        new_start = self._start_value.value()
         new_stop = min(cur_bounds[1], new_start)
         egen_params.set_trig_impulse_ceil_bounds([new_start, new_stop])
         self._updater.signal_update(self._get_update_signal_type())
 
-    def _change_stop(self, new_stop):
+    def _change_stop(self):
         egen_params = self._get_egen_params()
         cur_bounds = egen_params.get_trig_impulse_ceil_bounds()
 
+        new_stop = self._stop_value.value()
         new_start = max(cur_bounds[0], new_stop)
         egen_params.set_trig_impulse_ceil_bounds([new_start, new_stop])
         self._updater.signal_update(self._get_update_signal_type())

--- a/kunquat/tracker/ui/views/processor/envgenproc.py
+++ b/kunquat/tracker/ui/views/processor/envgenproc.py
@@ -147,9 +147,9 @@ class RangeEditor(QWidget, ProcessorUpdater):
         self.register_action(
                 self._get_linear_force_signal_type(), self._update_force_type)
 
-        self._min_editor.valueChanged.connect(self._set_range_min)
+        self._min_editor.editingFinished.connect(self._set_range_min)
         self._min_var_editor.valueChanged.connect(self._set_range_min_var)
-        self._max_editor.valueChanged.connect(self._set_range_max)
+        self._max_editor.editingFinished.connect(self._set_range_max)
         self._max_var_editor.valueChanged.connect(self._set_range_max_var)
 
         self._update_range_params()
@@ -185,10 +185,10 @@ class RangeEditor(QWidget, ProcessorUpdater):
         for i in range(self._disableables.count()):
             self._disableables.itemAt(i).widget().setEnabled(not lf_enabled)
 
-    def _set_range_min(self, value):
+    def _set_range_min(self):
         egen_params = utils.get_proc_params(self._ui_model, self._au_id, self._proc_id)
         y_range = egen_params.get_y_range()
-        y_range[0] = value
+        y_range[0] = self._min_editor.value()
         y_range[1] = max(y_range)
         egen_params.set_y_range(y_range)
         self._updater.signal_update(self._get_update_signal_type())
@@ -198,10 +198,10 @@ class RangeEditor(QWidget, ProcessorUpdater):
         egen_params.set_y_range_min_var(value)
         self._updater.signal_update(self._get_update_signal_type())
 
-    def _set_range_max(self, value):
+    def _set_range_max(self):
         egen_params = utils.get_proc_params(self._ui_model, self._au_id, self._proc_id)
         y_range = egen_params.get_y_range()
-        y_range[1] = value
+        y_range[1] = self._max_editor.value()
         y_range[0] = min(y_range)
         egen_params.set_y_range(y_range)
         self._updater.signal_update(self._get_update_signal_type())

--- a/kunquat/tracker/ui/views/processor/rangemapproc.py
+++ b/kunquat/tracker/ui/views/processor/rangemapproc.py
@@ -54,8 +54,8 @@ class RangeMapProc(QWidget, ProcessorUpdater):
     def _on_setup(self):
         self.register_action(self._get_update_signal_type(), self._update_all)
 
-        self._from_min.valueChanged.connect(self._set_from_min)
-        self._from_max.valueChanged.connect(self._set_from_max)
+        self._from_min.editingFinished.connect(self._set_from_min)
+        self._from_max.editingFinished.connect(self._set_from_max)
         self._min_to.valueChanged.connect(self._set_min_to)
         self._max_to.valueChanged.connect(self._set_max_to)
         self._clamp_dest_min.stateChanged.connect(self._set_clamp_dest_min)
@@ -80,15 +80,15 @@ class RangeMapProc(QWidget, ProcessorUpdater):
         self._clamp_dest_min.set_enabled(params.get_clamp_dest_min())
         self._clamp_dest_max.set_enabled(params.get_clamp_dest_max())
 
-    def _set_from_min(self, value):
+    def _set_from_min(self):
         params = self._get_range_map_params()
-        params.set_from_min(value)
+        params.set_from_min(self._from_min.value())
         params.set_from_max(max(params.get_from_min(), params.get_from_max()))
         self._updater.signal_update(self._get_update_signal_type())
 
-    def _set_from_max(self, value):
+    def _set_from_max(self):
         params = self._get_range_map_params()
-        params.set_from_max(value)
+        params.set_from_max(self._from_max.value())
         params.set_from_min(min(params.get_from_min(), params.get_from_max()))
         self._updater.signal_update(self._get_update_signal_type())
 


### PR DESCRIPTION
This branch fixes an issue where an overzealous validity check would destroy an existing range boundary value while the other value was being edited.