### PR TITLE
Centralised action calls

### DIFF
--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -2,7 +2,7 @@
 
 #
 # Authors: Toni Ruottu, Finland 2013-2014
-#          Tomi Jylhä-Ollila, Finland 2014-2017
+#          Tomi Jylhä-Ollila, Finland 2014-2018
 #
 # This file is part of Kunquat.
 #
@@ -12,13 +12,17 @@
 # copyright and related or neighboring rights to Kunquat.
 #
 
+from collections import OrderedDict
+
 
 class Updater():
 
     def __init__(self):
         self._update_signals = set(['signal_init'])
         self._updaters = set()
-        self._iterator = set()
+        self._actions = OrderedDict()
+        self._upcoming_actions = []
+        self._removed_actor_ids = []
         self._is_updating = False
 
     def signal_update(self, *signals):
@@ -28,15 +32,48 @@ class Updater():
             assert type(s) == str
         self._update_signals |= set([*signals])
 
+    def _update_actions(self):
+        assert not self._is_updating
+
+        for signal, action_info in self._upcoming_actions:
+            if signal not in self._actions:
+                self._actions[signal] = []
+            assert action_info not in self._actions[signal]
+            self._actions[signal].append(action_info)
+        self._upcoming_actions = []
+
+        if self._removed_actor_ids:
+            new_actions = OrderedDict()
+            for signal, action_list in self._actions.items():
+                new_actions[signal] = [elem for elem in action_list
+                        if elem[0] not in self._removed_actor_ids]
+            self._actions = new_actions
+            self._removed_actor_ids = []
+
+    def register_actions(self, actions):
+        if not actions:
+            return
+
+        self._upcoming_actions.extend(actions)
+        if not self._is_updating:
+            self._update_actions()
+
+    def unregister_actions(self, actor_id):
+        self._removed_actor_ids.append(actor_id)
+        if not self._is_updating:
+            self._update_actions()
+
     def register_updater(self, updater):
         self._updaters.add(updater)
 
     def unregister_updater(self, updater):
         self._updaters.remove(updater)
-        self._iterator -= set([updater])
 
     def perform_updates(self):
+        self._update_actions()
+
         self._is_updating = True
+
         try:
             self._perform_updates()
         finally:
@@ -45,13 +82,39 @@ class Updater():
     def _perform_updates(self):
         if not self._update_signals:
             return
-        self._iterator = set(self._updaters)
-        while len(self._iterator) > 0:
-            updater = self._iterator.pop()
+
+        called_action_infos = set()
+        for signal in self._update_signals:
+            if signal in self._actions:
+                for action_info in self._actions[signal]:
+                    if action_info not in called_action_infos:
+                        called_action_infos.add(action_info)
+                        _, action, _ = action_info
+                        action()
+
+        iterator = set(self._updaters)
+        while len(iterator) > 0:
+            updater = iterator.pop()
             updater(self._update_signals)
         self._update_signals = set()
 
     def verify_ready_to_exit(self):
+        self._update_actions()
+
+        live_actions = []
+        last_signal = None
+        for signal, actions in self._actions.items():
+            for a in actions:
+                if signal != last_signal:
+                    live_actions.append('{}:'.format(signal))
+                    last_signal = signal
+                _, action, _ = a
+                live_actions.append('    {}'.format(str(action)))
+        if live_actions:
+            actions_str = '\n'.join(a for a in live_actions)
+            raise RuntimeError(
+                    'Actions left on exit:\n{}'.format(actions_str))
+
         if self._updaters:
             updaters_str = '\n'.join(str(u) for u in self._updaters)
             raise RuntimeError(

--- a/kunquat/tracker/ui/views/octavebutton.py
+++ b/kunquat/tracker/ui/views/octavebutton.py
@@ -14,8 +14,10 @@
 
 from kunquat.tracker.ui.qt import *
 
+from .updater import Updater
 
-class OctaveButton(QPushButton):
+
+class OctaveButton(QPushButton, Updater):
 
     def __init__(self, octave_id):
         super().__init__()
@@ -45,21 +47,21 @@ class OctaveButton(QPushButton):
     def _select_octave(self):
         self._typewriter_mgr.set_octave(self._octave_id)
 
-    def set_ui_model(self, ui_model):
-        self._ui_model = ui_model
-        self._updater = ui_model.get_updater()
-        self._updater.register_updater(self._perform_updates)
-        self._control_mgr = ui_model.get_control_manager()
-        self._typewriter_mgr = ui_model.get_typewriter_manager()
+    def _on_setup(self):
+        self._control_mgr = self._ui_model.get_control_manager()
+        self._typewriter_mgr = self._ui_model.get_typewriter_manager()
         self._button_model = self._typewriter_mgr.get_octave_button_model(
                 self._octave_id)
+
+        self.register_action('signal_notation', self._update_name)
+        self.register_action('signal_select_keymap', self._update_name)
+        self.register_action('signal_octave', self._update_pressed)
+        self.register_action('signal_init', self._update_pressed)
+        self.register_action('signal_style_changed', self._update_style)
 
         self._update_name()
         self._update_pressed()
         self._update_style()
-
-    def unregister_updaters(self):
-        self._updater.unregister_updater(self._perform_updates)
 
     def update_led_state(self, enabled):
         if enabled:
@@ -83,16 +85,5 @@ class OctaveButton(QPushButton):
         style_mgr = self._ui_model.get_style_manager()
         self.setFixedWidth(style_mgr.get_scaled_size_param('typewriter_button_size'))
         self._led.setFixedWidth(style_mgr.get_scaled_size(1.5))
-
-    def _perform_updates(self, signals):
-        name_update_signals = set(['signal_notation', 'signal_select_keymap'])
-        if not signals.isdisjoint(name_update_signals):
-            self._update_name()
-
-        if any(s in signals for s in ['signal_octave', 'signal_init']):
-            self._update_pressed()
-
-        if 'signal_style_changed' in signals:
-            self._update_style()
 
 


### PR DESCRIPTION
This branch fixes #826. Additionally, some typewriter widgets use the new action registration system and thus no longer do individual signal checks on every update. A more complete pass over the other "busy-waiters" will happen in a later branch.