### PR TITLE
Deactivate final zero signal of multiplier voice processors

### DIFF
--- a/src/lib/init/devices/Proc_type.c
+++ b/src/lib/init/devices/Proc_type.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2017
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2019
  *
  * This file is part of Kunquat.
  *
@@ -16,6 +16,7 @@
 
 #include <debug/assert.h>
 #include <init/devices/Proc_cons.h>
+#include <init/devices/Proc_type_init.h>
 #include <string/common.h>
 
 #include <stdbool.h>
@@ -26,14 +27,15 @@ typedef struct Proc_type_info
 {
     const char* type_name;
     Proc_cons* cons;
+    bool needs_vstate_if_connected_to_mixed;
 } Proc_type_info;
 
 
-static const Proc_type_info proc_type_infos[] =
+static Proc_type_info proc_type_infos[] =
 {
-#define PROC_TYPE(name) { #name, new_Proc_ ## name },
+#define PROC_TYPE(name) { #name, new_Proc_ ## name, false },
 #include <init/devices/Proc_types.h>
-    { NULL, NULL }
+    { NULL, NULL, false }
 };
 
 
@@ -57,6 +59,26 @@ Proc_cons* Proc_type_get_cons(Proc_type type)
     rassert(type < Proc_type_COUNT);
 
     return proc_type_infos[type].cons;
+}
+
+
+void Proc_type_set_needs_vstate_if_connected_to_mixed(Proc_type type)
+{
+    rassert(type >= 0);
+    rassert(type < Proc_type_COUNT);
+
+    proc_type_infos[type].needs_vstate_if_connected_to_mixed = true;
+
+    return;
+}
+
+
+bool Proc_type_needs_vstate_if_connected_to_mixed(Proc_type type)
+{
+    rassert(type >= 0);
+    rassert(type < Proc_type_COUNT);
+
+    return proc_type_infos[type].needs_vstate_if_connected_to_mixed;
 }
 
 

--- a/src/lib/init/devices/Proc_type.h
+++ b/src/lib/init/devices/Proc_type.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2017
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2019
  *
  * This file is part of Kunquat.
  *
@@ -18,6 +18,7 @@
 
 #include <decl.h>
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 
@@ -60,6 +61,16 @@ Proc_type Proc_type_get_from_string(const char* type_name);
  * \return   The Processor constructor.
  */
 Proc_cons* Proc_type_get_cons(Proc_type type);
+
+
+/**
+ * Find out if Processor type requires a Voices state if connected to mixed signal.
+ *
+ * \param type   The Processor type -- must be valid.
+ *
+ * \return   \c true if Voice state is needed, otherwise \c false.
+ */
+bool Proc_type_needs_vstate_if_connected_to_mixed(Proc_type type);
 
 
 #endif // KQT_PROC_TYPE_H

--- a/src/lib/init/devices/Proc_type_init.h
+++ b/src/lib/init/devices/Proc_type_init.h
@@ -1,0 +1,20 @@
+
+
+/*
+ * Author: Tomi Jylhä-Ollila, Finland 2019
+ *
+ * This file is part of Kunquat.
+ *
+ * CC0 1.0 Universal, http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * To the extent possible under law, Kunquat Affirmers have waived all
+ * copyright and related or neighboring rights to Kunquat.
+ */
+
+
+#include <init/devices/Proc_type.h>
+
+
+void Proc_type_set_needs_vstate_if_connected_to_mixed(Proc_type type);
+
+

--- a/src/lib/init/devices/processors/Proc_mult.c
+++ b/src/lib/init/devices/processors/Proc_mult.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2019
  *
  * This file is part of Kunquat.
  *
@@ -17,6 +17,8 @@
 #include <debug/assert.h>
 #include <init/devices/Device_impl.h>
 #include <init/devices/Proc_cons.h>
