### PR TITLE
Eliminate unconditional widget updates

### DIFF
--- a/kunquat/tracker/audio/audioengine.py
+++ b/kunquat/tracker/audio/audioengine.py
@@ -260,7 +260,7 @@ class AudioEngine():
                 self._ui_engine.update_render_speed(self._render_speed)
                 self._ui_engine.update_render_load(ratio)
 
-            self._ui_engine.update_audio_levels(self._audio_levels)
+            self._ui_engine.notify_audio_rendered(self._audio_levels)
             if self._send_voice_info:
                 self.tfire_event(0, ('qvoices', None))
                 self._send_voice_info = False

--- a/kunquat/tracker/processes/uiprocess.py
+++ b/kunquat/tracker/processes/uiprocess.py
@@ -106,6 +106,9 @@ class UiProcess(Process):
     def update_drivers(self, drivers):
         self._q.put('update_drivers', drivers)
 
+    def notify_audio_rendered(self, levels):
+        self._q.put('notify_audio_rendered', levels)
+
     def update_selected_driver(self, driver_class):
         self._q.put('update_selected_driver', driver_class)
 
@@ -117,9 +120,6 @@ class UiProcess(Process):
 
     def update_render_load(self, ratio):
         self._q.put('update_render_load', ratio)
-
-    def update_audio_levels(self, levels):
-        self._q.put('update_audio_levels', levels)
 
     def update_selected_control(self, channel_number, control_number):
         self._q.put('update_selected_control', channel_number, control_number)

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -575,6 +575,10 @@ class Controller():
     def notify_libkunquat_error(self, e):
         raise e
 
+    def notify_audio_rendered(self, levels):
+        self._session.set_audio_levels(levels)
+        self._updater.signal_update('signal_audio_rendered')
+
     def update_output_speed(self, fps):
         self._session.set_output_speed(fps)
         self._updater.signal_update()
@@ -585,10 +589,6 @@ class Controller():
 
     def update_render_load(self, load):
         self._session.set_render_load(load)
-        self._updater.signal_update()
-
-    def update_audio_levels(self, levels):
-        self._session.set_audio_levels(levels)
         self._updater.signal_update()
 
     def update_ui_load(self, load):

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -673,7 +673,7 @@ class Controller():
 
     def update_event_log_with(self, channel_number, event_type, event_value, context):
         self._session.log_event(channel_number, event_type, event_value, context)
-        self._updater.signal_update()
+        self._updater.signal_update('signal_event_log_updated')
 
     def update_import_progress(self, progress):
         self._update_progress_step(progress)

--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -95,6 +95,8 @@ class Controller():
     def set_updater(self, updater):
         self._updater = updater
 
+        self._store.set_updater(self._updater)
+
     def get_updater(self):
         return self._updater
 
@@ -581,19 +583,19 @@ class Controller():
 
     def update_output_speed(self, fps):
         self._session.set_output_speed(fps)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def update_render_speed(self, fps):
         self._session.set_render_speed(fps)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def update_render_load(self, load):
         self._session.set_render_load(load)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def update_ui_load(self, load):
         self._session.set_ui_load(load)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def add_ui_load_average(self, load_avg):
         self._session.add_ui_load_average(load_avg)
@@ -605,11 +607,11 @@ class Controller():
 
     def update_selected_control(self, channel, control_id):
         self._session.set_selected_control_id_by_channel(channel, control_id)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def update_active_note(self, channel, event_type, pitch):
         self._session.set_active_note(channel, event_type, pitch)
-        self._updater.signal_update()
+        #self._updater.signal_update()
 
     def update_active_var_name(self, ch, var_name):
         self._session.set_active_var_name(ch, var_name)
@@ -731,8 +733,8 @@ def create_controller():
     controller.set_store(store)
     controller.set_session(session)
     controller.set_share(share)
-    controller.set_updater(updater)
     controller.set_note_channel_mapper(note_channel_mapper)
+    controller.set_updater(updater)
     return controller
 
 

--- a/kunquat/tracker/ui/controller/session.py
+++ b/kunquat/tracker/ui/controller/session.py
@@ -130,6 +130,7 @@ class Session():
         self._edit_mode_enabled = False
         self._typewriter_connected = False
         self._replace_mode_enabled = False
+        self._column_updates = []
 
         # Grids
         self._is_grid_enabled = True
@@ -600,6 +601,15 @@ class Session():
 
     def get_replace_mode(self):
         return self._replace_mode_enabled
+
+    def add_column_update(self, track_num, system_num, col_num):
+        self._column_updates.append((track_num, system_num, col_num))
+
+    def get_column_updates(self):
+        return self._column_updates
+
+    def clear_column_updates(self):
+        self._column_updates = []
 
     def set_playback_active(self, active):
         self._is_playback_active = active

--- a/kunquat/tracker/ui/controller/session.py
+++ b/kunquat/tracker/ui/controller/session.py
@@ -45,7 +45,8 @@ class Session():
 
     def __init__(self):
         # Visibility
-        self._visible = set()
+        self._visible_uis = set()
+        self._signalled_uis = set()
 
         # Stats
         self._output_speed = 0
@@ -446,17 +447,27 @@ class Session():
 
     def show_ui(self, ui_id):
         assert ui_id
-        self._visible.add(ui_id)
+        self._visible_uis.add(ui_id)
 
     def hide_ui(self, ui_id):
         assert ui_id
-        self._visible -= set([ui_id])
+        self._visible_uis.discard(ui_id)
 
     def hide_all(self):
-        self._visible = set()
+        self._visible_uis = set()
 
     def get_visible(self):
-        return self._visible
+        return self._visible_uis
+
+    def signal_ui(self, ui_id):
+        assert ui_id
+        self._signalled_uis.add(ui_id)
+
+    def get_signalled_uis(self):
+        return self._signalled_uis
+
+    def clear_signalled_uis(self):
+        self._signalled_uis = set()
 
     def log_event(self, channel, event_type, event_value, context):
         if context != 'tfire':

--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -28,11 +28,11 @@ class Updater():
     def signal_update(self, *signals):
         assert not self._is_updating
 
