### PR TITLE
Select a test note expression if available when opening an instrument view

### DIFF
--- a/kunquat/tracker/ui/controller/controller.py
+++ b/kunquat/tracker/ui/controller/controller.py
@@ -531,7 +531,7 @@ class Controller():
             force = au.get_test_force() - module.get_force_shift()
             expressions = []
             for i in range(2):
-                expr_name = au.get_test_expression(i)
+                expr_name = au.get_test_expression(i) or ''
                 expressions.append(expr_name)
         else:
             channel_defaults = self._ui_model.get_module().get_channel_defaults()

--- a/kunquat/tracker/ui/controller/session.py
+++ b/kunquat/tracker/ui/controller/session.py
@@ -881,7 +881,7 @@ class Session():
         self._aus[au_id].test_expressions[index] = expr_name
 
     def get_au_test_expression(self, au_id, index):
-        return self._aus[au_id].test_expressions.get(index, '')
+        return self._aus[au_id].test_expressions.get(index, None)
 
     def set_au_test_params_enabled(self, au_id, enabled):
         self._aus[au_id].test_params_enabled = enabled

--- a/kunquat/tracker/ui/views/audiounit/editor.py
+++ b/kunquat/tracker/ui/views/audiounit/editor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Author: Tomi Jylhä-Ollila, Finland 2014-2018
+# Author: Tomi Jylhä-Ollila, Finland 2014-2019
 #
 # This file is part of Kunquat.
 #
@@ -167,8 +167,17 @@ class TestExpression(KqtComboBox, AudioUnitUpdater):
             # Apply instrument default as the initial note expression
             module = self._ui_model.get_module()
             au = module.get_audio_unit(self._au_id)
-            note_expr = au.get_default_note_expression()
-            au.set_test_expression(self._index, note_expr)
+            if (au.get_test_expression(self._index) == None and
+                    au.get_test_expression(1 - self._index) == None):
+                note_expr = au.get_default_note_expression()
+                if note_expr:
+                    au.set_test_expression(self._index, note_expr)
+                else:
+                    expressions = au.get_expression_names()
+                    if expressions:
+                        # Pick some expression by default
+                        # to avoid unpleasant surprise when testing the instrument
+                        au.set_test_expression(self._index, min(expressions))
 
         self._update_expression_list()
 


### PR DESCRIPTION
This branch eliminates most unpleasant surprises when first testing multi-expression instruments in the instrument editor.