### PR TITLE
Bare essential new audio units

### DIFF
--- a/kunquat/tracker/ui/controller/store.py
+++ b/kunquat/tracker/ui/controller/store.py
@@ -2,7 +2,7 @@
 
 #
 # Authors: Toni Ruottu, Finland 2013
-#          Tomi Jylhä-Ollila, Finland 2014-2018
+#          Tomi Jylhä-Ollila, Finland 2014-2019
 #
 # This file is part of Kunquat.
 #
@@ -111,6 +111,11 @@ class Store(MutableMapping):
         transaction_id, transaction = self._pending_validation.popleft()
         assert transaction_id == validated_id
         return transaction
+
+    def get(self, key, default=None, *, pending_changes=None):
+        if pending_changes and (key in pending_changes):
+            return pending_changes[key]
+        return super().get(key, default)
 
     def get_with_version(self, key):
         # If the key has non-validated changes, return the most recent one

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -45,7 +45,7 @@ class AudioUnit():
     def get_id(self):
         return self._au_id
 
-    def get_edit_create_new_instrument(self):
+    def get_edit_create_new_instrument(self, name):
         transaction = self.get_edit_set_existence('instrument')
 
         # Audio unit ports
@@ -86,7 +86,7 @@ class AudioUnit():
         transaction.update(conns.get_edit_set_layout(layout))
 
         # Names
-        transaction.update(self.get_edit_set_name('New instrument'))
+        transaction.update(self.get_edit_set_name(name))
 
         proc_names = {
             pitch_id: 'Pitch',

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -496,7 +496,6 @@ class AudioUnit():
         self._updater.signal_update('signal_start_export_au')
 
     def add_effect(self, au_id):
-        key = '/'.join((self._au_id, au_id))
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -500,15 +500,9 @@ class AudioUnit():
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)
-        au.set_existence('effect')
-        au.set_port_existence('in_00', True)
-        au.set_port_existence('in_01', True)
-        au.set_port_existence('out_00', True)
-        au.set_port_existence('out_01', True)
-        au.set_port_name('in_00', 'audio L')
-        au.set_port_name('in_01', 'audio R')
-        au.set_port_name('out_00', 'audio L')
-        au.set_port_name('out_01', 'audio R')
+
+        transaction = au.get_edit_create_new_effect()
+        self._store.put(transaction)
 
     def _remove_device(self, dev_id):
         assert dev_id.startswith(self._au_id)

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -98,6 +98,12 @@ class AudioUnit():
             proc.set_controller(self._controller)
             transaction.update(proc.get_edit_set_name(proc_name))
 
+        # Force parameters
+        force_proc = Processor(self._au_id, force_id)
+        force_proc.set_controller(self._controller)
+        force_params = force_proc.get_type_params(transaction)
+        transaction.update(force_params.get_edit_set_default_configuration())
+
         return transaction
 
     def _get_key(self, subkey):

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -106,6 +106,29 @@ class AudioUnit():
 
         return transaction
 
+    def get_edit_create_new_effect(self):
+        transaction = self.get_edit_set_existence('effect')
+
+        port_infos = {
+            'in_00': 'audio L',
+            'in_01': 'audio R',
+            'out_00': 'audio L',
+            'out_01': 'audio R',
+        }
+        for port_id, port_name in port_infos.items():
+            transaction.update(self.get_edit_set_port_existence(port_id, True))
+            transaction.update(self.get_edit_set_port_name(port_id, port_name))
+
+        conns = self.get_connections()
+        transaction.update(conns.get_edit_connect_ports(
+            'Iin', 'in_00', 'master', 'out_00', transaction))
+        transaction.update(conns.get_edit_connect_ports(
+            'Iin', 'in_01', 'master', 'out_01', transaction))
+
+        transaction.update(self.get_edit_set_name('New effect'))
+
+        return transaction
+
     def _get_key(self, subkey):
         return '{}/{}'.format(self._au_id, subkey)
 

--- a/kunquat/tracker/ui/model/audiounit.py
+++ b/kunquat/tracker/ui/model/audiounit.py
@@ -73,6 +73,15 @@ class AudioUnit():
         ]
         transaction.update(conns.get_edit_set_connections(conns_list))
 
+        layout = {
+            'Iin'           : { 'offset': (-27, 0) },
+            pitch_conn_id   : { 'offset': (-9, -4) },
+            force_conn_id   : { 'offset': (-9, 4) },
+            base_conn_id    : { 'offset': (9, 0) },
+            'master'        : { 'offset': (27, 0) },
+        }
+        transaction.update(conns.get_edit_set_layout(layout))
+
         return transaction
 
     def _get_key(self, subkey):