-        if self._deferred_update_signals:
-            self._update_signals = self._deferred_update_signals
-            self._deferred_update_signals = []
-        else:
-            if not self._update_signals:
+        if not self._update_signals:
+            if self._deferred_update_signals:
+                self._update_signals = self._deferred_update_signals
+                self._deferred_update_signals = []
+            else:
                 self._update_signals.append('signal_change')
 
         for s in signals:

--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -32,8 +32,6 @@ class Updater():
             if self._deferred_update_signals:
                 self._update_signals = self._deferred_update_signals
                 self._deferred_update_signals = []
-            else:
-                self._update_signals.append('signal_change')
 
         for s in signals:
             assert type(s) == str
@@ -41,9 +39,6 @@ class Updater():
                 self._update_signals.append(s)
 
     def signal_update_deferred(self, *signals):
-        if not self._deferred_update_signals:
-            self._deferred_update_signals.append('signal_change')
-
         for s in signals:
             assert type(s) == str
             if s not in self._deferred_update_signals:
@@ -94,9 +89,6 @@ class Updater():
         if self._deferred_update_signals:
             self._update_signals = self._deferred_update_signals + self._update_signals
             self._deferred_update_signals = []
-
-        if not self._update_signals:
-            return
 
         called_action_infos = set()
         for signal in self._update_signals:

--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 class Updater():
 
     def __init__(self):
-        self._update_signals = set(['signal_init'])
+        self._update_signals = ['signal_init']
         self._updaters = set()
         self._actions = OrderedDict()
         self._upcoming_actions = []
@@ -27,10 +27,14 @@ class Updater():
 
     def signal_update(self, *signals):
         assert not self._is_updating
-        self._update_signals.add('signal_change')
+
+        if not self._update_signals:
+            self._update_signals.append('signal_change')
+
         for s in signals:
             assert type(s) == str
-        self._update_signals |= set([*signals])
+            if s not in self._update_signals:
+                self._update_signals.append(s)
 
     def _update_actions(self):
         assert not self._is_updating
@@ -95,8 +99,8 @@ class Updater():
         iterator = set(self._updaters)
         while len(iterator) > 0:
             updater = iterator.pop()
-            updater(self._update_signals)
-        self._update_signals = set()
+            updater(set(self._update_signals))
+        self._update_signals = []
 
     def verify_ready_to_exit(self):
         self._update_actions()

--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -19,6 +19,7 @@ class Updater():
 
     def __init__(self):
         self._update_signals = ['signal_init']
+        self._deferred_update_signals = []
         self._updaters = set()
         self._actions = OrderedDict()
         self._upcoming_actions = []
@@ -28,13 +29,26 @@ class Updater():
     def signal_update(self, *signals):
         assert not self._is_updating
 
-        if not self._update_signals:
-            self._update_signals.append('signal_change')
+        if self._deferred_update_signals:
+            self._update_signals = self._deferred_update_signals
+            self._deferred_update_signals = []
+        else:
+            if not self._update_signals:
+                self._update_signals.append('signal_change')
 
         for s in signals:
             assert type(s) == str
             if s not in self._update_signals:
                 self._update_signals.append(s)
+
+    def signal_update_deferred(self, *signals):
+        if not self._deferred_update_signals:
+            self._deferred_update_signals.append('signal_change')
+
+        for s in signals:
+            assert type(s) == str
+            if s not in self._deferred_update_signals:
+                self._deferred_update_signals.append(s)
 
     def _update_actions(self):
         assert not self._is_updating
@@ -84,6 +98,10 @@ class Updater():
             self._is_updating = False
 
     def _perform_updates(self):
+        if self._deferred_update_signals:
+            self._update_signals = self._deferred_update_signals + self._update_signals
+            self._deferred_update_signals = []
+
         if not self._update_signals:
             return
 

--- a/kunquat/tracker/ui/controller/updater.py
+++ b/kunquat/tracker/ui/controller/updater.py
@@ -20,7 +20,6 @@ class Updater():
     def __init__(self):
         self._update_signals = ['signal_init']
         self._deferred_update_signals = []
-        self._updaters = set()
         self._actions = OrderedDict()
         self._upcoming_actions = []
         self._removed_actor_ids = []
@@ -81,12 +80,6 @@ class Updater():
         if not self._is_updating:
             self._update_actions()
 
-    def register_updater(self, updater):
-        self._updaters.add(updater)
-
-    def unregister_updater(self, updater):
-        self._updaters.remove(updater)
-
     def perform_updates(self):
         self._update_actions()
 
@@ -114,10 +107,6 @@ class Updater():
                         _, action, _ = action_info
                         action()
 
-        iterator = set(self._updaters)
-        while len(iterator) > 0:
-            updater = iterator.pop()
-            updater(set(self._update_signals))
         self._update_signals = []
 
     def verify_ready_to_exit(self):
@@ -136,10 +125,5 @@ class Updater():
             actions_str = '\n'.join(a for a in live_actions)
             raise RuntimeError(
                     'Actions left on exit:\n{}'.format(actions_str))
-
-        if self._updaters:
-            updaters_str = '\n'.join(str(u) for u in self._updaters)
-            raise RuntimeError(
-                    'Updaters left on exit:\n{}'.format(updaters_str))
 
 

--- a/kunquat/tracker/ui/model/sheethistory.py
+++ b/kunquat/tracker/ui/model/sheethistory.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2016-2017
+# Author: Tomi Jylhä-Ollila, Finland 2016-2018
 #
 # This file is part of Kunquat.
 #
@@ -46,7 +46,7 @@ class SheetHistory():
     def add_step(self, transaction, location, commit=True):
         cur_step = self._session.get_sheet_cur_step()
         if not cur_step:
-            cur_step = Step(self._store, self._ui_model)
+            cur_step = Step(self._store, self._session, self._ui_model)
             self._session.set_sheet_cur_step(cur_step)
         cur_step.add_transaction(transaction, location)
 
@@ -116,8 +116,9 @@ class SheetHistory():
 
 class Step():
 
-    def __init__(self, store, ui_model):
+    def __init__(self, store, session, ui_model):
         self._store = store
+        self._session = session
         self._ui_model = ui_model
         self._updater = ui_model.get_updater()
 
@@ -182,8 +183,8 @@ class Step():
                 track_num, system_num = album.get_pattern_instance_location_by_nums(
                         pat_num, inst_num)
 
