### PR TITLE
Fix compilation on newer GCC versions (at least 8.1)

### DIFF
--- a/src/file/lib/file.c
+++ b/src/file/lib/file.c
@@ -103,8 +103,7 @@ static void set_error_va_list(Module* module, const char* message, va_list args)
 
     if (module != NULL)
     {
-        memset(module->error, 0, ERROR_LENGTH_MAX + 1);
-        strncpy(module->error, null_error, ERROR_LENGTH_MAX);
+        strncpy(module->error, null_error, ERROR_LENGTH_MAX + 1);
     }
 
     return;

--- a/src/lib/init/devices/processors/Proc_padsynth.c
+++ b/src/lib/init/devices/processors/Proc_padsynth.c
@@ -380,7 +380,7 @@ static void make_padsynth_sample(
     rassert(fw != NULL);
 
     char context_str[16] = "";
-    snprintf(context_str, 16, "PADsynth%d", context_index);
+    snprintf(context_str, 16, "PADsynth%hhd", context_index);
     Random_init(random, context_str);
 
     int32_t sample_length = PADSYNTH_DEFAULT_SAMPLE_LENGTH;

--- a/src/lib/init/devices/processors/Proc_padsynth.c
+++ b/src/lib/init/devices/processors/Proc_padsynth.c
@@ -380,7 +380,7 @@ static void make_padsynth_sample(
     rassert(fw != NULL);
 
     char context_str[16] = "";
-    snprintf(context_str, 16, "PADsynth%hhd", context_index);
+    snprintf(context_str, 16, "PADsynth%hd", (unsigned short)context_index);
     Random_init(random, context_str);
 
     int32_t sample_length = PADSYNTH_DEFAULT_SAMPLE_LENGTH;

--- a/src/lib/string/serialise.c
+++ b/src/lib/string/serialise.c
@@ -191,7 +191,7 @@ int serialise_float(char* dest, int size, double value)
         // Exponential notation
 
         // d1.d2d3...
-        strncat(result, &digits[0], 1);
+        result[strlen(result)] = digits[0];
 
         if (strlen(digits) > 1)
         {
@@ -209,7 +209,7 @@ int serialise_float(char* dest, int size, double value)
     {
         const int before_point = shift + 1;
         const int available = (int)strlen(digits);
-        strncat(result, digits, (size_t)min(before_point, available));
+        strncat(result, digits, (size_t)before_point);
 
         if (before_point >= available)
         {


### PR DESCRIPTION
This fixes warnings (i.e. errors) with
- snprintf potentially truncating input - the decimal was changed to h:  
  ```c
  snprintf(context_str, 16, "PADsynth%hd", (unsigned short)context_index);
  ```  
  I assume that adding hh is safe, since sample count is asserted to be below 128. It might be better to change the function argument to unsigned short though?
- Appending a single character in serialize was changed from `strncat` to direct assignment:  
  ```c
  -        strncat(result, &digits[0], 1);
  +        result[strlen(result)] = digits[0];
  ```  
  Otherwise, GCC would complain that strncat possibly truncates `digits` when assigning.
- `strncat` stops if input runs out, so unless I'm missing something, using `strlen` was  unnecessary and caused a warning:
  ```c
  -        strncat(result, digits, (size_t)min(before_point, available));
  +        strncat(result, digits, (size_t)before_point);
  ```

-  Fix warning about strncpy potentially truncating. The `memset` was unnecessary, since strncpy will do the zero-padding. Note that the length argument to strncpy specifies the maximum length of bytes operated on, not the length of the string, thus `ERROR_LENGTH_MAX + 1` would be correct.
  ```c
  vsnprintf(null_error, ERROR_LENGTH_MAX + 1, message, args);
  if (module != NULL)
  {
  -        memset(module->error, 0, ERROR_LENGTH_MAX + 1);
  -        strncpy(module->error, null_error, ERROR_LENGTH_MAX);
  +        strncpy(module->error, null_error, ERROR_LENGTH_MAX + 1);
  ```