--- a/kunquat/tracker/ui/model/connections.py
+++ b/kunquat/tracker/ui/model/connections.py
@@ -158,9 +158,13 @@ class Connections():
         key = self._get_layout_key()
         return self._store.get(key, {})
 
-    def set_layout(self, layout, mark_modified=True):
+    def get_edit_set_layout(self, layout):
         key = self._get_layout_key()
-        self._store.put({ key: layout }, mark_modified=mark_modified)
+        return { key: layout }
+
+    def set_layout(self, layout, mark_modified=True):
+        transaction = self.get_edit_set_layout(layout)
+        self._store.put(transaction, mark_modified=mark_modified)
 
     def get_send_device_ids(self, recv_id):
         sub_recv_id = recv_id.split('/')[-1]

--- a/kunquat/tracker/ui/model/connections.py
+++ b/kunquat/tracker/ui/model/connections.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2014-2018
+# Author: Tomi Jylhä-Ollila, Finland 2014-2019
 #
 # This file is part of Kunquat.
 #
@@ -146,9 +146,13 @@ class Connections():
         key = self._get_graph_key()
         return self._store.get(key, get_default_value(key))
 
-    def set_connections(self, conns):
+    def get_edit_set_connections(self, conns):
         key = self._get_graph_key()
-        self._store[key] = conns
+        return { key: conns }
+
+    def set_connections(self, conns):
+        transaction = self.get_edit_set_connections(conns)
+        self._store.put(transaction)
 
     def get_layout(self):
         key = self._get_layout_key()

--- a/kunquat/tracker/ui/model/connections.py
+++ b/kunquat/tracker/ui/model/connections.py
@@ -142,9 +142,10 @@ class Connections():
     def _get_layout_key(self):
         return self._get_complete_key('i_connections_layout.json')
 
-    def get_connections(self):
+    def get_connections(self, pending_changes=None):
         key = self._get_graph_key()
-        return self._store.get(key, get_default_value(key))
+        return self._store.get(
+                key, get_default_value(key), pending_changes=pending_changes)
 
     def get_edit_set_connections(self, conns):
         key = self._get_graph_key()
@@ -181,6 +182,25 @@ class Connections():
                 send_ids.add(send_id)
 
         return send_ids
+
+    def _get_connection_path(self, dev_id, port_id):
+        if dev_id.startswith(('master', 'Iin')):
+            return port_id
+        sep = '/C/' if dev_id.startswith('proc') else '/'
+        return sep.join((dev_id, port_id))
+
+    def get_edit_connect_ports(
+            self,
+            src_dev_id,
+            src_port_id,
+            dest_dev_id,
+            dest_port_id,
+            pending_changes=None):
+        conns = list(self.get_connections(pending_changes))
+        src_path = self._get_connection_path(src_dev_id, src_port_id)
+        dest_path = self._get_connection_path(dest_dev_id, dest_port_id)
+        conns.append([src_path, dest_path])
+        return self.get_edit_set_connections(conns)
 
     def disconnect_device(self, dev_id):
         sub_dev_id = dev_id.split('/')[-1]

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -247,15 +247,9 @@ class Module():
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)
-        au.set_existence('effect')
-        au.set_port_existence('in_00', True)
-        au.set_port_existence('in_01', True)
-        au.set_port_existence('out_00', True)
-        au.set_port_existence('out_01', True)
-        au.set_port_name('in_00', 'audio L')
-        au.set_port_name('in_01', 'audio R')
-        au.set_port_name('out_00', 'audio L')
-        au.set_port_name('out_01', 'audio R')
+
+        transaction = au.get_edit_create_new_effect()
+        self._store.put(transaction)
 
     def get_out_ports(self):
         out_ports = []

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -227,7 +227,7 @@ class Module():
             transaction))
         return transaction
 
-    def add_instrument_with_control(self, au_id, control_id):
+    def add_instrument_with_control(self, au_id, control_id, ins_name='New instrument'):
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)
@@ -236,7 +236,7 @@ class Module():
         control.set_controller(self._controller)
         control.set_ui_model(self._ui_model)
 
-        transaction = au.get_edit_create_new_instrument()
+        transaction = au.get_edit_create_new_instrument(ins_name)
         transaction.update(control.get_edit_create_new())
         transaction.update(control.get_edit_connect_to_au(au_id))
         transaction.update(self._get_edit_try_connect_au_to_master(au_id))