-                self._updater.signal_update(SheetManager.encode_column_signal(
-                    track_num, system_num, col_num))
+                self._session.add_column_update(track_num, system_num, col_num)
+                self._updater.signal_update('signal_column_updated')
                 return
 
         elif re.match('pat_[0-9a-f]{3}/col_[0-9a-f]{2}/i_overlay_grids.json', key):

--- a/kunquat/tracker/ui/model/visibilitymanager.py
+++ b/kunquat/tracker/ui/model/visibilitymanager.py
@@ -41,19 +41,16 @@ class VisibilityManager():
         self._session.hide_all()
 
     def show_main(self):
-        if self._is_closing:
-            return
-        self._session.show_ui(UI_MAIN)
-        self._updater.signal_update()
+        self._show_window(UI_MAIN)
 
     def hide_main(self):
-        self._session.hide_ui(UI_MAIN)
-        self._updater.signal_update()
+        self._hide_window(UI_MAIN)
+        self.hide_all()
 
     def hide_main_after_saving(self):
-        # XXX: This hacky version can be called from an update function
-        #      It only works because there are always some signals emitted
         self._session.hide_ui(UI_MAIN)
+        self.hide_all()
+        self._updater.signal_update_deferred('signal_visibility')
 
     def set_input_control_view(self, mode):
         config = get_config()
@@ -66,44 +63,42 @@ class VisibilityManager():
     def _show_window(self, ui):
         if self._is_closing:
             return
+        if ui in self.get_visible():
+            self._session.signal_ui(ui)
         self._session.show_ui(ui)
 
-        if type(ui) == str:
-            signal = 'signal_window_{}'.format(ui)
-        else:
-            signal = 'signal_window_{}_{}'.format(ui[0], ui[1])
-        self._updater.signal_update(signal)
+        self._updater.signal_update('signal_visibility')
+
+    def _hide_window(self, ui):
+        self._session.hide_ui(ui)
+        self._updater.signal_update('signal_visibility')
 
     def show_about(self):
         self._show_window(UI_ABOUT)
 
     def hide_about(self):
-        self._session.hide_ui(UI_ABOUT)
-        self._updater.signal_update()
+        self._hide_window(UI_ABOUT)
 
     def show_event_log(self):
         self._show_window(UI_EVENT_LOG)
 
     def hide_event_log(self):
-        self._session.hide_ui(UI_EVENT_LOG)
-        self._updater.signal_update()
+        self._hide_window(UI_EVENT_LOG)
 
     def show_connections(self):
         self._show_window(UI_CONNECTIONS)
 
     def hide_connections(self):
-        self._session.hide_ui(UI_CONNECTIONS)
-        self._updater.signal_update()
+        self._hide_window(UI_CONNECTIONS)
 
     def show_audio_unit(self, au_id):
         self._show_window((UI_AUDIO_UNIT, au_id))
 
     def hide_audio_unit(self, au_id):
-        self._session.hide_ui((UI_AUDIO_UNIT, au_id))
-        self._updater.signal_update()
+        self._hide_window((UI_AUDIO_UNIT, au_id))
 
     def hide_audio_unit_and_subdevices(self, au_id):
-        self._session.hide_ui((UI_AUDIO_UNIT, au_id))
+        self._hide_window((UI_AUDIO_UNIT, au_id))
 
         visible_entries = self._session.get_visible()
 
@@ -113,7 +108,7 @@ class VisibilityManager():
                 (e[0] == UI_AUDIO_UNIT) and
                 e[1].startswith(au_prefix))
         for au_entry in au_entries:
-            self._session.hide_ui(au_entry)
+            self._hide_window(au_entry)
 
         proc_prefix = '{}/'.format(au_id)
         proc_entries = set(e for e in visible_entries
@@ -121,81 +116,74 @@ class VisibilityManager():
                 (e[0] == UI_PROCESSOR) and
                 e[1].startswith(proc_prefix))
         for proc_entry in proc_entries:
-            self._session.hide_ui(proc_entry)
-
-        self._updater.signal_update()
+            self._hide_window(proc_entry)
 
     def show_songs_channels(self):
         self._show_window(UI_SONGS_CHS)
 
     def hide_songs_channels(self):
-        self._session.hide_ui(UI_SONGS_CHS)
-        self._updater.signal_update()
+        self._hide_window(UI_SONGS_CHS)
 
     def show_env_and_bindings(self):
         self._show_window(UI_ENV_BIND)
 
     def hide_env_and_bindings(self):
-        self._session.hide_ui(UI_ENV_BIND)
-        self._updater.signal_update()
+        self._hide_window(UI_ENV_BIND)
 
     def show_processor(self, proc_id):
         self._show_window((UI_PROCESSOR, proc_id))
 
     def hide_processor(self, proc_id):
-        self._session.hide_ui((UI_PROCESSOR, proc_id))
-        self._updater.signal_update()
+        self._hide_window((UI_PROCESSOR, proc_id))
 
     def show_grid_editor(self):
         self._show_window(UI_GRID_EDITOR)
 
     def hide_grid_editor(self):
-        self._session.hide_ui(UI_GRID_EDITOR)
-        self._updater.signal_update()
+        self._hide_window(UI_GRID_EDITOR)
 
     def show_notation_editor(self):
         self._show_window(UI_NOTATION)
 
     def hide_notation_editor(self):
-        self._session.hide_ui(UI_NOTATION)
-        self._updater.signal_update()
+        self._hide_window(UI_NOTATION)
 
     def show_tuning_table_editor(self, table_id):
         self._show_window((UI_TUNING_TABLE, table_id))
 
     def hide_tuning_table_editor(self, table_id):
-        self._session.hide_ui((UI_TUNING_TABLE, table_id))
-        self._updater.signal_update()
+        self._hide_window((UI_TUNING_TABLE, table_id))
 
     def show_general_module_settings(self):
         self._show_window(UI_GENERAL_MOD)
 
     def hide_general_module_settings(self):
-        self._session.hide_ui(UI_GENERAL_MOD)
-        self._updater.signal_update()
+        self._hide_window(UI_GENERAL_MOD)
 
     def show_settings(self):
         self._show_window(UI_SETTINGS)
 
     def hide_settings(self):
-        self._session.hide_ui(UI_SETTINGS)
-        self._updater.signal_update()
+        self._hide_window(UI_SETTINGS)
 
     def show_render_stats(self):
         self._show_window(UI_RENDER_STATS)
 
     def hide_render_stats(self):
