### PR TITLE
Fix PADsynth backwards compatibility

### DIFF
--- a/src/lib/init/devices/param_types/Padsynth_params.c
+++ b/src/lib/init/devices/param_types/Padsynth_params.c
@@ -371,6 +371,7 @@ Padsynth_params* new_Padsynth_params(Streader* sr, int version)
     pp->min_pitch = 0;
     pp->max_pitch = 0;
     pp->centre_pitch = 0;
+    pp->round_to_period = (version > 0);
 
     pp->bandwidth_base = PADSYNTH_DEFAULT_BANDWIDTH_BASE;
     pp->bandwidth_scale = PADSYNTH_DEFAULT_BANDWIDTH_SCALE;

--- a/src/lib/init/devices/param_types/Padsynth_params.h
+++ b/src/lib/init/devices/param_types/Padsynth_params.h
@@ -57,6 +57,7 @@ typedef struct Padsynth_params
     double max_pitch;
     double centre_pitch;
     bool use_phase_data;
+    bool round_to_period;
 
     double bandwidth_base;
     double bandwidth_scale;


### PR DESCRIPTION
This branch disables the new sample pitch rounding with the PADsynth format of Kunquat 0.9.3 and earlier.