### PR TITLE
Order list usage improvements

### DIFF
--- a/kunquat/tracker/ui/views/orderlist.py
+++ b/kunquat/tracker/ui/views/orderlist.py
@@ -2,7 +2,7 @@
 
 #
 # Authors: Toni Ruottu, Finland 2014
-#          Tomi Jylhä-Ollila, Finland 2014-2018
+#          Tomi Jylhä-Ollila, Finland 2014-2019
 #
 # This file is part of Kunquat.
 #
@@ -358,8 +358,8 @@ class Orderlist(QWidget, Updater):
             song = node.get_payload()
             album = self._ui_model.get_module().get_album()
             album.set_selected_track_num(song.get_containing_track_number())
-            self._updater.signal_update('signal_song')
+            self._updater.signal_update_deferred('signal_song')
 
-        self._updater.signal_update('signal_order_list_selection')
+        self._updater.signal_update_deferred('signal_order_list_selection')
 
 

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -15,6 +15,7 @@ from kunquat.tracker.ui.qt import *
 
 from kunquat.tracker.ui.model.patterninstance import PatternInstance
 from kunquat.tracker.ui.model.song import Song
+from .confirmdialog import ConfirmDialog
 from .headerline import HeaderLine
 from .iconbutton import IconButton
 from .orderlist import Orderlist
@@ -72,6 +73,12 @@ class OrderlistEditor(QWidget, Updater):
             self._updater.signal_update('signal_order_list')
             self._waiting_for_update = True
 