-        self._session.hide_ui(UI_RENDER_STATS)
-        self._updater.signal_update()
+        self._hide_window(UI_RENDER_STATS)
 
     def show_interactivity_controls(self):
         self._show_window(UI_IA_CONTROLS)
 
     def hide_interactivity_controls(self):
-        self._session.hide_ui(UI_IA_CONTROLS)
-        self._updater.signal_update()
+        self._hide_window(UI_IA_CONTROLS)
 
     def get_visible(self):
         return self._session.get_visible()
+
+    def get_and_clear_signalled(self):
+        signalled = self._session.get_signalled_uis()
+        self._session.clear_signalled_uis()
+        return signalled
 
 

--- a/kunquat/tracker/ui/views/bindeditor.py
+++ b/kunquat/tracker/ui/views/bindeditor.py
@@ -397,6 +397,8 @@ class ConstraintEditor(QWidget, Updater):
 
         self.add_to_updaters(self._remove_button)
 
+        self._is_pending_removal = False
+
         h = QHBoxLayout()
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(2)
@@ -417,18 +419,22 @@ class ConstraintEditor(QWidget, Updater):
                 style_mgr.get_style_param('list_button_padding'))
 
         self._event.currentIndexChanged.connect(self._change_event)
-
         self._expression.editingFinished.connect(self._change_expression)
-
         self._remove_button.clicked.connect(self._remove)
 
         self._update_all()
+
+    def _on_teardown(self):
+        self._is_pending_removal = True
 
     def _update_style(self):
         style_mgr = self._ui_model.get_style_manager()
         self.layout().setSpacing(style_mgr.get_scaled_size_param('small_padding'))
 
     def _update_all(self):
+        if self._is_pending_removal:
+            return
+
         bindings = self._ui_model.get_module().get_bindings()
         if not bindings.has_selected_binding():
             return
@@ -468,6 +474,8 @@ class ConstraintEditor(QWidget, Updater):
         self._updater.signal_update('signal_bind')
 
     def _remove(self):
+        self._is_pending_removal = True
+
         bindings = self._ui_model.get_module().get_bindings()
         binding = bindings.get_selected_binding()
         binding.get_constraints().remove_constraint(self._index)
@@ -575,6 +583,8 @@ class TargetEditor(QWidget, Updater):
 
         self.add_to_updaters(self._remove_button)
 
+        self._is_pending_removal = False
+
         h = QHBoxLayout()
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(2)
@@ -604,11 +614,17 @@ class TargetEditor(QWidget, Updater):
         self._update_style()
         self._update_all()
 
+    def _on_teardown(self):
+        self._is_pending_removal = True
+
     def _update_style(self):
         style_mgr = self._ui_model.get_style_manager()
         self.layout().setSpacing(style_mgr.get_scaled_size_param('small_padding'))
 
     def _update_all(self):
+        if self._is_pending_removal:
+            return
+
         bindings = self._ui_model.get_module().get_bindings()
         if not bindings.has_selected_binding():
             return
@@ -676,6 +692,8 @@ class TargetEditor(QWidget, Updater):
         self._updater.signal_update('signal_bind')
 
     def _remove(self):
+        self._is_pending_removal = True
+
         bindings = self._ui_model.get_module().get_bindings()
         binding = bindings.get_selected_binding()
         binding.get_targets().remove_target(self._index)

--- a/kunquat/tracker/ui/views/hitmaptoggle.py
+++ b/kunquat/tracker/ui/views/hitmaptoggle.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2017
+# Author: Tomi Jylhä-Ollila, Finland 2017-2018
 #
 # This file is part of Kunquat.
 #
@@ -13,8 +13,10 @@
 
 from kunquat.tracker.ui.qt import *
 
+from .updater import Updater
 
-class HitMapToggle(QCheckBox):
+
+class HitMapToggle(QCheckBox, Updater):
 
     def __init__(self):
         super().__init__('Use hit keymap')
@@ -24,17 +26,14 @@ class HitMapToggle(QCheckBox):
         self.setToolTip('Use hit keymap (Ctrl + H)')
         self.setFocusPolicy(Qt.NoFocus)
 
-    def set_ui_model(self, ui_model):
-        self._ui_model = ui_model
-        self._updater = ui_model.get_updater()
-        self._updater.register_updater(self._perform_updates)
+    def _on_setup(self):
+        self.register_action('signal_select_keymap', self._update_checked)
 
         self.stateChanged.connect(self._set_hit_map_active)
 
-    def unregister_updaters(self):
-        self._updater.unregister_updater(self._perform_updates)
+        self._update_checked()
 
-    def _perform_updates(self, signals):
+    def _update_checked(self):
         keymap_mgr = self._ui_model.get_keymap_manager()
         is_active = keymap_mgr.is_hit_keymap_active()
         is_checked = (self.checkState() == Qt.Checked)

--- a/kunquat/tracker/ui/views/mainwindow.py
+++ b/kunquat/tracker/ui/views/mainwindow.py
@@ -50,7 +50,7 @@ class MainWindow(Updater, SaverWindow):
                 'signal_save_module_finished',
                 self._exit_helper.notify_save_module_finished)
         self.register_action('signal_module', self._update_title)
-        self.register_action('signal_change', self._update_title)
+        self.register_action('signal_store', self._update_title)
 
         self._update_icon()
         self._update_title()

--- a/kunquat/tracker/ui/views/octaveselector.py
+++ b/kunquat/tracker/ui/views/octaveselector.py
@@ -42,7 +42,7 @@ class OctaveSelector(QFrame, Updater):
     def _on_setup(self):
         self.register_action('signal_select_keymap', self._update_layout)
         self.register_action('signal_notation', self._update_layout)
-        self.register_action('signal_change', self._update_leds)
+        self.register_action('signal_audio_rendered', self._update_leds)
 
         self._typewriter_mgr = self._ui_model.get_typewriter_manager()
         self._update_layout()

--- a/kunquat/tracker/ui/views/orderlist.py
+++ b/kunquat/tracker/ui/views/orderlist.py
@@ -2,7 +2,7 @@
 
 #
 # Authors: Toni Ruottu, Finland 2014
-#          Tomi Jylhä-Ollila, Finland 2014-2017
+#          Tomi Jylhä-Ollila, Finland 2014-2018
 #
 # This file is part of Kunquat.
 #