+#include <init/devices/Proc_type.h>
+#include <init/devices/Proc_type_init.h>
 #include <init/devices/Processor.h>
 #include <memory.h>
 #include <player/devices/processors/Mult_state.h>
@@ -30,6 +32,8 @@ static void del_Proc_mult(Device_impl* dimpl);
 
 Device_impl* new_Proc_mult(void)
 {
+    Proc_type_set_needs_vstate_if_connected_to_mixed(Proc_type_mult);
+
     Proc_mult* mult = memory_alloc_item(Proc_mult);
     if (mult == NULL)
         return NULL;

--- a/src/lib/player/devices/Proc_state.c
+++ b/src/lib/player/devices/Proc_state.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2019
  *
  * This file is part of Kunquat.
  *
@@ -58,6 +58,8 @@ bool Proc_state_init(
     rassert(device != NULL);
     rassert(audio_rate > 0);
     rassert(audio_buffer_size >= 0);
+
+    proc_state->is_voice_connected_to_mixed = false;
 
     proc_state->destroy = NULL;
     proc_state->set_audio_rate = NULL;
@@ -153,6 +155,24 @@ void Proc_state_clear_history(Proc_state* proc_state)
         proc_state->clear_history(proc_state);
 
     return;
+}
+
+
+bool Proc_state_needs_vstate(const Proc_state* proc_state)
+{
+    rassert(proc_state != NULL);
+
+    const Device_impl* dimpl = proc_state->parent.device->dimpl;
+
+    Voice_state_get_size_func* get_vstate_size = dimpl->get_vstate_size;
+    if ((get_vstate_size == NULL) || (get_vstate_size() > 0))
+        return true;
+
+    if (Proc_type_needs_vstate_if_connected_to_mixed(dimpl->proc_type) &&
+            proc_state->is_voice_connected_to_mixed)
+        return true;
+
+    return false;
 }
 
 

--- a/src/lib/player/devices/Proc_state.h
+++ b/src/lib/player/devices/Proc_state.h
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2013-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2013-2019
  *
  * This file is part of Kunquat.
  *
@@ -17,6 +17,7 @@
 
 
 #include <decl.h>
+#include <init/devices/Proc_type.h>
 #include <player/devices/Device_state.h>
 #include <string/key_pattern.h>
 
@@ -33,6 +34,8 @@ typedef void Proc_state_fire_event_func(Device_state*, const char*, const Value*
 struct Proc_state
 {
     Device_state parent;
+
+    bool is_voice_connected_to_mixed;
 
     Device_state_destroy_func* destroy;
     Device_state_set_audio_rate_func* set_audio_rate;
@@ -69,6 +72,12 @@ bool Proc_state_init(
  * \param proc_state   The Processor state -- must not be \c NULL.
  */
 void Proc_state_clear_history(Proc_state* proc_state);
+
+
+/**
+ * Find out if the Processor state requires a Voice state in voice signal mode.
+ */
+bool Proc_state_needs_vstate(const Proc_state* proc_state);
 
 
 #endif // KQT_PROC_STATE_H

--- a/src/lib/player/devices/Voice_state.c
+++ b/src/lib/player/devices/Voice_state.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2010-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2010-2019
  *
  * This file is part of Kunquat.
  *
@@ -22,6 +22,7 @@
 #include <init/devices/Proc_type.h>
 #include <init/devices/Processor.h>
 #include <kunquat/limits.h>
+#include <mathnum/common.h>
 #include <mathnum/Tstamp.h>
 #include <player/Device_states.h>
 #include <player/devices/Device_thread_state.h>
@@ -138,9 +139,7 @@ int32_t Voice_state_render_voice(
     const Device_impl* dimpl = device->dimpl;
     rassert(dimpl != NULL);
 
-    const int32_t vstate_size = (dimpl->get_vstate_size != NULL)
-        ? dimpl->get_vstate_size() : (int32_t)sizeof(Voice_state);
-    rassert((vstate == NULL) == (vstate_size == 0));
+    rassert(implies(Proc_state_needs_vstate(proc_state), vstate != NULL));
 
     const Processor* proc = (const Processor*)device;
     if (!Processor_get_voice_signals(proc) || (dimpl->render_voice == NULL))

--- a/src/lib/player/devices/processors/Mult_state.c
+++ b/src/lib/player/devices/processors/Mult_state.c
@@ -1,7 +1,7 @@
 
 
 /*
- * Author: Tomi Jylhä-Ollila, Finland 2015-2018
+ * Author: Tomi Jylhä-Ollila, Finland 2015-2019
  *
  * This file is part of Kunquat.
  *
@@ -179,7 +179,6 @@ int32_t Mult_vstate_render_voice(
         int32_t frame_count,
         double tempo)
 {
-    rassert(vstate == NULL);
     rassert(proc_state != NULL);
     rassert(proc_ts != NULL);
     rassert(au_state != NULL);
@@ -187,6 +186,8 @@ int32_t Mult_vstate_render_voice(
     rassert(frame_count > 0);
     rassert(isfinite(tempo));
     rassert(tempo > 0);
+
+    rassert(proc_state->is_voice_connected_to_mixed == (vstate != NULL));
 
     // Get inputs
     Work_buffer* in1_wb =
@@ -201,7 +202,12 @@ int32_t Mult_vstate_render_voice(
         (is_final_zero(in1_wb, 1) || is_final_zero(in2_wb, 1));
 
     if (is_out1_final_zero && is_out2_final_zero)
+    {
+        if (vstate != NULL)
+            vstate->active = false;
+
         return 0;
+    }
 
     // Get outputs
     Work_buffer* out_wb = Proc_get_voice_output_2ch(proc_ts, PORT_OUT_SIGNAL_L);

--- a/src/lib/player/events/Event_channel_note.c
+++ b/src/lib/player/events/Event_channel_note.c
@@ -225,9 +225,7 @@ bool Event_channel_note_on_process(
         const Proc_state* proc_state = (Proc_state*)Device_states_get_state(
                 dstates, Device_get_id((const Device*)proc));
 
-        Voice_state_get_size_func* get_vstate_size =
-            proc_state->parent.device->dimpl->get_vstate_size;
-        if ((get_vstate_size != NULL) && (get_vstate_size() == 0))
+        if (!Proc_state_needs_vstate(proc_state))
             continue;
 
         char context_str[16] = "";
@@ -337,9 +335,7 @@ bool Event_channel_hit_process(
         const Proc_state* proc_state = (Proc_state*)Device_states_get_state(
                 dstates, Device_get_id((const Device*)proc));
 
-        Voice_state_get_size_func* get_vstate_size =
-            proc_state->parent.device->dimpl->get_vstate_size;
-        if ((get_vstate_size != NULL) && (get_vstate_size() == 0))
+        if (!Proc_state_needs_vstate(proc_state))
             continue;
 
         char context_str[16] = "";

--- a/src/lib/player/events/note_setup.c
+++ b/src/lib/player/events/note_setup.c
@@ -33,17 +33,12 @@
 
 
 static bool reserve_voice(
-        Channel* ch,
-        uint64_t group_id,
-        const Proc_state* proc_state,
-        bool is_external)
+        Channel* ch, uint64_t group_id, const Proc_state* proc_state, bool is_external)
 {
     rassert(ch != NULL);
     rassert(proc_state != NULL);
 
-    Voice_state_get_size_func* get_vstate_size =
-        proc_state->parent.device->dimpl->get_vstate_size;
-    if ((get_vstate_size != NULL) && (get_vstate_size() == 0))
+    if (!Proc_state_needs_vstate(proc_state))
         return false;
 
     Voice* voice = Voice_pool_get_voice(ch->pool, group_id);


### PR DESCRIPTION
This branch adds an optimisation that prevents indefinite calculation of certain voice signals that are multiplied by zero and thus do not contribute to audio output.