@@ -402,12 +402,9 @@ class Module():
     def execute_create_sandbox(self, task_executor):
         assert not self.is_saving()
         self._controller.create_sandbox()
-        kqtifile = self._controller.get_share().get_default_instrument()
-        load_au_task = self._controller.get_task_load_audio_unit(
-                kqtifile, 'au_00', 'control_00', is_sandbox=True)
+        self.add_instrument_with_control('au_00', 'control_00', 'Sine')
         finalise_task = self.finalise_create_sandbox()
-        task = chain(load_au_task, finalise_task)
-        task_executor(task)
+        task_executor(finalise_task)
 
     def start_import_au(self, path, au_id, control_id=None):
         assert not self.is_saving()

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -213,15 +213,20 @@ class Module():
         #    return [] #valid
         return all_audio_units
 
-    def add_instrument(self, au_id):
+    def add_instrument_with_control(self, au_id, control_id):
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)
-        au.set_existence('instrument')
-        au.set_port_existence('out_00', True)
-        au.set_port_existence('out_01', True)
-        au.set_port_name('out_00', 'audio L')
-        au.set_port_name('out_01', 'audio R')
+
+        control = Control(control_id)
+        control.set_controller(self._controller)
+        control.set_ui_model(self._ui_model)
+
+        transaction = au.get_edit_create_new_instrument()
+        transaction.update(control.get_edit_create_new())
+        transaction.update(control.get_edit_connect_to_au(au_id))
+
+        self._store.put(transaction)
 
     def add_effect(self, au_id):
         au = AudioUnit(au_id)

--- a/kunquat/tracker/ui/model/module.py
+++ b/kunquat/tracker/ui/model/module.py
@@ -243,12 +243,19 @@ class Module():
 
         self._store.put(transaction)
 
-    def add_effect(self, au_id):
+    def add_effect(self, au_id, control_id):
         au = AudioUnit(au_id)
         au.set_controller(self._controller)
         au.set_ui_model(self._ui_model)
 
+        control = Control(control_id)
+        control.set_controller(self._controller)
+        control.set_ui_model(self._ui_model)
+
         transaction = au.get_edit_create_new_effect()
+        transaction.update(control.get_edit_create_new())
+        transaction.update(control.get_edit_connect_to_au(au_id))
+
         self._store.put(transaction)
 
     def get_out_ports(self):

--- a/kunquat/tracker/ui/model/processor.py
+++ b/kunquat/tracker/ui/model/processor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2014-2018
+# Author: Tomi Jylhä-Ollila, Finland 2014-2019
 #
 # This file is part of Kunquat.
 #
@@ -113,9 +113,13 @@ class Processor():
         key = self._get_key('m_name.json')
         return self._store.get(key)
 
-    def set_name(self, name):
+    def get_edit_set_name(self, name):
         key = self._get_key('m_name.json')
-        self._store[key] = name
+        return { key: name }
+
+    def set_name(self, name):
+        transaction = self.get_edit_set_name(name)
+        self._store.put(key, name)
 
     def get_message(self):
         key = self._get_key('m_message.json')

--- a/kunquat/tracker/ui/model/processor.py
+++ b/kunquat/tracker/ui/model/processor.py
@@ -129,18 +129,19 @@ class Processor():
         key = self._get_key('m_message.json')
         self._store[key] = message or None
 
-    def get_type(self):
+    def get_type(self, pending_changes=None):
         key = self._get_key('p_manifest.json')
-        manifest = self._store.get(key)
+        manifest = self._store.get(key, pending_changes=pending_changes)
         if manifest:
             return manifest['type']
         return None
 
-    def get_type_params(self):
-        if self.get_type() not in _proc_classes:
+    def get_type_params(self, pending_changes=None):
+        proc_type = self.get_type(pending_changes)
+        if proc_type not in _proc_classes:
             return None
 
-        cons = _proc_classes[self.get_type()]
+        cons = _proc_classes[proc_type]
         return cons(self._proc_id, self._controller)
 
     def get_signal_type(self):

--- a/kunquat/tracker/ui/model/procparams/forceparams.py
+++ b/kunquat/tracker/ui/model/procparams/forceparams.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2016-2017
+# Author: Tomi Jylhä-Ollila, Finland 2016-2019
 #
 # This file is part of Kunquat.
 #
@@ -27,8 +27,16 @@ class ForceParams(ProcParams):
     def __init__(self, proc_id, controller):
         super().__init__(proc_id, controller)
 