@@ -332,6 +332,8 @@ class Orderlist(QWidget, Updater):
 
         self._album_tree.selectionModel().currentChanged.connect(self._change_selection)
 
+        self._updater.signal_update_deferred('signal_order_list_updated')
+
     def get_selected_object(self):
         selection_model = self._album_tree.selectionModel()
         index = selection_model.currentIndex()
@@ -357,5 +359,7 @@ class Orderlist(QWidget, Updater):
             album = self._ui_model.get_module().get_album()
             album.set_selected_track_num(song.get_containing_track_number())
             self._updater.signal_update('signal_song')
+
+        self._updater.signal_update('signal_order_list_selection')
 
 

--- a/kunquat/tracker/ui/views/peakmeter.py
+++ b/kunquat/tracker/ui/views/peakmeter.py
@@ -16,6 +16,8 @@ import time
 
 from kunquat.tracker.ui.qt import *
 
+from .updater import Updater
+
 
 DEFAULT_CONFIG = {
         'colours'   : {
@@ -43,13 +45,10 @@ def lerp(from_val, to_val, lerp_val):
     return from_val + (lerp_val * diff)
 
 
-class PeakMeter(QWidget):
+class PeakMeter(QWidget, Updater):
 
     def __init__(self):
         super().__init__()
-        self._ui_model = None
-        self._updater = None
-
         self._config = None
         self._colours = None
         self._dim_colours = None
@@ -144,22 +143,14 @@ class PeakMeter(QWidget):
                 grad_width, self._config['thickness'],
                 fg_grad)
 
-    def set_ui_model(self, ui_model):
-        self._ui_model = ui_model
-        self._updater = ui_model.get_updater()
-        self._updater.register_updater(self._perform_updates)
-        self._stat_mgr = ui_model.get_stat_manager()
+    def _on_setup(self):
+        self._stat_mgr = self._ui_model.get_stat_manager()
+
+        self.register_action('signal_audio_rendered', self._update_levels)
+        self.register_action('signal_style_changed', self._update_style)
 
         self._update_style()
-
-    def unregister_updaters(self):
-        self._updater.unregister_updater(self._perform_updates)
-
-    def _perform_updates(self, signals):
         self._update_levels()
-
-        if 'signal_style_changed' in signals:
-            self._update_style()
 
     def _update_levels(self):
         levels = self._stat_mgr.get_audio_levels()

--- a/kunquat/tracker/ui/views/portal.py
+++ b/kunquat/tracker/ui/views/portal.py
@@ -288,12 +288,10 @@ class RenderLoadMeter(QWidget):
         return QSize(self._config['width'], self._config['height'])
 
 
-class RenderStatsButton(QToolButton):
+class RenderStatsButton(QToolButton, Updater):
 
     def __init__(self):
         super().__init__()
-        self._ui_model = None
-        self._updater = None
         self._stat_mgr = None
 
         self._load_meter = RenderLoadMeter()
@@ -307,24 +305,19 @@ class RenderStatsButton(QToolButton):
         h.addWidget(label)
         self.setLayout(h)
 
-    def set_ui_model(self, ui_model):
-        self._ui_model = ui_model
-        self._updater = ui_model.get_updater()
-        self._updater.register_updater(self._perform_updates)
-        self._stat_mgr = ui_model.get_stat_manager()
+    def _on_setup(self):
+        self._stat_mgr = self._ui_model.get_stat_manager()
+
+        self.register_action('signal_audio_rendered', self._update_load_meter)
+        self.register_action('signal_style_changed', self._update_style)
 
         self.clicked.connect(self._clicked)
 
+        self._update_load_meter()
         self._update_style()
 
-    def unregister_updaters(self):
-        self._updater.unregister_updater(self._perform_updates)
-
-    def _perform_updates(self, signals):
+    def _update_load_meter(self):
         self._load_meter.set_load_norm(self._stat_mgr.get_render_load())
-
-        if 'signal_style_changed' in signals:
-            self._update_style()
 
     def _update_style(self):
         style_mgr = self._ui_model.get_style_manager()

--- a/kunquat/tracker/ui/views/portal.py
+++ b/kunquat/tracker/ui/views/portal.py
@@ -111,7 +111,7 @@ class FileButton(QToolButton, Updater):
 
     def _on_setup(self):
         self.register_action('signal_module', self._set_module_loaded)
-        self.register_action('signal_change', self._update_save_enabled)
+        self.register_action('signal_store', self._update_save_enabled)
         self.register_action(
                 'signal_save_module_finished', self._on_save_module_finished)
 
@@ -123,6 +123,8 @@ class FileButton(QToolButton, Updater):
         self._save_as_action.triggered.connect(self._save_as)
         self._quit_action.triggered.connect(self._quit)
 
+        self._update_save_enabled()
+
     def _set_module_loaded(self):
         self._module_loaded = True
 
@@ -130,6 +132,8 @@ class FileButton(QToolButton, Updater):
         if self._module_loaded:
             module = self._ui_model.get_module()
             self._save_action.setEnabled(module.is_modified())
+        else:
+            self._save_action.setEnabled(False)
 
     def _on_save_module_finished(self):
         self._exit_helper.notify_save_module_finished()

--- a/kunquat/tracker/ui/views/rootview.py
+++ b/kunquat/tracker/ui/views/rootview.py
@@ -90,8 +90,6 @@ class RootView(Updater):
 
         self.add_to_updaters(self._main_window)
 
-        self._update_visibility()
-
     def _on_teardown(self):
         self._style_creator.unregister_updaters()
 

--- a/kunquat/tracker/ui/views/rootview.py
+++ b/kunquat/tracker/ui/views/rootview.py
@@ -32,70 +32,73 @@ from .procwindow import ProcWindow
 from .sheet.grideditorwindow import GridEditorWindow
 from .iawindow import IAWindow
 from .renderstatswindow import RenderStatsWindow
+from .updater import Updater
 from . import utils
 
 
-class RootView():
+class RootView(Updater):
 
     def __init__(self):
-        self._ui_model = None
-        self._updater = None
+        super().__init__()
+
         self._visible = set()
 
         self._style_creator = StyleCreator()
         self._crash_dialog = None
 
         self._main_window = MainWindow()
-        self._about_window = None
-        self._event_log = None
-        self._connections = None
-        self._songs_channels = None
-        self._notation = None
-        self._tuning_tables = {}
-        self._env_bind = None
-        self._general_mod = None
-        self._settings = None
-        self._au_windows = {}
-        self._proc_windows = {}
-        self._grid_editor = None
-        self._ia_controls = None
-        self._render_stats = None
-        self._progress_window = None
+        self._single_windows = {}
+        self._mult_windows = {
+            UI_TUNING_TABLE:    {},
+            UI_AUDIO_UNIT:      {},
+            UI_PROCESSOR:       {},
+        }
 
         self._module = None
 
+        self._progress_window = None
         self._load_error_dialog = None
         self._au_import_error_dialog = None
 
-        self._window_raise_signals = set('signal_window_{}'.format(ui) for ui in [
-                UI_ABOUT,
-                UI_EVENT_LOG,
-                UI_CONNECTIONS,
-                UI_SONGS_CHS,
-                UI_NOTATION,
-                UI_ENV_BIND,
-                UI_GENERAL_MOD,
-                UI_SETTINGS,
-                UI_GRID_EDITOR,
-                UI_IA_CONTROLS,
-                UI_RENDER_STATS,
-            ])
-        self._window_raise_signal_prefixes = tuple('signal_window_{}'.format(ui)
-                for ui in [UI_TUNING_TABLE, UI_AUDIO_UNIT, UI_PROCESSOR])
+    def _on_setup(self):
+        self._style_creator.set_ui_model(self._ui_model)
 
-    def set_ui_model(self, ui_model):
-        self._ui_model = ui_model
-
-        self._style_creator.set_ui_model(ui_model)
-        self._main_window.set_ui_model(ui_model)
-        self._updater = self._ui_model.get_updater()
-        self._updater.register_updater(self._perform_updates)
         self._module = self._ui_model.get_module()
+
+        self.register_action('signal_visibility', self._update_visibility)
+        self.register_action('signal_audio_rendered', self._send_audio_state_queries)
+
+        self.register_action('signal_module', self._on_module_setup_finished)
+        self.register_action('signal_start_save_module', self._start_save_module)
+        self.register_action(
+                'signal_save_module_finished', self._on_save_module_finished)
+        self.register_action('signal_start_import_au', self._start_import_au)
+        self.register_action('signal_au_import_error', self._on_au_import_error)
+        self.register_action('signal_au_import_finished', self._on_au_import_finished)
+        self.register_action('signal_start_export_au', self._start_export_au)
+        self.register_action('signal_export_au_finished', self._on_export_au_finished)
+        self.register_action('signal_progress_start', self._show_progress_window)
+        self.register_action('signal_progress_step', self._update_progress_window)
+        self.register_action('signal_progress_finished', self._hide_progress_window)
+        self.register_action('signal_module_load_error', self._on_module_load_error)
+        self.register_action('signal_style_changed', self._update_style)
 
         style_mgr = self._ui_model.get_style_manager()
         style_mgr.set_init_style_sheet(QApplication.instance().styleSheet())
         style_sheet = self._style_creator.get_updated_style_sheet()
         QApplication.instance().setStyleSheet(style_sheet)
+
+        self.add_to_updaters(self._main_window)
+
+        self._update_visibility()
+
+    def _on_teardown(self):
+        self._style_creator.unregister_updaters()
+
+    def _update_style(self):
+        style_sheet = self._style_creator.get_updated_style_sheet()
+        QApplication.instance().setStyleSheet(style_sheet)
+        self._crash_dialog.update_style(self._ui_model.get_style_manager())
 
     def set_crash_dialog(self, crash_dialog):
         self._crash_dialog = crash_dialog
@@ -116,12 +119,32 @@ class RootView():
         else:
             module.execute_create_sandbox(task_executor)
 
-    def _perform_updates(self, signals):
+    def _update_visibility(self):
         visibility_mgr = self._ui_model.get_visibility_manager()
         visibility_update = visibility_mgr.get_visible()
 
         opened = visibility_update - self._visible
         closed = self._visible - visibility_update
+
+        single_window_cons = {
+            UI_ABOUT:           AboutWindow,
+            UI_EVENT_LOG:       EventListWindow,
+            UI_CONNECTIONS:     ConnectionsWindow,
+            UI_SONGS_CHS:       SongsChannelsWindow,
+            UI_NOTATION:        NotationWindow,
+            UI_ENV_BIND:        EnvBindWindow,
+            UI_GENERAL_MOD:     GeneralModWindow,
+            UI_SETTINGS:        SettingsWindow,
+            UI_GRID_EDITOR:     GridEditorWindow,
+            UI_IA_CONTROLS:     IAWindow,
+            UI_RENDER_STATS:    RenderStatsWindow,
+        }
+
+        mult_window_cons = {
+            UI_TUNING_TABLE:    TuningTableWindow,
+            UI_AUDIO_UNIT:      AuWindow,
+            UI_PROCESSOR:       ProcWindow,
+        }
 
         for ui in opened:
             # Check settings for UI visibility
@@ -130,236 +153,75 @@ class RootView():
             if ui == UI_MAIN:
                 if is_show_allowed:
                     self._main_window.show()
-            elif ui == UI_ABOUT:
-                self._about_window = AboutWindow()
-                self._about_window.set_ui_model(self._ui_model)
+            elif ui in single_window_cons:
+                assert ui not in self._single_windows
+                window = single_window_cons[ui]()
+                self.add_to_updaters(window)
+                self._single_windows[ui] = window
                 if is_show_allowed:
-                    self._about_window.show()
-            elif ui == UI_EVENT_LOG:
-                self._event_log = EventListWindow()
-                self._event_log.set_ui_model(self._ui_model)
+                    window.show()
+            elif isinstance(ui, tuple):
+                ui_type, ui_id = ui
+                assert ui_id not in self._mult_windows[ui_type]
+
+                window = mult_window_cons[ui_type]()
+                if ui_type == UI_TUNING_TABLE:
+                    window.set_tuning_table_id(ui_id)
+                elif ui_type == UI_AUDIO_UNIT:
+                    window.set_au_id(ui_id)
+                elif ui_type == UI_PROCESSOR:
+                    proc_id = ui_id
+                    proc_id_parts = proc_id.split('/')
+                    au_id = '/'.join(proc_id_parts[:-1])
+                    window.set_au_id(au_id)
+                    window.set_proc_id(proc_id)
+                else:
+                    assert False
+
+                self.add_to_updaters(window)
+                self._mult_windows[ui_type][ui_id] = window
                 if is_show_allowed:
-                    self._event_log.show()
-            elif ui == UI_CONNECTIONS:
-                self._connections = ConnectionsWindow()
-                self._connections.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._connections.show()
-            elif ui == UI_SONGS_CHS:
-                self._songs_channels = SongsChannelsWindow()
-                self._songs_channels.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._songs_channels.show()
-            elif ui == UI_NOTATION:
-                self._notation = NotationWindow()
-                self._notation.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._notation.show()
-            elif type(ui) == tuple and ui[0] == UI_TUNING_TABLE:
-                table_id = ui[1]
-                tt_window = TuningTableWindow()
-                tt_window.set_tuning_table_id(table_id)
-                tt_window.set_ui_model(self._ui_model)
-                self._tuning_tables[table_id] = tt_window
-                if is_show_allowed:
-                    self._tuning_tables[table_id].show()
-            elif ui == UI_ENV_BIND:
-                self._env_bind = EnvBindWindow()
-                self._env_bind.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._env_bind.show()
-            elif ui == UI_GENERAL_MOD:
-                self._general_mod = GeneralModWindow()
-                self._general_mod.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._general_mod.show()
-            elif ui == UI_SETTINGS:
-                self._settings = SettingsWindow()
-                self._settings.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._settings.show()
-            elif type(ui) == tuple and ui[0] == UI_AUDIO_UNIT:
-                au_id = ui[1]
-                au_window = AuWindow()
-                au_window.set_au_id(au_id)
-                au_window.set_ui_model(self._ui_model)
-                self._au_windows[au_id] = au_window
-                if is_show_allowed:
-                    self._au_windows[au_id].show()
-            elif type(ui) == tuple and ui[0] == UI_PROCESSOR:
-                proc_id = ui[1]
-                proc_id_parts = proc_id.split('/')
-                au_id = '/'.join(proc_id_parts[:-1])
-                proc_window = ProcWindow()
-                proc_window.set_au_id(au_id)
-                proc_window.set_proc_id(proc_id)
-                proc_window.set_ui_model(self._ui_model)
-                self._proc_windows[proc_id] = proc_window
-                if is_show_allowed:
-                    self._proc_windows[proc_id].show()
-            elif ui == UI_GRID_EDITOR:
-                self._grid_editor = GridEditorWindow()
-                self._grid_editor.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._grid_editor.show()
-            elif ui == UI_IA_CONTROLS:
-                self._ia_controls = IAWindow()
-                self._ia_controls.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._ia_controls.show()
-            elif ui == UI_RENDER_STATS:
-                self._render_stats = RenderStatsWindow()
-                self._render_stats.set_ui_model(self._ui_model)
-                if is_show_allowed:
-                    self._render_stats.show()
+                    window.show()
             else:
                 raise ValueError('Unsupported UI type: {}'.format(ui))
 
         for ui in closed:
             if ui == UI_MAIN:
-                visibility_mgr.hide_all()
                 self._main_window.hide()
-            elif ui == UI_ABOUT:
-                self._about_window.unregister_updaters()
-                self._about_window.deleteLater()
-                self._about_window = None
-            elif ui == UI_EVENT_LOG:
-                self._event_log.unregister_updaters()
-                self._event_log.deleteLater()
-                self._event_log = None
-            elif ui == UI_CONNECTIONS:
-                self._connections.unregister_updaters()
-                self._connections.deleteLater()
-                self._connections = None
-            elif ui == UI_SONGS_CHS:
-                self._songs_channels.unregister_updaters()
-                self._songs_channels.deleteLater()
-                self._songs_channels = None
-            elif ui == UI_NOTATION:
-                self._notation.unregister_updaters()
-                self._notation.deleteLater()
-                self._notation = None
-            elif type(ui) == tuple and ui[0] == UI_TUNING_TABLE:
-                table_id = ui[1]
-                tt_window = self._tuning_tables.pop(table_id)
-                tt_window.unregister_updaters()
-                tt_window.deleteLater()
-            elif ui == UI_ENV_BIND:
-                self._env_bind.unregister_updaters()
-                self._env_bind.deleteLater()
-                self._env_bind = None
-            elif ui == UI_GENERAL_MOD:
-                self._general_mod.unregister_updaters()
-                self._general_mod.deleteLater()
-                self._general_mod = None
-            elif ui == UI_SETTINGS:
-                self._settings.unregister_updaters()
-                self._settings.deleteLater()
-                self._settings = None
-            elif type(ui) == tuple and ui[0] == UI_AUDIO_UNIT:
-                au_id = ui[1]
-                au_window = self._au_windows.pop(au_id)
-                au_window.unregister_updaters()
-                au_window.deleteLater()
-            elif type(ui) == tuple and ui[0] == UI_PROCESSOR:
-                proc_id = ui[1]
-                proc_window = self._proc_windows.pop(proc_id)
-                proc_window.unregister_updaters()
-                proc_window.deleteLater()
-            elif ui == UI_GRID_EDITOR:
-                self._grid_editor.unregister_updaters()
-                self._grid_editor.deleteLater()
-                self._grid_editor = None
-            elif ui == UI_IA_CONTROLS:
-                self._ia_controls.unregister_updaters()
-                self._ia_controls.deleteLater()
-                self._ia_controls = None
-            elif ui == UI_RENDER_STATS:
-                self._render_stats.unregister_updaters()
-                self._render_stats.deleteLater()
-                self._render_stats = None
+            elif ui in single_window_cons:
+                window = self._single_windows.pop(ui)
+                self.remove_from_updaters(window)
+                window.deleteLater()
+            elif isinstance(ui, tuple):
+                ui_type, ui_id = ui
+                window = self._mult_windows[ui_type].pop(ui_id)
+                self.remove_from_updaters(window)
+                window.deleteLater()
             else:
                 raise ValueError('Unsupported UI type: {}'.format(ui))
 
         self._visible = set(visibility_update)
 
         if self._visible:
+            signalled = visibility_mgr.get_and_clear_signalled()
+
             # Raise signalled windows to top
-            bring_to_top = self._window_raise_signals & signals
-            if bring_to_top:
-                windows = {
-                    UI_ABOUT:           self._about_window,
-                    UI_EVENT_LOG:       self._event_log,
-                    UI_CONNECTIONS:     self._connections,
-                    UI_SONGS_CHS:       self._songs_channels,
-                    UI_NOTATION:        self._notation,
-                    UI_ENV_BIND:        self._env_bind,
-                    UI_GENERAL_MOD:     self._general_mod,
-                    UI_SETTINGS:        self._settings,
-                    UI_GRID_EDITOR:     self._grid_editor,
-                    UI_IA_CONTROLS:     self._ia_controls,
-                    UI_RENDER_STATS:    self._render_stats,
-                }
-                for ui, window in windows.items():
-                    sig = 'signal_window_{}'.format(ui)
-                    if sig in bring_to_top and window:
+            if signalled:
+                for signalled_id in signalled:
+                    if isinstance(signalled_id, tuple):
+                        win_type, win_id = signalled_id
+                        window = self._mult_windows[win_type].get(win_id)
+                    else:
+                        window = self._single_windows.get(signalled_id)
+
+                    if window:
                         window.activateWindow()
                         window.raise_()
 
-            bring_to_top = (s for s in signals
-                    if s.startswith(self._window_raise_signal_prefixes))
-            for s in bring_to_top:
-                prefix_format = 'signal_window_{}_'
-                window = None
-                if s.startswith(prefix_format.format(UI_TUNING_TABLE)):
-                    tuning_id = '_'.join(s.split('_')[-2:])
-                    if tuning_id in self._tuning_tables:
-                        window = self._tuning_tables[tuning_id]
-                elif s.startswith(prefix_format.format(UI_AUDIO_UNIT)):
-                    au_id = '_'.join(s.split('_')[-2:])
-                    if au_id in self._au_windows:
-                        window = self._au_windows[au_id]
-                elif s.startswith(prefix_format.format(UI_PROCESSOR)):
-                    proc_id = s[len(prefix_format.format(UI_PROCESSOR)):]
-                    if proc_id in self._proc_windows:
-                        window = self._proc_windows[proc_id]
-
-                if window:
-                    window.activateWindow()
-                    window.raise_()
-
-            # Process other signals
-            if 'signal_module' in signals:
-                self._on_module_setup_finished()
-            if 'signal_start_save_module' in signals:
-                self._start_save_module()
-            if 'signal_save_module_finished' in signals:
-                self._on_save_module_finished()
-            if 'signal_start_import_au' in signals:
-                self._start_import_au()
-            if 'signal_au_import_error' in signals:
-                self._on_au_import_error()
-            if 'signal_au_import_finished' in signals:
-                self._on_au_import_finished()
-            if 'signal_start_export_au' in signals:
-                self._start_export_au()
-            if 'signal_export_au_finished' in signals:
-                self._on_export_au_finished()
-            if 'signal_progress_start' in signals:
-                self._show_progress_window()
-            if 'signal_progress_step' in signals:
-                self._update_progress_window()
-            if 'signal_progress_finished' in signals:
-                self._hide_progress_window()
-            if 'signal_module_load_error' in signals:
-                self._on_module_load_error()
-            if 'signal_style_changed' in signals:
-                style_sheet = self._style_creator.get_updated_style_sheet()
-                QApplication.instance().setStyleSheet(style_sheet)
-                self._crash_dialog.update_style(self._ui_model.get_style_manager())
         else:
             QApplication.quit()
 
+    def _send_audio_state_queries(self):
         self._ui_model.clock()
 
     def _show_progress_window(self):
@@ -393,29 +255,14 @@ class RootView():
             if window:
                 window.setEnabled(enabled)
 
-        try_set_enabled(self._main_window)
-        try_set_enabled(self._about_window)
-        try_set_enabled(self._event_log)
-        try_set_enabled(self._connections)
-        try_set_enabled(self._songs_channels)
-        try_set_enabled(self._notation)
-        for window in self._tuning_tables.values():
-            window.setEnabled(enabled)
-        try_set_enabled(self._env_bind)
-        try_set_enabled(self._general_mod)
-        try_set_enabled(self._settings)
-        for window in self._au_windows.values():
-            window.setEnabled(enabled)
-        for window in self._proc_windows.values():
-            window.setEnabled(enabled)
-        try_set_enabled(self._grid_editor)
-        try_set_enabled(self._ia_controls)
-        try_set_enabled(self._render_stats)
+        self._main_window.setEnabled(enabled)
 
-    def unregister_updaters(self):
-        self._updater.unregister_updater(self._perform_updates)
-        self._main_window.unregister_updaters()
-        self._style_creator.unregister_updaters()
+        for window in self._single_windows.values():
+            window.setEnabled(enabled)
+
+        for group in self._mult_windows.values():
+            for window in group.values():
+                window.setEnabled(enabled)
 
     def _start_save_module(self):
         self._set_windows_enabled(False)

--- a/kunquat/tracker/ui/views/sheet/toolbar.py
+++ b/kunquat/tracker/ui/views/sheet/toolbar.py
@@ -318,7 +318,7 @@ class DelSelectionButton(IconButton):
 
         self.register_action('signal_selection', self._update_enabled)
         self.register_action('signal_module', self._update_enabled)
-        self.register_action('signal_column', self._update_enabled)
+        self.register_action('signal_column_updated', self._update_enabled)
         self.register_action('signal_edit_mode', self._update_enabled)
 
         self._sheet_mgr = self._ui_model.get_sheet_manager()

--- a/kunquat/tracker/ui/views/typewriter.py
+++ b/kunquat/tracker/ui/views/typewriter.py
@@ -29,7 +29,7 @@ class Typewriter(QFrame, Updater):
 
     def _on_setup(self):
         self.add_to_updaters(self._keyboard_mapper)
-        self.register_action('signal_change', self._update_button_leds)
+        self.register_action('signal_audio_rendered', self._update_button_leds)
         self.register_action('signal_style_changed', self._update_style)
 
         self._typewriter_mgr = self._ui_model.get_typewriter_manager()


### PR DESCRIPTION
This branch removes the old widget update logic that executed callbacks unconditionally. All widgets that react to updater signals now do so via the action registration system.