### PR TITLE
Fix channel stream tempo

### DIFF
--- a/src/lib/player/LFO.c
+++ b/src/lib/player/LFO.c
@@ -378,7 +378,7 @@ double LFO_skip(LFO* lfo, int64_t steps)
         int64_t process_steps_left = steps;
         while (process_steps_left > 0)
         {
-            int32_t steps32 = (process_steps_left > (int64_t)INT32_MAX)
+            const int32_t steps32 = (process_steps_left > (int64_t)INT32_MAX)
                 ? INT32_MAX : (int32_t)process_steps_left;
 
             const double init_speed_progress = Slider_get_value(&lfo->speed_slider);

--- a/src/lib/player/Linear_controls.c
+++ b/src/lib/player/Linear_controls.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2019
  *
  * This file is part of Kunquat.
  *
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 
 void Linear_controls_init(Linear_controls* lc)
@@ -178,7 +179,7 @@ void Linear_controls_osc_speed_value(Linear_controls* lc, double speed)
 
     LFO_set_speed(&lc->lfo, speed);
 
-    if (lc->def_osc_depth > 0)
+    if ((lc->def_osc_depth > 0) && (lc->def_osc_depth != lc->lfo.target_depth))
         LFO_set_depth(&lc->lfo, lc->def_osc_depth);
 
     LFO_turn_on(&lc->lfo);
@@ -194,7 +195,7 @@ void Linear_controls_osc_depth_value(Linear_controls* lc, double depth)
 
     lc->def_osc_depth = depth;
 
-    if (lc->def_osc_speed > 0)
+    if ((lc->def_osc_speed > 0) && (lc->def_osc_speed != lc->lfo.target_speed))
         LFO_set_speed(&lc->lfo, lc->def_osc_speed);
 
     LFO_set_depth(&lc->lfo, depth);
@@ -347,9 +348,7 @@ void Linear_controls_copy(
     rassert(src != NULL);
     rassert(src != dest);
 
-    dest->value = src->value;
-    Slider_copy(&dest->slider, &src->slider);
-    LFO_copy(&dest->lfo, &src->lfo);
+    memcpy(dest, src, sizeof(Linear_controls));
 
     return;
 }

--- a/src/lib/player/Player.c
+++ b/src/lib/player/Player.c
@@ -1672,6 +1672,12 @@ static void Player_init_final(Player* player)
     Player_reset_channels(player);
 
     for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
+    {
+        Channel* ch = player->channels[i];
+        Channel_set_tempo(ch, player->master_params.tempo);
+    }
+
+    for (int i = 0; i < KQT_CHANNELS_MAX; ++i)
         Cgiter_reset(&player->cgiters[i], &player->master_params.cur_pos);
 
     return;

--- a/src/lib/player/devices/processors/Stream_state.c
+++ b/src/lib/player/devices/processors/Stream_state.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2016-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2016-2019
  *
  * This file is part of Kunquat.
  *
@@ -362,6 +362,7 @@ void Stream_vstate_init(Voice_state* vstate, const Proc_state* proc_state)
 
     Linear_controls_init(&svstate->controls);
     Linear_controls_set_audio_rate(&svstate->controls, proc_state->parent.audio_rate);
+    // FIXME: Find correct tempo; this leaks out!
     Linear_controls_set_tempo(&svstate->controls, 120);
     Linear_controls_set_value(&svstate->controls, stream->init_value);
     Linear_controls_set_osc_speed_init_value(

--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -68,7 +68,7 @@ static void init_force_controls(Channel* ch, const Master_params* master_params)
 }
 
 
-static void init_streams(Channel* ch, const Audio_unit* au)
+static void init_streams(Channel* ch, const Audio_unit* au, double tempo)
 {
     const Au_streams* streams = Audio_unit_get_streams(au);
     if (streams != NULL)
@@ -94,6 +94,7 @@ static void init_streams(Channel* ch, const Audio_unit* au)
                 {
                     Linear_controls new_lc;
                     Linear_controls_copy(&new_lc, Stream_vstate_get_controls(vstate));
+                    Linear_controls_set_tempo(&new_lc, tempo); // FIXME: init tempo
                     Channel_stream_state_apply_overrides(
                             stream_state, stream_name, &new_lc);
 
@@ -262,7 +263,7 @@ bool Event_channel_note_on_process(
 
     Channel_reset_test_output(ch);
 
-    init_streams(ch, au);
+    init_streams(ch, au, master_params->tempo);
 
     return true;
 }
@@ -372,7 +373,7 @@ bool Event_channel_hit_process(
 
     Channel_reset_test_output(ch);
 
-    init_streams(ch, au);
+    init_streams(ch, au, master_params->tempo);
 
     return true;
 }


### PR DESCRIPTION
This branch fixes incorrect tempo settings in the player state that caused stream oscillators to update incorrectly.