+    def get_edit_set_default_configuration(self):
+        transaction = self.get_edit_set_global_force(-8)
+        transaction.update(self.get_edit_set_release_ramp_enabled(True))
+        return transaction
+
     def get_global_force(self):
         return self._get_value('p_f_global_force.json', 0.0)
+
+    def get_edit_set_global_force(self, value):
+        return self._get_edit_set_value('p_f_global_force.json', value)
 
     def set_global_force(self, value):
         self._set_value('p_f_global_force.json', value)
@@ -77,6 +85,9 @@ class ForceParams(ProcParams):
 
     def get_release_ramp_enabled(self):
         return self._get_value('p_b_release_ramp.json', False)
+
+    def get_edit_set_release_ramp_enabled(self, enabled):
+        return self._get_edit_set_value('p_b_release_ramp.json', enabled)
 
     def set_release_ramp_enabled(self, enabled):
         self._set_value('p_b_release_ramp.json', enabled)

--- a/kunquat/tracker/ui/model/procparams/procparams.py
+++ b/kunquat/tracker/ui/model/procparams/procparams.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015-2018
+# Author: Tomi Jylhä-Ollila, Finland 2015-2019
 #
 # This file is part of Kunquat.
 #
@@ -55,8 +55,13 @@ class ProcParams():
             return value
         return default_value
 
-    def _set_value(self, subkey, value):
+    def _get_edit_set_value(self, subkey, value):
         key = self._get_key('c/', subkey)
-        self._store[key] = value
+        transaction = { key: value }
+        return transaction
+
+    def _set_value(self, subkey, value):
+        transaction = self._get_edit_set_value(subkey, value)
+        self._store.put(transaction)
 
 

--- a/kunquat/tracker/ui/views/connectionseditor.py
+++ b/kunquat/tracker/ui/views/connectionseditor.py
@@ -163,30 +163,19 @@ class ConnectionsToolBar(QToolBar, AudioUnitUpdater):
 
     def _add_effect(self):
         module = self._ui_model.get_module()
-        is_control_needed = True
-        parent_device = module
+
         if self._au_id != None:
-            is_control_needed = False
-            parent_device = module.get_audio_unit(self._au_id)
-
-        new_au_id = parent_device.get_free_au_id()
-        new_control_id = module.get_free_control_id() if is_control_needed else None
-
-        if (not is_control_needed or new_control_id) and new_au_id:
-            parent_device.add_effect(new_au_id)
-            update_signals = []
-            if is_control_needed:
-                parent_device.add_control(new_control_id)
-                control = parent_device.get_control(new_control_id)
-                control.connect_to_au(new_au_id)
-                update_signals.append('signal_controls')
-
-            update_signal = 'signal_connections'
-            if self._au_id != None:
-                update_signal = '_'.join((update_signal, self._au_id))
-            update_signals.append(update_signal)
-
-            self._updater.signal_update(*update_signals)
+            au = module.get_audio_unit(self._au_id)
+            new_au_id = au.get_free_au_id()
+            if new_au_id:
+                au.add_effect(new_au_id)
+                self._updater.signal_update('signal_connections_{}'.format(self._au_id))
+        else:
+            new_au_id = module.get_free_au_id()
+            new_control_id = module.get_free_control_id()
+            if new_au_id and new_control_id:
+                module.add_effect(new_au_id, new_control_id)
+                self._updater.signal_update('signal_controls', 'signal_connections')
 
     def _import_au(self):
         module = self._ui_model.get_module()

--- a/kunquat/tracker/ui/views/connectionseditor.py
+++ b/kunquat/tracker/ui/views/connectionseditor.py
@@ -144,10 +144,7 @@ class ConnectionsToolBar(QToolBar, AudioUnitUpdater):
         new_control_id = module.get_free_control_id()
         new_au_id = module.get_free_au_id()
         if new_control_id and new_au_id:
-            module.add_instrument(new_au_id)
-            module.add_control(new_control_id)
-            control = module.get_control(new_control_id)
-            control.connect_to_au(new_au_id)
+            module.add_instrument_with_control(new_au_id, new_control_id)
             update_signals = ['signal_connections', 'signal_controls']
             self._updater.signal_update(*update_signals)
 


### PR DESCRIPTION
This branch makes creating new audio units more pleasant by adding essential internals. New instruments produce audible output when played, and new effects connect their inputs to their outputs by default. Also, creation of new audio units now take place in a single transaction, which will help if we want to add undo support to these operations in the future.