+    def _confirm_handle_delete(self):
+        selection = self._orderlist.get_selected_object()
+        if isinstance(selection, PatternInstance):
+            dialog = _RemovePatternConfirmDialog(self._ui_model, self._handle_delete)
+            dialog.exec_()
+
     def _handle_delete(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
@@ -109,7 +116,7 @@ class OrderlistEditor(QWidget, Updater):
                 self._handle_insert_at(1)
                 return
             elif event.key() == Qt.Key_Delete:
-                self._handle_delete()
+                self._confirm_handle_delete()
                 return
         elif event.modifiers() == Qt.ShiftModifier:
             if event.key() == Qt.Key_Up:
@@ -118,7 +125,28 @@ class OrderlistEditor(QWidget, Updater):
             elif event.key() == Qt.Key_Down:
                 self._handle_move_pattern_instance(1)
                 return
+            elif event.key() == Qt.Key_Delete:
+                self._handle_delete()
+                return
         event.ignore()
+
+
+class ShiftClickButton(IconButton):
+
+    shiftClicked = Signal(name='shiftClicked')
+
+    def __init__(self, flat):
+        super().__init__(flat)
+
+    def mouseReleaseEvent(self, event):
+        if (event.button() == Qt.LeftButton) and (event.modifiers() == Qt.ShiftModifier):
+            self.shiftClicked.emit()
+            self.setDown(False)
+            event.accept()
+            return
+
+        event.ignore()
+        super().mouseReleaseEvent(event)
 
 
 class OrderlistToolBar(QToolBar, Updater):
@@ -130,14 +158,14 @@ class OrderlistToolBar(QToolBar, Updater):
         self._orderlist = orderlist
         self._selection = None
 
-        def create_button(text):
-            button = IconButton(flat=True)
+        def create_button(text, cons=IconButton):
+            button = cons(flat=True)
             button.setToolTip(text)
             button.setEnabled(False)
             return button
 
         self._new_pat_button        = create_button('New pattern')
-        self._remove_pat_button     = create_button('Remove pattern')
+        self._remove_pat_button     = create_button('Remove pattern', ShiftClickButton)
         self._reuse_pat_button      = create_button('Reuse pattern')
         self._new_song_button       = create_button('New song')
         self._remove_song_button    = create_button('Remove song')
@@ -170,10 +198,11 @@ class OrderlistToolBar(QToolBar, Updater):
         self._update_buttons_enabled(None)
 
         self._new_pat_button.clicked.connect(self._add_pattern)
-        self._remove_pat_button.clicked.connect(self._remove_pattern)
+        self._remove_pat_button.clicked.connect(self._confirm_remove_pattern)
+        self._remove_pat_button.shiftClicked.connect(self._remove_pattern)
         self._reuse_pat_button.clicked.connect(self._reuse_pattern)
         self._new_song_button.clicked.connect(self._add_song)
-        self._remove_song_button.clicked.connect(self._remove_song)
+        self._remove_song_button.clicked.connect(self._confirm_remove_song)
 
         self.register_action(
                 'signal_order_list_updated', self._update_buttons_with_selection)
@@ -223,6 +252,10 @@ class OrderlistToolBar(QToolBar, Updater):
         self._orderlist_mgr.set_orderlist_selection((track_num, system_num))
         self._updater.signal_update('signal_order_list')
 
+    def _confirm_remove_pattern(self):
+        dialog = _RemovePatternConfirmDialog(self._ui_model, self._remove_pattern)
+        dialog.exec_()
+
     def _remove_pattern(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
@@ -255,11 +288,60 @@ class OrderlistToolBar(QToolBar, Updater):
         self._album.insert_song(track_num)
         self._updater.signal_update('signal_order_list')
 
+    def _confirm_remove_song(self):
+        dialog = _RemoveSongConfirmDialog(self._ui_model, self._remove_song)
+        dialog.exec_()
+
     def _remove_song(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, Song):
             track_num = selection.get_containing_track_number()
             self._album.remove_song(track_num)
             self._updater.signal_update('signal_order_list')
+
+
+class _RemoveConfirmDialog(ConfirmDialog):
+
+    def __init__(self, ui_model, msg, target_desc, confirm_action):
+        super().__init__(ui_model)
+        self.setModal(True)
+
+        self._confirm_action = confirm_action
+
+        self.setWindowTitle('Confirm pattern removal')
+
+        self._set_message(msg)
+
+        self._cancel_button = QPushButton('Keep {}'.format(target_desc))
+        self._remove_button = QPushButton('Remove {}'.format(target_desc))
+
+        b = self._get_button_layout()
+        b.addWidget(self._cancel_button)
+        b.addWidget(self._remove_button)
+
+        self._cancel_button.clicked.connect(self.close)
+        self._remove_button.clicked.connect(self._perform_action)
+
+    def _perform_action(self):
+        self._confirm_action()
+        self.close()
+
+
+class _RemovePatternConfirmDialog(_RemoveConfirmDialog):
+
+    def __init__(self, ui_model, confirm_action):
+        msg = '<p>Do you really want to remove the pattern?</p>'
+        msg += '<p>(Tip: You can Shift+click the remove button'
+        msg += ' to remove without confirmation.)</p>'
+        target_desc = 'the pattern'
+        super().__init__(ui_model, msg, target_desc, confirm_action)
+
+
+class _RemoveSongConfirmDialog(_RemoveConfirmDialog):
+
+    def __init__(self, ui_model, confirm_action):
+        msg = '<p>Do you really want to remove the song?</p>'
+        target_desc = 'the song'
+        super().__init__(ui_model, msg, target_desc, confirm_action)
 
 

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -136,8 +136,8 @@ class ShiftClickButton(IconButton):
 
     shiftClicked = Signal(name='shiftClicked')
 
-    def __init__(self, flat):
-        super().__init__(flat)
+    def __init__(self):
+        super().__init__(flat=True)
 
     def mouseReleaseEvent(self, event):
         if (event.button() == Qt.LeftButton) and (event.modifiers() == Qt.ShiftModifier):
@@ -165,11 +165,16 @@ class OrderlistToolBar(QToolBar, Updater):
             button.setEnabled(False)
             return button
 
-        self._new_pat_button        = create_button('New pattern')
-        self._remove_pat_button     = create_button('Remove pattern', ShiftClickButton)
-        self._reuse_pat_button      = create_button('Reuse pattern')
-        self._new_song_button       = create_button('New song')
-        self._remove_song_button    = create_button('Remove song')
+        self._new_pat_button = IconButton(flat=True)
+        self._new_pat_button.setToolTip('Add new pattern (N)')
+        self._remove_pat_button = ShiftClickButton()
+        self._remove_pat_button.setToolTip('Remove pattern (Delete)')
+        self._reuse_pat_button = IconButton(flat=True)
+        self._reuse_pat_button.setToolTip('Reuse pattern')
+        self._new_song_button = IconButton(flat=True)
+        self._new_song_button.setToolTip('Add new song')
+        self._remove_song_button = IconButton(flat=True)
+        self._remove_song_button.setToolTip('Remove song')
 
         self.addWidget(self._new_pat_button)
         self.addWidget(self._remove_pat_button)
@@ -249,8 +254,8 @@ class OrderlistToolBar(QToolBar, Updater):
             return
 
         pattern_num = self._album.get_new_pattern_num()
-        self._album.insert_pattern_instance(track_num, system_num, pattern_num, 0)
-        self._orderlist_mgr.set_orderlist_selection((track_num, system_num))
+        self._album.insert_pattern_instance(track_num, system_num + 1, pattern_num, 0)
+        self._orderlist_mgr.set_orderlist_selection((track_num, system_num + 1))
         self._updater.signal_update('signal_order_list')
 
     def _confirm_remove_pattern(self):
@@ -286,7 +291,7 @@ class OrderlistToolBar(QToolBar, Updater):
             track_num = selection.get_containing_track_number()
         else:
             track_num = self._album.get_track_count()
-        self._album.insert_song(track_num)
+        self._album.insert_song(track_num + 1)
         self._updater.signal_update('signal_order_list')
 
     def _confirm_remove_song(self):

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -110,9 +110,6 @@ class OrderlistEditor(QWidget, Updater):
 
         if event.modifiers() == Qt.NoModifier:
             if event.key() == Qt.Key_Insert:
-                self._handle_insert_at(0)
-                return
-            elif event.key() == Qt.Key_N:
                 self._handle_insert_at(1)
                 return
             elif event.key() == Qt.Key_Delete:
@@ -166,7 +163,7 @@ class OrderlistToolBar(QToolBar, Updater):
             return button
 
         self._new_pat_button = IconButton(flat=True)
-        self._new_pat_button.setToolTip('Add new pattern (N)')
+        self._new_pat_button.setToolTip('Add new pattern (Insert)')
         self._remove_pat_button = ShiftClickButton()
         self._remove_pat_button.setToolTip('Remove pattern (Delete)')
         self._reuse_pat_button = IconButton(flat=True)

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -73,6 +73,20 @@ class OrderlistEditor(QWidget, Updater):
             self._updater.signal_update('signal_order_list')
             self._waiting_for_update = True
 
+    def _handle_reuse_pattern(self):
+        selection = self._orderlist.get_selected_object()
+        if isinstance(selection, PatternInstance):
+            track_num, system_num = self._album.get_pattern_instance_location(selection)
+            song = self._album.get_song_by_track(track_num)
+            pinst = song.get_pattern_instance(system_num)
+            pattern_num = pinst.get_pattern_num()
+            instance_num = self._album.get_new_pattern_instance_num(pattern_num)
+            self._album.insert_pattern_instance(
+                    track_num, system_num + 1, pattern_num, instance_num)
+            self._orderlist_mgr.set_orderlist_selection((track_num, system_num + 1))
+            self._updater.signal_update('signal_order_list')
+            self._waiting_for_update = True
+
     def _confirm_handle_delete(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
@@ -111,6 +125,9 @@ class OrderlistEditor(QWidget, Updater):
         if event.modifiers() == Qt.NoModifier:
             if event.key() == Qt.Key_Insert:
                 self._handle_insert_at(1)
+                return
+            elif event.key() == Qt.Key_R:
+                self._handle_reuse_pattern()
                 return
             elif event.key() == Qt.Key_Delete:
                 self._confirm_handle_delete()
@@ -167,7 +184,7 @@ class OrderlistToolBar(QToolBar, Updater):
         self._remove_pat_button = ShiftClickButton()
         self._remove_pat_button.setToolTip('Remove pattern (Delete)')
         self._reuse_pat_button = IconButton(flat=True)
-        self._reuse_pat_button.setToolTip('Reuse pattern')
+        self._reuse_pat_button.setToolTip('Reuse pattern (R)')
         self._new_song_button = IconButton(flat=True)
         self._new_song_button.setToolTip('Add new song')
         self._remove_song_button = IconButton(flat=True)

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -126,7 +126,8 @@ class OrderlistEditor(QWidget, Updater):
                 self._handle_move_pattern_instance(1)
                 return
             elif event.key() == Qt.Key_Delete:
-                self._handle_delete()
+                if not event.isAutoRepeat():
+                    self._handle_delete()
                 return
         event.ignore()
 

--- a/kunquat/tracker/ui/views/orderlisteditor.py
+++ b/kunquat/tracker/ui/views/orderlisteditor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2015-2018
+# Author: Tomi Jylhä-Ollila, Finland 2015-2019
 #
 # This file is part of Kunquat.
 #
@@ -169,11 +169,11 @@ class OrderlistToolBar(QToolBar, Updater):
 
         self._update_buttons_enabled(None)
 
-        self._new_pat_button.clicked.connect(self._pattern_added)
-        self._remove_pat_button.clicked.connect(self._pattern_removed)
-        self._reuse_pat_button.clicked.connect(self._pattern_reused)
-        self._new_song_button.clicked.connect(self._song_added)
-        self._remove_song_button.clicked.connect(self._song_removed)
+        self._new_pat_button.clicked.connect(self._add_pattern)
+        self._remove_pat_button.clicked.connect(self._remove_pattern)
+        self._reuse_pat_button.clicked.connect(self._reuse_pattern)
+        self._new_song_button.clicked.connect(self._add_song)
+        self._remove_song_button.clicked.connect(self._remove_song)
 
         self.register_action(
                 'signal_order_list_updated', self._update_buttons_with_selection)
@@ -207,7 +207,7 @@ class OrderlistToolBar(QToolBar, Updater):
         else:
             self._remove_song_button.setEnabled(False)
 
-    def _pattern_added(self):
+    def _add_pattern(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
             track_num, system_num = self._album.get_pattern_instance_location(selection)
@@ -223,7 +223,7 @@ class OrderlistToolBar(QToolBar, Updater):
         self._orderlist_mgr.set_orderlist_selection((track_num, system_num))
         self._updater.signal_update('signal_order_list')
 
-    def _pattern_removed(self):
+    def _remove_pattern(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
             track_num, system_num = self._album.get_pattern_instance_location(selection)
@@ -233,7 +233,7 @@ class OrderlistToolBar(QToolBar, Updater):
                     (track_num, min(system_num, song.get_system_count() - 1)))
             self._updater.signal_update('signal_order_list')
 
-    def _pattern_reused(self):
+    def _reuse_pattern(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, PatternInstance):
             track_num, system_num = self._album.get_pattern_instance_location(selection)
@@ -246,7 +246,7 @@ class OrderlistToolBar(QToolBar, Updater):
             self._orderlist_mgr.set_orderlist_selection((track_num, system_num + 1))
             self._updater.signal_update('signal_order_list')
 
-    def _song_added(self):
+    def _add_song(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, Song):
             track_num = selection.get_containing_track_number()
@@ -255,7 +255,7 @@ class OrderlistToolBar(QToolBar, Updater):
         self._album.insert_song(track_num)
         self._updater.signal_update('signal_order_list')
 
-    def _song_removed(self):
+    def _remove_song(self):
         selection = self._orderlist.get_selected_object()
         if isinstance(selection, Song):
             track_num = selection.get_containing_track_number()


### PR DESCRIPTION
This branch improves the behaviour of the order list editor. Most importantly, it adds a confirmation dialog for pattern (as well as song) removal so that the user cannot accidentally remove the entire composition by simply having their cat step on the Delete button. Also, the insert buttons now add the new pattern/song after the selected one, which is usually the desired result. Finally, a signalling bug on song removal was discovered and fixed.